### PR TITLE
fixes to dashboard dates and heat map showing incomplete years

### DIFF
--- a/src/app/dashboard/account-overview/energy-use-heat-map/energy-use-heat-map.component.ts
+++ b/src/app/dashboard/account-overview/energy-use-heat-map/energy-use-heat-map.component.ts
@@ -122,7 +122,7 @@ export class EnergyUseHeatMapComponent implements OnInit {
       facilityIds.forEach(id => {
         let facilityMeters: Array<IdbUtilityMeter> = accountMetersCopy.filter(meter => { return meter.facilityId == id });
         let facility: IdbFacility = accountFacilites.find(facility => { return facility.id == id });
-        let facilityHeatMapData: HeatMapData = this.visualizationService.getMeterHeatMapData(facilityMeters, facility.name, true, true);
+        let facilityHeatMapData: HeatMapData = this.visualizationService.getMeterHeatMapData(facilityMeters, facility.name, true);
         this.facilityHeatMapData.push(facilityHeatMapData);
       });
       this.drawChart();

--- a/src/app/dashboard/dashboard.service.ts
+++ b/src/app/dashboard/dashboard.service.ts
@@ -47,7 +47,7 @@ export class DashboardService {
           energyUsage: _.sumBy(facilityMetersDataSummary, 'energyUse'),
           energyCost: _.sumBy(facilityMetersDataSummary, 'energyCost'),
           numberOfMeters: facilityMeters.length,
-          lastBillDate: new Date(facilityLastBill.year, (facilityLastBill.monthNumValue))
+          lastBillDate: new Date(facilityLastBill.year, (facilityLastBill.monthNumValue + 1))
         }
       } else {
         return {
@@ -219,24 +219,39 @@ export class DashboardService {
     let utilityMeters: Array<IdbUtilityMeter> = facilityMeters.filter(meter => { return meter.source == utility });
     if (utilityMeters.length != 0) {
       let lastYearData: Array<LastYearData> = this.calanderizationService.getPastYearData(utilityMeters, inAccount, allMetersLastBill);
-      let previousMonthData: LastYearData = _.maxBy(lastYearData, 'date');
-      let totalEnergyUseFromLastYear: number = _.sumBy(lastYearData, 'energyUse');
-      let totalEnergyCostFromLastYear: number = _.sumBy(lastYearData, 'energyCost');
       let lastBillForTheseMeters: MonthlyData = this.calanderizationService.getLastBillEntry(utilityMeters, inAccount);
       if (lastBillForTheseMeters) {
         let yearPriorBill: MonthlyData = this.calanderizationService.getYearPriorBillEntry(utilityMeters, inAccount, lastBillForTheseMeters);
-        return {
-          lastBillDate: new Date(lastBillForTheseMeters.year, lastBillForTheseMeters.monthNumValue),
-          previousMonthEnergyUse: previousMonthData.energyUse,
-          previousMonthEnergyCost: previousMonthData.energyCost,
-          averageEnergyUse: (totalEnergyUseFromLastYear / lastYearData.length),
-          averageEnergyCost: (totalEnergyCostFromLastYear / lastYearData.length),
-          yearPriorEnergyCost: yearPriorBill.energyCost,
-          yearPriorEnergyUse: yearPriorBill.energyUse,
-          energyCostChangeSinceLastYear: previousMonthData.energyCost - yearPriorBill.energyCost,
-          energyUseChangeSinceLastYear: previousMonthData.energyUse - yearPriorBill.energyUse,
-          utility: utility
-        };
+        if (lastYearData.length != 0) {
+          let previousMonthData: LastYearData = _.maxBy(lastYearData, 'date');
+          let totalEnergyUseFromLastYear: number = _.sumBy(lastYearData, 'energyUse');
+          let totalEnergyCostFromLastYear: number = _.sumBy(lastYearData, 'energyCost');
+          return {
+            lastBillDate: new Date(lastBillForTheseMeters.year, lastBillForTheseMeters.monthNumValue),
+            previousMonthEnergyUse: previousMonthData.energyUse,
+            previousMonthEnergyCost: previousMonthData.energyCost,
+            averageEnergyUse: (totalEnergyUseFromLastYear / lastYearData.length),
+            averageEnergyCost: (totalEnergyCostFromLastYear / lastYearData.length),
+            yearPriorEnergyCost: yearPriorBill.energyCost,
+            yearPriorEnergyUse: yearPriorBill.energyUse,
+            energyCostChangeSinceLastYear: previousMonthData.energyCost - yearPriorBill.energyCost,
+            energyUseChangeSinceLastYear: previousMonthData.energyUse - yearPriorBill.energyUse,
+            utility: utility
+          };
+        }else{
+          return {
+            lastBillDate: new Date(lastBillForTheseMeters.year, lastBillForTheseMeters.monthNumValue),
+            previousMonthEnergyUse: 0,
+            previousMonthEnergyCost: 0,
+            averageEnergyUse: 0,
+            averageEnergyCost: 0,
+            yearPriorEnergyCost: 0,
+            yearPriorEnergyUse: 0,
+            energyUseChangeSinceLastYear: 0,
+            energyCostChangeSinceLastYear: 0,
+            utility: utility
+          }
+        }
       }
     }
     return {
@@ -256,11 +271,11 @@ export class DashboardService {
   getFacilityMetersSummary(inAccount: boolean): FacilityMeterSummaryData {
     let facilityMetersSummary: Array<MeterSummary> = new Array();
     let facilityMeters: Array<IdbUtilityMeter> = this.utilityMeterDbService.facilityMeters.getValue();
+    let allMetersLastBill: MonthlyData = this.calanderizationService.getLastBillEntry(facilityMeters, inAccount)
     facilityMeters.forEach(meter => {
-      let summary: MeterSummary = this.getMeterSummary(meter, inAccount);
+      let summary: MeterSummary = this.getMeterSummary(meter, inAccount, allMetersLastBill);
       facilityMetersSummary.push(summary);
     });
-    let allMetersLastBill: MonthlyData = this.calanderizationService.getLastBillEntry(facilityMeters, inAccount)
     return {
       meterSummaries: facilityMetersSummary,
       totalEnergyUse: _.sumBy(facilityMetersSummary, 'energyUsage'),
@@ -269,9 +284,9 @@ export class DashboardService {
     };
   }
 
-  getMeterSummary(meter: IdbUtilityMeter, inAccount: boolean): MeterSummary {
+  getMeterSummary(meter: IdbUtilityMeter, inAccount: boolean, allMetersLastBill: MonthlyData): MeterSummary {
     let lastBill: MonthlyData = this.calanderizationService.getLastBillEntry([meter], inAccount);
-    let lastYearData: Array<{ time: string, energyUse: number, energyCost: number }> = this.calanderizationService.getPastYearData([meter], inAccount, lastBill);
+    let lastYearData: Array<{ time: string, energyUse: number, energyCost: number }> = this.calanderizationService.getPastYearData([meter], inAccount, allMetersLastBill);
     let group: IdbUtilityMeterGroup = this.utilityMeterGroupDbService.getGroupById(meter.groupId);
     let groupName: string = 'Ungrouped';
     if (group) {
@@ -279,7 +294,7 @@ export class DashboardService {
     }
     let lastBillDate: Date;
     if (lastBill) {
-      lastBillDate = new Date(lastBill.year, lastBill.monthNumValue);
+      lastBillDate = new Date(lastBill.year, lastBill.monthNumValue + 1);
     }
     return {
       meter: meter,

--- a/src/app/dashboard/facility-overview/facility-heat-map/facility-heat-map.component.ts
+++ b/src/app/dashboard/facility-overview/facility-heat-map/facility-heat-map.component.ts
@@ -60,7 +60,7 @@ export class FacilityHeatMapComponent implements OnInit {
   setGraphData() {
     if (this.facilityMeters && this.facilityMeters.length != 0 && this.accountMeters && this.accountMeters.length != 0) {
       let selectedFacility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-      let heatMapData: HeatMapData = this.vizualizationService.getMeterHeatMapData(this.facilityMeters, selectedFacility.name, true, false);
+      let heatMapData: HeatMapData = this.vizualizationService.getMeterHeatMapData(this.facilityMeters, selectedFacility.name, false);
       this.resultData = heatMapData.resultData;
       this.months = heatMapData.months;
       this.years = heatMapData.years;

--- a/src/app/shared/helper-services/visualization.service.ts
+++ b/src/app/shared/helper-services/visualization.service.ts
@@ -86,7 +86,7 @@ export class VisualizationService {
     return resultData;
   }
 
-  getMeterHeatMapData(meters: Array<IdbUtilityMeter>, facilityName: string, removeIncompleteYears: boolean, inAccount: boolean): HeatMapData {
+  getMeterHeatMapData(meters: Array<IdbUtilityMeter>, facilityName: string, inAccount: boolean): HeatMapData {
     let months: Array<string> = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
     //calanderize meters
     let calanderizedMeterData: Array<CalanderizedMeter> = this.calanderizationService.getCalanderizedMeterData(meters, inAccount, false);
@@ -95,15 +95,14 @@ export class VisualizationService {
       return meterData.monthlyData;
     });
     let yearMonths = combindedCalanderizedMeterData.map(data => { return { year: data.year, month: data.month } });
-    if (removeIncompleteYears) {
-      yearMonths = _.uniqWith(yearMonths, (a, b) => {
-        return (a.year == b.year && a.month == b.month)
-      });
-      //remove data without 12 months for the year
-      //TODO: Make optional?
-      let counts = _.countBy(yearMonths, 'year');
-      yearMonths = yearMonths.filter(yearMonthItem => { return counts[yearMonthItem.year] == 12 })
-    }
+    // if (removeIncompleteYears) {
+    yearMonths = _.uniqWith(yearMonths, (a, b) => {
+      return (a.year == b.year && a.month == b.month)
+    });
+    //remove data without 12 months for the year
+    // let counts = _.countBy(yearMonths, 'year');
+    // yearMonths = yearMonths.filter(yearMonthItem => { return counts[yearMonthItem.year] == 12 })
+    // }
     //create array of the uniq months and years
     let years: Array<number> = yearMonths.map(data => { return data.year });
     years = _.uniq(years);
@@ -116,14 +115,14 @@ export class VisualizationService {
           if (meterData.year == year && meterData.month == month) {
             return meterData.energyCost;
           } else {
-            return 0;
+            return undefined;
           }
         });
         let totalEnergy: number = _.sumBy(combindedCalanderizedMeterData, (meterData: MonthlyData) => {
           if (meterData.year == year && meterData.month == month) {
             return meterData.energyUse;
           } else {
-            return 0;
+            return undefined;
           }
         });
         yearData.monthlyCost.push(totalCost)


### PR DESCRIPTION
last bill date was showing last complete month of data but last bill was the month after that

Summary was using previous year from last bill date for each meter but should have been previous year from last bill date of all meters.

Heat map showing data even when there are not 12 months of data.