### PR TITLE
fix calanderization bug for 31st date reading

### DIFF
--- a/src/app/shared/helper-services/calanderization.service.ts
+++ b/src/app/shared/helper-services/calanderization.service.ts
@@ -84,6 +84,7 @@ export class CalanderizationService {
     if (orderedMeterData.length > 3) {
       let startDate: Date = new Date(orderedMeterData[0].readDate);
       startDate.setUTCMonth(startDate.getUTCMonth() + 1);
+      startDate.setUTCDate(1);
       let endDate: Date = new Date(orderedMeterData[orderedMeterData.length - 1].readDate);
       while (startDate.getUTCMonth() != endDate.getUTCMonth() || startDate.getUTCFullYear() != endDate.getUTCFullYear()) {
         let month: number = startDate.getUTCMonth();


### PR DESCRIPTION
connects #582 

when first reading date was 31st and month was incremented it sometime skipped ahead one month. Feb 31st -> March 1