### PR TITLE
remove json.parse copy call from analysis for speed fix

### DIFF
--- a/src/app/web-workers/classes/annualAccountAnalysisSummaryClass.ts
+++ b/src/app/web-workers/classes/annualAccountAnalysisSummaryClass.ts
@@ -51,8 +51,8 @@ export class AnnualAccountAnalysisSummaryClass {
         this.annualAnalysisSummaryDataClasses = new Array();
         let analysisYear: number = this.baselineYear;
         while (analysisYear <= this.reportYear) {
-            let annualAnalysisSummaryDataClassCopy: Array<AnnualAnalysisSummaryDataClass> = JSON.parse(JSON.stringify(this.annualAnalysisSummaryDataClasses))
-            let yearAnalysisSummaryDataClass: AnnualAnalysisSummaryDataClass = new AnnualAnalysisSummaryDataClass(this.monthlyAnalysisSummaryData, analysisYear, accountPredictorEntries, undefined, annualAnalysisSummaryDataClassCopy);
+            // let annualAnalysisSummaryDataClassCopy: Array<AnnualAnalysisSummaryDataClass> = JSON.parse(JSON.stringify(this.annualAnalysisSummaryDataClasses))
+            let yearAnalysisSummaryDataClass: AnnualAnalysisSummaryDataClass = new AnnualAnalysisSummaryDataClass(this.monthlyAnalysisSummaryData, analysisYear, accountPredictorEntries, undefined, this.annualAnalysisSummaryDataClasses);
             this.annualAnalysisSummaryDataClasses.push(yearAnalysisSummaryDataClass);
             analysisYear++;
         }

--- a/src/app/web-workers/classes/annualFacilityAnalysisSummaryClass.ts
+++ b/src/app/web-workers/classes/annualFacilityAnalysisSummaryClass.ts
@@ -45,8 +45,8 @@ export class AnnualFacilityAnalysisSummaryClass {
         this.annualAnalysisSummaryDataClasses = new Array();
         let analysisYear: number = this.baselineYear;
         while (analysisYear <= this.reportYear) {
-            let annualAnalysisSummaryDataClassCopy: Array<AnnualAnalysisSummaryDataClass> = JSON.parse(JSON.stringify(this.annualAnalysisSummaryDataClasses))
-            let yearAnalysisSummaryDataClass: AnnualAnalysisSummaryDataClass = new AnnualAnalysisSummaryDataClass(this.monthlyAnalysisSummaryData, analysisYear, accountPredictorEntries, facility, annualAnalysisSummaryDataClassCopy);
+            // let annualAnalysisSummaryDataClassCopy: Array<AnnualAnalysisSummaryDataClass> = JSON.parse(JSON.stringify(this.annualAnalysisSummaryDataClasses))
+            let yearAnalysisSummaryDataClass: AnnualAnalysisSummaryDataClass = new AnnualAnalysisSummaryDataClass(this.monthlyAnalysisSummaryData, analysisYear, accountPredictorEntries, facility, this.annualAnalysisSummaryDataClasses);
             this.annualAnalysisSummaryDataClasses.push(yearAnalysisSummaryDataClass);
             analysisYear++;
         }

--- a/src/app/web-workers/classes/annualGroupAnalysisSummaryClass.ts
+++ b/src/app/web-workers/classes/annualGroupAnalysisSummaryClass.ts
@@ -45,8 +45,8 @@ export class AnnualGroupAnalysisSummaryClass {
         this.annualAnalysisSummaryDataClasses = new Array();
         let analysisYear: number = this.baselineYear;
         while (analysisYear <= this.reportYear) {
-            let annualAnalysisSummaryDataClassCopy: Array<AnnualAnalysisSummaryDataClass> = JSON.parse(JSON.stringify(this.annualAnalysisSummaryDataClasses))
-            let yearAnalysisSummaryDataClass: AnnualAnalysisSummaryDataClass = new AnnualAnalysisSummaryDataClass(this.monthlyAnalysisSummaryData, analysisYear, accountPredictorEntries, facility, annualAnalysisSummaryDataClassCopy);
+            // let annualAnalysisSummaryDataClassCopy: Array<AnnualAnalysisSummaryDataClass> = JSON.parse(JSON.stringify(this.annualAnalysisSummaryDataClasses))
+            let yearAnalysisSummaryDataClass: AnnualAnalysisSummaryDataClass = new AnnualAnalysisSummaryDataClass(this.monthlyAnalysisSummaryData, analysisYear, accountPredictorEntries, facility, this.annualAnalysisSummaryDataClasses);
             this.annualAnalysisSummaryDataClasses.push(yearAnalysisSummaryDataClass);
             analysisYear++;
         }

--- a/src/app/web-workers/classes/monthlyAnalysisCalculatedValuesClass.ts
+++ b/src/app/web-workers/classes/monthlyAnalysisCalculatedValuesClass.ts
@@ -155,8 +155,8 @@ export class MonthlyAnalysisCalculatedValues {
             let baselineMonthsSummaryData: Array<MonthlyAnalysisCalculatedValues> = previousMonthsValues.filter(dataItem => { return dataItem.fiscalYear == baselineYear });
             let totalBaselineModeledEnergy: number = _.sumBy(baselineMonthsSummaryData, 'modeledEnergy');
             let totalBaselineEnergy: number = _.sumBy(baselineMonthsSummaryData, 'energyUse');
-            let last11MonthsData: Array<MonthlyAnalysisCalculatedValues> = JSON.parse(JSON.stringify(previousMonthsValues));
-            last11MonthsData = last11MonthsData.splice(this.summaryDataIndex - 11, this.summaryDataIndex);
+            // let last11MonthsData: Array<MonthlyAnalysisCalculatedValues> = JSON.parse(JSON.stringify(previousMonthsValues));
+            let last11MonthsData: Array<MonthlyAnalysisCalculatedValues> = previousMonthsValues.splice(this.summaryDataIndex - 11, this.summaryDataIndex);
             let total12MonthsEnergyUse: number = _.sumBy(last11MonthsData, 'energyUse') + this.energyUse;
             let total12MonthsModeledEnergy: number = _.sumBy(last11MonthsData, 'modeledEnergy') + this.modeledEnergy;
             this.rollingSavings = (totalBaselineEnergy - totalBaselineModeledEnergy) - (total12MonthsEnergyUse - total12MonthsModeledEnergy);

--- a/src/app/web-workers/classes/monthlyAnalysisSummaryClass.ts
+++ b/src/app/web-workers/classes/monthlyAnalysisSummaryClass.ts
@@ -20,8 +20,8 @@ export class MonthlyAnalysisSummaryClass {
         this.monthlyAnalysisSummaryData = new Array();
         let baselineDate: Date = new Date(this.monthlyGroupAnalysisClass.baselineDate);
         while (baselineDate < this.monthlyGroupAnalysisClass.endDate) {
-            let monthlyanalysisSummaryDataCopy: Array<MonthlyAnalysisSummaryDataClass> = JSON.parse(JSON.stringify(this.monthlyAnalysisSummaryData))
-            let monthlyAnalysisSummaryDataClass: MonthlyAnalysisSummaryDataClass = new MonthlyAnalysisSummaryDataClass(this.monthlyGroupAnalysisClass, baselineDate, monthlyanalysisSummaryDataCopy)
+            // let monthlyanalysisSummaryDataCopy: Array<MonthlyAnalysisSummaryDataClass> = JSON.parse(JSON.stringify(this.monthlyAnalysisSummaryData))
+            let monthlyAnalysisSummaryDataClass: MonthlyAnalysisSummaryDataClass = new MonthlyAnalysisSummaryDataClass(this.monthlyGroupAnalysisClass, baselineDate, this.monthlyAnalysisSummaryData)
             this.monthlyAnalysisSummaryData.push(monthlyAnalysisSummaryDataClass);
             let currentMonth: number = baselineDate.getUTCMonth()
             let nextMonth: number = currentMonth + 1;


### PR DESCRIPTION
using copy of data was unnecessary and causing performance bottleneck