### PR TITLE
Enhancements to analysis setup

### DIFF
--- a/src/app/account/account-analysis/account-analysis-setup/account-analysis-setup.component.css
+++ b/src/app/account/account-analysis/account-analysis-setup/account-analysis-setup.component.css
@@ -15,3 +15,7 @@
 .row.form-group{
     margin-bottom:.25rem;
 }
+
+.switch-col{
+    padding-top: calc(.375rem + 1px);
+}

--- a/src/app/account/account-analysis/account-analysis-setup/account-analysis-setup.component.html
+++ b/src/app/account/account-analysis/account-analysis-setup/account-analysis-setup.component.html
@@ -18,13 +18,13 @@
                                 <div class="form-check">
                                     <input type="radio" class="form-check-input" name="energyIsSource" [value]="true"
                                         id="sourceEnergy" [(ngModel)]="analysisItem.energyIsSource"
-                                        (change)="changeSiteSource()">
+                                        (change)="saveItem()" [disabled]="disableForm">
                                     <label class="form-check-label" for="sourceEnergy">Source Energy</label>
                                 </div>
                                 <div class="form-check">
                                     <input type="radio" class="form-check-input" name="energyIsSource" [value]="false"
-                                        id="siteEnergy" [(ngModel)]="analysisItem.energyIsSource"
-                                        (change)="changeSiteSource()">
+                                        id="siteEnergy" [(ngModel)]="analysisItem.energyIsSource" (change)="saveItem()"
+                                        [disabled]="disableForm">
                                     <label class="form-check-label" for="siteEnergy">Site Energy</label>
                                 </div>
                             </div>
@@ -33,7 +33,8 @@
                             <label class="col-5 col-form-label" for="energyUnit">Energy Unit</label>
                             <div class="col-7">
                                 <select class="form-select" name="energyUnit" id="energyUnit"
-                                    [(ngModel)]="analysisItem.energyUnit" (change)="saveItem()">
+                                    [(ngModel)]="analysisItem.energyUnit" (change)="saveItem()"
+                                    [disabled]="disableForm">
                                     <option *ngFor="let energyUnitOption of energyUnitOptions"
                                         [ngValue]="energyUnitOption.value">
                                         <span [innerHTML]="energyUnitOption.display"></span>
@@ -47,7 +48,7 @@
                             <label class="col-5 col-form-label" for="waterUnit">Water Unit</label>
                             <div class="col-7">
                                 <select class="form-select" name="waterUnit" id="waterUnit"
-                                    [(ngModel)]="analysisItem.waterUnit" (change)="saveItem()">
+                                    [(ngModel)]="analysisItem.waterUnit" (change)="saveItem()" [disabled]="disableForm">
                                     <option *ngFor="let waterUnitOption of waterUnitOptions"
                                         [ngValue]="waterUnitOption.value">
                                         <span [innerHTML]="waterUnitOption.display"></span>
@@ -56,12 +57,11 @@
                             </div>
                         </div>
                     </ng-container>
-                    <hr>
                     <div class="form-group row">
                         <label for="hasBaselineAdjustement" class="col-5 col-form-label">
                             Has Baseline Adjustement
                         </label>
-                        <div class="col-7">
+                        <div class="col-7 switch-col">
                             <label class="switch" for="hasBaselineAdjustement">
                                 <input class="checkbox" type="checkbox" id="hasBaselineAdjustement"
                                     name="hasBaselineAdjustement" [(ngModel)]="analysisItem.hasBaselineAdjustement"
@@ -100,7 +100,8 @@
                         <div class="col-7">
                             <select required class="form-select" id="baselineYear" name="baselineYear"
                                 [(ngModel)]="analysisItem.baselineYear" (change)="changeReportYear()"
-                                [ngClass]="{'ng-invalid': analysisItem.setupErrors.reportYearBeforeBaselineYear}">
+                                [ngClass]="{'ng-invalid': analysisItem.setupErrors.reportYearBeforeBaselineYear}"
+                                [disabled]="disableForm">
                                 <option *ngFor="let year of yearOptions" [ngValue]="year">
                                     {{year| yearDisplay: account.fiscalYear}}</option>
                             </select>
@@ -117,7 +118,8 @@
                         <div class="col-7">
                             <select required class="form-select" name="reportYear" id="reportYear"
                                 [(ngModel)]="analysisItem.reportYear" (change)="changeReportYear()"
-                                [ngClass]="{'ng-invalid': analysisItem.setupErrors.reportYearBeforeBaselineYear}">
+                                [ngClass]="{'ng-invalid': analysisItem.setupErrors.reportYearBeforeBaselineYear}"
+                                [disabled]="disableForm">
                                 <option *ngFor="let year of yearOptions" [ngValue]="year">{{year| yearDisplay:
                                     account.fiscalYear}}
                                 </option>
@@ -171,9 +173,49 @@
                     <div class="alert alert-info text-center p-2">
                         Fields set in "<span class="fa fa-gear"></span> Settings" tab.
                     </div>
-                    <hr>
                 </div>
             </div>
         </form>
+        <div class="row">
+            <div class="col">
+                <hr>
+            </div>
+        </div>
+        <div class="row" *ngIf="disableForm">
+            <div class="col-12 alert alert-warning text-center">
+                Facility items selected for this analysis. Changing these settings will clear out the current selections
+                for
+                each corresponding facility. If you'd like to change these settings <a class="click-link"
+                    (click)="showEnableForm()">click here</a>.
+            </div>
+        </div>
+        <div class="row" *ngIf="hasCorrespondingReport">
+            <div class="col-12 alert alert-info text-center">
+                This analysis is used in one or more reports. Changes to this analysis may effect the results of the
+                corresponding reports.
+            </div>
+        </div>
+    </div>
+</div>
+
+
+<div [ngClass]="{'windowOverlay': displayEnableForm}"></div>
+<div class="popup" [class.open]="displayEnableForm">
+    <div class="popup-header">Are you sure?
+        <button class="item-right" (click)="cancelEnableForm()">x</button>
+    </div>
+    <div class="popup-body">
+        Are you sure you want to clear the existing facility analysis item selections? This cannot be undone!
+        <hr>
+        <!-- <div class="row"> -->
+        <div class="col-12 alert alert-info text-center" *ngIf="hasCorrespondingReport">
+            This analysis is used in one or more reports. Changes to this analysis may effect the results of the
+            corresponding reports.
+        </div>
+        <!-- </div> -->
+    </div>
+    <div class="saveCancel popup-footer text-end">
+        <button class="btn btn-secondary" (click)="cancelEnableForm()">Cancel</button>
+        <button class="btn action-btn" (click)="confirmEnableForm()">Change Settings</button>
     </div>
 </div>

--- a/src/app/account/account-analysis/account-analysis-setup/account-analysis-setup.component.html
+++ b/src/app/account/account-analysis/account-analysis-setup/account-analysis-setup.component.html
@@ -1,6 +1,13 @@
 <div class="wrapper main-content p-0">
     <div class="content-padding">
         <h4>Analysis Setup</h4>
+        <div class="row" *ngIf="showInUseMessage">
+            <div class="col-12 alert alert-info text-center">
+                <button type="button" class="btn-close" aria-label="Close" (click)="hideInUseMessage()"></button>
+                This analysis is used in one or more reports. Changes to this analysis may effect the results of the
+                corresponding reports.
+            </div>
+        </div>
         <form>
             <div class="row">
                 <div class="col-6">
@@ -189,12 +196,6 @@
                     (click)="showEnableForm()">click here</a>.
             </div>
         </div>
-        <div class="row" *ngIf="hasCorrespondingReport">
-            <div class="col-12 alert alert-info text-center">
-                This analysis is used in one or more reports. Changes to this analysis may effect the results of the
-                corresponding reports.
-            </div>
-        </div>
     </div>
 </div>
 
@@ -207,12 +208,10 @@
     <div class="popup-body">
         Are you sure you want to clear the existing facility analysis item selections? This cannot be undone!
         <hr>
-        <!-- <div class="row"> -->
-        <div class="col-12 alert alert-info text-center" *ngIf="hasCorrespondingReport">
+        <div class="col-12 alert alert-info text-center" *ngIf="showInUseMessage">
             This analysis is used in one or more reports. Changes to this analysis may effect the results of the
             corresponding reports.
         </div>
-        <!-- </div> -->
     </div>
     <div class="saveCancel popup-footer text-end">
         <button class="btn btn-secondary" (click)="cancelEnableForm()">Cancel</button>

--- a/src/app/account/account-analysis/account-analysis-setup/account-analysis-setup.component.ts
+++ b/src/app/account/account-analysis/account-analysis-setup/account-analysis-setup.component.ts
@@ -11,6 +11,7 @@ import { firstValueFrom } from 'rxjs';
 import { AnalysisValidationService } from 'src/app/shared/helper-services/analysis-validation.service';
 import { CalanderizationService } from 'src/app/shared/helper-services/calanderization.service';
 import { AccountReportDbService } from 'src/app/indexedDB/account-report-db.service';
+import { AccountAnalysisService } from '../account-analysis.service';
 
 @Component({
   selector: 'app-account-analysis-setup',
@@ -29,7 +30,7 @@ export class AccountAnalysisSetupComponent implements OnInit {
   yearOptions: Array<number>;
   baselineYearWarning: string;
   disableForm: boolean;
-  hasCorrespondingReport: boolean;
+  showInUseMessage: boolean;
   displayEnableForm: boolean = false;
   constructor(private accountDbService: AccountdbService, private accountAnalysisDbService: AccountAnalysisDbService,
     private router: Router,
@@ -37,7 +38,8 @@ export class AccountAnalysisSetupComponent implements OnInit {
     private analysisDbService: AnalysisDbService,
     private analysisValidationService: AnalysisValidationService,
     private calendarizationService: CalanderizationService,
-    private accountReportDbService: AccountReportDbService) { }
+    private accountReportDbService: AccountReportDbService,
+    private accountAnalysisService: AccountAnalysisService) { }
 
   ngOnInit(): void {
     this.analysisItem = this.accountAnalysisDbService.selectedAnalysisItem.getValue();
@@ -46,7 +48,7 @@ export class AccountAnalysisSetupComponent implements OnInit {
     }
     this.account = this.accountDbService.selectedAccount.getValue();
     this.setDisableForm();
-    this.setHasCorrespondingReport();
+    this.setShowInUseMessage();
     this.energyUnit = this.account.energyUnit;
     this.yearOptions = this.calendarizationService.getYearOptionsAccount(this.analysisItem.analysisCategory);
     this.setBaselineYearWarning();
@@ -104,13 +106,16 @@ export class AccountAnalysisSetupComponent implements OnInit {
     this.disableForm = hasItemsSelected;
   }
 
-  setHasCorrespondingReport() {
-    let accountReports: Array<IdbAccountReport> = this.accountReportDbService.accountReports.getValue();
-    let hasReport: IdbAccountReport = accountReports.find(report => {
-      return (report.reportType == 'betterPlants' && report.betterPlantsReportSetup.analysisItemId == this.analysisItem.guid);
-    });
-    console.log(hasReport);
-    this.hasCorrespondingReport = (hasReport != undefined);
+  setShowInUseMessage() {
+    let hasCorrespondingReport: boolean = this.accountReportDbService.getHasCorrespondingReport(this.analysisItem.guid);
+    if (hasCorrespondingReport && this.accountAnalysisService.hideInUseMessage == false) {
+      this.showInUseMessage = true;
+    }
+  }
+
+  hideInUseMessage() {
+    this.showInUseMessage = false;
+    this.accountAnalysisService.hideInUseMessage = true;
   }
 
   showEnableForm() {

--- a/src/app/account/account-analysis/account-analysis-setup/account-analysis-setup.component.ts
+++ b/src/app/account/account-analysis/account-analysis-setup/account-analysis-setup.component.ts
@@ -75,6 +75,14 @@ export class AccountAnalysisSetupComponent implements OnInit {
       }
       this.analysisItem.baselineAdjustments = yearAdjustments;
     }
+    let allAnalysisItems: Array<IdbAccountAnalysisItem> = this.accountAnalysisDbService.accountAnalysisItems.getValue();
+    let selectYearAnalysis: boolean = true;
+    allAnalysisItems.forEach(item => {
+      if (item.reportYear == this.analysisItem.reportYear && item.selectedYearAnalysis) {
+        selectYearAnalysis = false;
+      }
+    });
+    this.analysisItem.selectedYearAnalysis = selectYearAnalysis;
     await this.saveItem();
   }
 

--- a/src/app/account/account-analysis/account-analysis.component.ts
+++ b/src/app/account/account-analysis/account-analysis.component.ts
@@ -3,7 +3,6 @@ import { Subscription } from 'rxjs';
 import { UtilityMeterDatadbService } from 'src/app/indexedDB/utilityMeterData-db.service';
 import { IdbUtilityMeterData } from 'src/app/models/idb';
 import { AccountAnalysisService } from './account-analysis.service';
-import { AccountAnalysisDbService } from 'src/app/indexedDB/account-analysis-db.service';
 
 @Component({
   selector: 'app-account-analysis',
@@ -14,7 +13,8 @@ export class AccountAnalysisComponent implements OnInit {
 
   utilityMeterDataSub: Subscription;
   utilityMeterData: Array<IdbUtilityMeterData>;
-  constructor(private utilityMeterDataDbService: UtilityMeterDatadbService) { }
+  constructor(private utilityMeterDataDbService: UtilityMeterDatadbService,
+    private accountAnalysisService: AccountAnalysisService) { }
 
   ngOnInit(): void {
     this.utilityMeterDataSub = this.utilityMeterDataDbService.accountMeterData.subscribe(val => {
@@ -24,6 +24,7 @@ export class AccountAnalysisComponent implements OnInit {
 
   ngOnDestroy() {
     this.utilityMeterDataSub.unsubscribe();
+    this.accountAnalysisService.hideInUseMessage = false;
   }
 
 }

--- a/src/app/account/account-analysis/account-analysis.service.ts
+++ b/src/app/account/account-analysis/account-analysis.service.ts
@@ -12,6 +12,7 @@ export class AccountAnalysisService {
   calculating: BehaviorSubject<boolean | 'error'>;
   annualAnalysisSummary: BehaviorSubject<Array<AnnualAnalysisSummary>>;
   monthlyAccountAnalysisData: BehaviorSubject<Array<MonthlyAnalysisSummaryData>>;
+  hideInUseMessage: boolean = false;
   constructor() { 
     this.selectedFacility = new BehaviorSubject<IdbFacility>(undefined);
     this.calculating = new BehaviorSubject<boolean>(true);

--- a/src/app/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.html
+++ b/src/app/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.html
@@ -10,6 +10,13 @@
             </div>
         </div>
         <div class="flex-fill pt-2 ps-4 pe-4 pb-4">
+            <div class="p-2" *ngIf="showInUseMessage">
+                <div class="alert alert-info text-center mb-0">
+                    <button type="button" class="btn-close" aria-label="Close" (click)="hideInUseMessage()"></button>
+                    This analysis is used in one or more reports. Changes to this analysis may effect the results of the
+                    corresponding reports.
+                </div>
+            </div>
             <app-select-item-table [facility]="selectedFacility" [selectedAnalysisItem]="selectedAnalysisItem"
                 [facilityAnalysisItems]="facilityAnalysisItems"></app-select-item-table>
         </div>

--- a/src/app/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.ts
+++ b/src/app/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.ts
@@ -9,6 +9,7 @@ import { AccountAnalysisService } from '../account-analysis.service';
 import { AnalysisValidationService } from 'src/app/shared/helper-services/analysis-validation.service';
 import { AccountdbService } from 'src/app/indexedDB/account-db.service';
 import { DbChangesService } from 'src/app/indexedDB/db-changes.service';
+import { AccountReportDbService } from 'src/app/indexedDB/account-report-db.service';
 
 @Component({
   selector: 'app-select-facility-analysis-items',
@@ -27,6 +28,7 @@ export class SelectFacilityAnalysisItemsComponent implements OnInit {
   facilityAnalysisItems: Array<IdbAnalysisItem>;
   selectedFacilitySub: Subscription;
   selectedFacility: IdbFacility;
+  showInUseMessage: boolean;
   constructor(private facilityDbService: FacilitydbService,
     private analysisDbService: AnalysisDbService,
     private accountAnalysisDbService: AccountAnalysisDbService,
@@ -34,11 +36,13 @@ export class SelectFacilityAnalysisItemsComponent implements OnInit {
     private accountAnalysisService: AccountAnalysisService,
     private analysisValidationService: AnalysisValidationService,
     private accountDbService: AccountdbService,
-    private dbChangesService: DbChangesService) { }
+    private dbChangesService: DbChangesService,
+    private accountReportDbService: AccountReportDbService) { }
 
   ngOnInit(): void {
     this.selectedAnalysisItemSub = this.accountAnalysisDbService.selectedAnalysisItem.subscribe(item => {
       this.selectedAnalysisItem = item;
+      this.setShowInUseMessage();
       this.initializeSelectedFacilitiesItems();
       this.setFacilitiesList();
     })
@@ -164,5 +168,18 @@ export class SelectFacilityAnalysisItemsComponent implements OnInit {
         this.accountAnalysisDbService.selectedAnalysisItem.next(this.selectedAnalysisItem);
       }
     }
+  }
+
+
+  setShowInUseMessage() {
+    let hasCorrespondingReport: boolean = this.accountReportDbService.getHasCorrespondingReport(this.selectedAnalysisItem.guid);
+    if (hasCorrespondingReport && this.accountAnalysisService.hideInUseMessage == false) {
+      this.showInUseMessage = true;
+    }
+  }
+
+  hideInUseMessage() {
+    this.showInUseMessage = false;
+    this.accountAnalysisService.hideInUseMessage = true;
   }
 }

--- a/src/app/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.ts
+++ b/src/app/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.ts
@@ -1,11 +1,14 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { Subscription } from 'rxjs';
+import { Subscription, firstValueFrom } from 'rxjs';
 import { AccountAnalysisDbService } from 'src/app/indexedDB/account-analysis-db.service';
 import { AnalysisDbService } from 'src/app/indexedDB/analysis-db.service';
 import { FacilitydbService } from 'src/app/indexedDB/facility-db.service';
-import { IdbAccountAnalysisItem, IdbAnalysisItem, IdbFacility } from 'src/app/models/idb';
+import { IdbAccount, IdbAccountAnalysisItem, IdbAnalysisItem, IdbFacility } from 'src/app/models/idb';
 import { AccountAnalysisService } from '../account-analysis.service';
+import { AnalysisValidationService } from 'src/app/shared/helper-services/analysis-validation.service';
+import { AccountdbService } from 'src/app/indexedDB/account-db.service';
+import { DbChangesService } from 'src/app/indexedDB/db-changes.service';
 
 @Component({
   selector: 'app-select-facility-analysis-items',
@@ -28,11 +31,15 @@ export class SelectFacilityAnalysisItemsComponent implements OnInit {
     private analysisDbService: AnalysisDbService,
     private accountAnalysisDbService: AccountAnalysisDbService,
     private router: Router,
-    private accountAnalysisService: AccountAnalysisService) { }
+    private accountAnalysisService: AccountAnalysisService,
+    private analysisValidationService: AnalysisValidationService,
+    private accountDbService: AccountdbService,
+    private dbChangesService: DbChangesService) { }
 
   ngOnInit(): void {
     this.selectedAnalysisItemSub = this.accountAnalysisDbService.selectedAnalysisItem.subscribe(item => {
       this.selectedAnalysisItem = item;
+      this.initializeSelectedFacilitiesItems();
       this.setFacilitiesList();
     })
 
@@ -125,5 +132,37 @@ export class SelectFacilityAnalysisItemsComponent implements OnInit {
         isInvalid: data.isInvalid
       }
     });
+  }
+
+  async initializeSelectedFacilitiesItems() {
+    if (!this.selectedAnalysisItem.facilityItemsInitialized) {
+      let findItemSelected = this.selectedAnalysisItem.facilityAnalysisItems.find(item => {
+        return item.analysisItemId != undefined;
+      });
+      if (!findItemSelected) {
+        let accountAnalysisItems: Array<IdbAnalysisItem> = this.analysisDbService.accountAnalysisItems.getValue();
+        this.selectedAnalysisItem.facilityAnalysisItems.forEach(item => {
+          let facilityItem: IdbAnalysisItem = accountAnalysisItems.find(accountItem => {
+            return (accountItem.reportYear == this.selectedAnalysisItem.reportYear
+              && accountItem.facilityId == item.facilityId
+              && accountItem.selectedYearAnalysis
+              && accountItem.baselineYear == this.selectedAnalysisItem.baselineYear
+              && accountItem.analysisCategory == this.selectedAnalysisItem.analysisCategory);
+          });
+          if (facilityItem) {
+            item.analysisItemId = facilityItem.guid;
+          } else {
+            item.analysisItemId = undefined;
+          }
+        });
+        this.selectedAnalysisItem.facilityItemsInitialized = true;
+        let analysisItems: Array<IdbAnalysisItem> = this.analysisDbService.accountAnalysisItems.getValue();
+        this.selectedAnalysisItem.setupErrors = this.analysisValidationService.getAccountAnalysisSetupErrors(this.selectedAnalysisItem, analysisItems);
+        await firstValueFrom(this.accountAnalysisDbService.updateWithObservable(this.selectedAnalysisItem));
+        let account: IdbAccount = this.accountDbService.selectedAccount.getValue();
+        await this.dbChangesService.setAccountAnalysisItems(account, false);
+        this.accountAnalysisDbService.selectedAnalysisItem.next(this.selectedAnalysisItem);
+      }
+    }
   }
 }

--- a/src/app/facility/analysis/account-analysis-list/account-analysis-list.component.ts
+++ b/src/app/facility/analysis/account-analysis-list/account-analysis-list.component.ts
@@ -31,22 +31,14 @@ export class AccountAnalysisListComponent implements OnInit {
   ngOnInit(): void {
     this.canReturnToAccount = this.analysisService.accountAnalysisItem != undefined;
     let selectedAnalysisItem: IdbAnalysisItem = this.analysisDbService.selectedAnalysisItem.getValue();
-    let allAccountAnalysisItems: Array<IdbAccountAnalysisItem> = this.accountAnalysisDbService.accountAnalysisItems.getValue();
-    this.accountAnalysisItems = new Array();
-    allAccountAnalysisItems.forEach(accountItem => {
-      accountItem.facilityAnalysisItems.forEach(facilityItem => {
-        if (facilityItem.analysisItemId == selectedAnalysisItem.guid) {
-          this.accountAnalysisItems.push(accountItem);
-        }
-      });
-    });
+    this.accountAnalysisItems = this.accountAnalysisDbService.getCorrespondingAccountAnalysisItems(selectedAnalysisItem.guid);
 
     this.itemsPerPageSub = this.sharedDataService.itemsPerPage.subscribe(val => {
       this.itemsPerPage = val;
     });
   }
 
-  ngOnDestroy(){
+  ngOnDestroy() {
     this.itemsPerPageSub.unsubscribe();
   }
 
@@ -65,7 +57,7 @@ export class AccountAnalysisListComponent implements OnInit {
     this.selectAnalysisItem(this.analysisService.accountAnalysisItem);
   }
 
-  goToAccountAnalysisDashboard(){
+  goToAccountAnalysisDashboard() {
     this.router.navigateByUrl('/account/analysis')
   }
 }

--- a/src/app/facility/analysis/analysis.component.ts
+++ b/src/app/facility/analysis/analysis.component.ts
@@ -48,6 +48,7 @@ export class AnalysisComponent implements OnInit {
     this.utilityMeterGroupsSub.unsubscribe();
     this.analysisService.accountAnalysisItem = undefined;
     this.facilityAnalysisItemsSub.unsubscribe();
+    this.analysisService.hideInUseMessage = false;
   }
 
   goToMeterGroups() {

--- a/src/app/facility/analysis/analysis.service.ts
+++ b/src/app/facility/analysis/analysis.service.ts
@@ -19,6 +19,7 @@ export class AnalysisService {
   monthlyAccountAnalysisData: BehaviorSubject<Array<MonthlyAnalysisSummaryData>>;
   accountAnalysisItem: IdbAccountAnalysisItem;
   showDetail: BehaviorSubject<boolean>;
+  hideInUseMessage: boolean = false;
   constructor(private localStorageService: LocalStorageService) {
     let dataDisplay: "graph" | "table" = this.localStorageService.retrieve("analysisDataDisplay");
     if (!dataDisplay) {

--- a/src/app/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.html
+++ b/src/app/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.html
@@ -22,13 +22,13 @@
                             <div class="form-check">
                                 <input type="radio" class="form-check-input" name="energyIsSource" [value]="true"
                                     id="sourceEnergy" [(ngModel)]="analysisItem.energyIsSource"
-                                    (change)="setSiteSource()">
+                                    (change)="setSiteSource()" [disabled]="disableForm">
                                 <label class="form-check-label" for="sourceEnergy">Source Energy</label>
                             </div>
                             <div class="form-check">
                                 <input type="radio" class="form-check-input" name="energyIsSource" [value]="false"
-                                    id="siteEnergy" [(ngModel)]="analysisItem.energyIsSource"
-                                    (change)="setSiteSource()">
+                                    id="siteEnergy" [(ngModel)]="analysisItem.energyIsSource" (change)="setSiteSource()"
+                                    [disabled]="disableForm">
                                 <label class="form-check-label" for="siteEnergy">Site Energy</label>
                             </div>
                         </div>
@@ -37,7 +37,7 @@
                         <label class="col-5 col-form-label" for="energyUnit">Energy Unit</label>
                         <div class="col-7">
                             <select class="form-select" name="energyUnit" id="energyUnit"
-                                [(ngModel)]="analysisItem.energyUnit" (change)="saveItem()">
+                                [(ngModel)]="analysisItem.energyUnit" (change)="saveItem()" [disabled]="disableForm">
                                 <option *ngFor="let energyUnitOption of energyUnitOptions"
                                     [ngValue]="energyUnitOption.value">
                                     <span [innerHTML]="energyUnitOption.display"></span>
@@ -51,7 +51,7 @@
                         <label class="col-5 col-form-label" for="waterUnit">Water Unit</label>
                         <div class="col-7">
                             <select class="form-select" name="waterUnit" id="waterUnit"
-                                [(ngModel)]="analysisItem.waterUnit" (change)="saveItem()">
+                                [(ngModel)]="analysisItem.waterUnit" (change)="saveItem()" [disabled]="disableForm">
                                 <option *ngFor="let waterUnitOption of waterUnitOptions"
                                     [ngValue]="waterUnitOption.value">
                                     <span [innerHTML]="waterUnitOption.display"></span>
@@ -60,7 +60,6 @@
                         </div>
                     </div>
                 </ng-container>
-                <hr>
             </div>
             <div class="col-6">
                 <div class="form-group row">
@@ -69,7 +68,8 @@
                     </label>
                     <div class="col-7">
                         <select required class="form-select" id="baselineYear" name="baselineYear"
-                            [(ngModel)]="analysisItem.baselineYear" (change)="changeReportYear()">
+                            [(ngModel)]="analysisItem.baselineYear" (change)="changeReportYear()"
+                            [disabled]="disableForm">
                             <option *ngFor="let year of yearOptions" [ngValue]="year">
                                 {{year| yearDisplay: facility.fiscalYear}}</option>
                         </select>
@@ -93,7 +93,8 @@
                     </label>
                     <div class="col-7">
                         <select required class="form-select" name="reportYear" id="reportYear"
-                            [(ngModel)]="analysisItem.reportYear" (change)="changeReportYear()">
+                            [(ngModel)]="analysisItem.reportYear" (change)="changeReportYear()"
+                            [disabled]="disableForm">
                             <option *ngFor="let year of yearOptions" [ngValue]="year">{{year| yearDisplay:
                                 facility.fiscalYear}}
                             </option>
@@ -142,8 +143,47 @@
                 <div class="alert alert-info text-center p-1">
                     Fields set in "<span class="fa fa-gear"></span> Settings" tab.
                 </div>
-                <hr>
             </div>
         </div>
     </form>
+    <div class="row">
+        <div class="col">
+            <hr>
+        </div>
+    </div>
+    <div class="row" *ngIf="hasModelsGenerated">
+        <div class="col-12 alert alert-warning text-center">
+            One or more groups have regression models generated. These settings were used to create the models and are
+            now locked. To clear the models so that you can modify these settings <a class="click-link"
+                (click)="showEnableForm()">click here</a>.
+        </div>
+    </div>
+    <div class="row" *ngIf="hasCorrespondingAccountItems">
+        <div class="col-12 alert alert-info text-center">
+            This analysis is used in one or more account analysis. Click the "Account Analysis" tab to view and navigate
+            to the corresponding analysis items.
+        </div>
+    </div>
+</div>
+
+
+<div [ngClass]="{'windowOverlay': displayEnableForm}"></div>
+<div class="popup" [class.open]="displayEnableForm">
+    <div class="popup-header">Are you sure?
+        <button class="item-right" (click)="cancelEnableForm()">x</button>
+    </div>
+    <div class="popup-body">
+        Are you sure you want to clear the existing regression models in this analysis? This cannot be undone!
+        <hr>
+        <!-- <div class="row"> -->
+        <div class="col-12 alert alert-info text-center" *ngIf="hasCorrespondingAccountItems">
+            This analysis is used in one or more account analysis. Altering the models in this analysis may effect
+            the results of the corresponding account analysis.
+        </div>
+        <!-- </div> -->
+    </div>
+    <div class="saveCancel popup-footer text-end">
+        <button class="btn btn-secondary" (click)="cancelEnableForm()">Cancel</button>
+        <button class="btn action-btn" (click)="confirmEnableForm()">Clear Models</button>
+    </div>
 </div>

--- a/src/app/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.html
+++ b/src/app/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.html
@@ -1,5 +1,13 @@
 <div class="content-padding">
     <h4>Analysis Setup</h4>
+    <div class="row" *ngIf="showInUseMessage">
+        <div class="col-12 alert alert-info text-center">
+            <button type="button" class="btn-close" aria-label="Close" (click)="hideInUseMessage()"></button>
+            This analysis is used in one or more account analysis. Click the "Account Analysis" tab to view and navigate
+            to the corresponding analysis items. Making changes to this analysis may effect the results of the account
+            analysis.
+        </div>
+    </div>
     <form>
         <div class="row">
             <div class="col-6">
@@ -158,12 +166,6 @@
                 (click)="showEnableForm()">click here</a>.
         </div>
     </div>
-    <div class="row" *ngIf="hasCorrespondingAccountItems">
-        <div class="col-12 alert alert-info text-center">
-            This analysis is used in one or more account analysis. Click the "Account Analysis" tab to view and navigate
-            to the corresponding analysis items.
-        </div>
-    </div>
 </div>
 
 
@@ -176,7 +178,7 @@
         Are you sure you want to clear the existing regression models in this analysis? This cannot be undone!
         <hr>
         <!-- <div class="row"> -->
-        <div class="col-12 alert alert-info text-center" *ngIf="hasCorrespondingAccountItems">
+        <div class="col-12 alert alert-info text-center" *ngIf="showInUseMessage">
             This analysis is used in one or more account analysis. Altering the models in this analysis may effect
             the results of the corresponding account analysis.
         </div>

--- a/src/app/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.ts
+++ b/src/app/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.ts
@@ -30,7 +30,7 @@ export class AnalysisSetupComponent implements OnInit {
   yearOptions: Array<number>;
   baselineYearWarning: string;
   disableForm: boolean;
-  hasCorrespondingAccountItems: boolean;
+  showInUseMessage: boolean;
   hasModelsGenerated: boolean;
   displayEnableForm: boolean = false;
   constructor(private facilityDbService: FacilitydbService, private analysisDbService: AnalysisDbService,
@@ -92,7 +92,9 @@ export class AnalysisSetupComponent implements OnInit {
 
   setComponentBools() {
     let accountAnalysisItems = this.accountAnalysisDbService.getCorrespondingAccountAnalysisItems(this.analysisItem.guid);
-    this.hasCorrespondingAccountItems = accountAnalysisItems.length != 0;
+    if(accountAnalysisItems.length != 0 && this.analysisService.hideInUseMessage == false){
+      this.showInUseMessage = true;
+    }
     let hasModelsGenerated: boolean = false;
     this.analysisItem.groups.forEach(group => {
       if (group.analysisType == 'regression') {
@@ -105,6 +107,10 @@ export class AnalysisSetupComponent implements OnInit {
     this.disableForm = this.hasModelsGenerated;
   }
 
+  hideInUseMessage(){
+    this.showInUseMessage = false;
+    this.analysisService.hideInUseMessage = true;
+  }
 
   showEnableForm() {
     this.displayEnableForm = true;

--- a/src/app/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.ts
+++ b/src/app/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.ts
@@ -61,6 +61,14 @@ export class AnalysisSetupComponent implements OnInit {
   changeReportYear() {
     this.analysisItem = this.analysisService.setBaselineAdjustments(this.analysisItem);
     this.setBaselineYearWarning();
+    let allFacilityAnalysisItems: Array<IdbAnalysisItem> = this.analysisDbService.facilityAnalysisItems.getValue();
+    let selectYearAnalysis: boolean = true;
+    allFacilityAnalysisItems.forEach(item => {
+      if (item.reportYear == this.analysisItem.reportYear && item.selectedYearAnalysis) {
+        selectYearAnalysis = false;
+      }
+    });
+    this.analysisItem.selectedYearAnalysis = selectYearAnalysis;
     this.saveItem();
   }
 
@@ -92,7 +100,7 @@ export class AnalysisSetupComponent implements OnInit {
 
   setComponentBools() {
     let accountAnalysisItems = this.accountAnalysisDbService.getCorrespondingAccountAnalysisItems(this.analysisItem.guid);
-    if(accountAnalysisItems.length != 0 && this.analysisService.hideInUseMessage == false){
+    if (accountAnalysisItems.length != 0 && this.analysisService.hideInUseMessage == false) {
       this.showInUseMessage = true;
     }
     let hasModelsGenerated: boolean = false;
@@ -107,7 +115,7 @@ export class AnalysisSetupComponent implements OnInit {
     this.disableForm = this.hasModelsGenerated;
   }
 
-  hideInUseMessage(){
+  hideInUseMessage() {
     this.showInUseMessage = false;
     this.analysisService.hideInUseMessage = true;
   }

--- a/src/app/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.ts
+++ b/src/app/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.ts
@@ -138,6 +138,7 @@ export class AnalysisSetupComponent implements OnInit {
       group.predictorVariables.forEach(variable => {
         variable.regressionCoefficient = undefined;
       })
+      group.groupErrors = this.analysisValidationService.getGroupErrors(group);
     });
     await this.saveItem();
     this.setComponentBools();

--- a/src/app/facility/analysis/run-analysis/group-analysis/group-analysis-options/group-analysis-options.component.html
+++ b/src/app/facility/analysis/run-analysis/group-analysis/group-analysis-options/group-analysis-options.component.html
@@ -6,6 +6,13 @@
     </div>
 </div>
 
+<div class="row" *ngIf="hasCorrespondingAccountItems">
+    <div class="col-12 alert alert-info text-center">
+        This analysis is used in one or more account analysis. Click the "Account Analysis" tab to view and navigate
+        to the corresponding analysis items. Making changes to this analysis may effect the results of the account
+        analysis.
+    </div>
+</div>
 <ng-container *ngIf="!group.groupErrors.missingGroupMeters">
     <form>
         <div class="row">
@@ -160,7 +167,8 @@
                     </div>
                 </div>
             </div>
-            <div class="col-md-6 col-sm-12" *ngIf="group.analysisType != 'skip' && group.analysisType != 'skipAnalysis'">
+            <div class="col-md-6 col-sm-12"
+                *ngIf="group.analysisType != 'skip' && group.analysisType != 'skipAnalysis'">
                 <label class="bold">
                     <span
                         *ngIf="group.analysisType == 'regression' || group.analysisType == 'absoluteEnergyConsumption'">2.</span>

--- a/src/app/facility/analysis/run-analysis/group-analysis/group-analysis-options/group-analysis-options.component.html
+++ b/src/app/facility/analysis/run-analysis/group-analysis/group-analysis-options/group-analysis-options.component.html
@@ -6,8 +6,9 @@
     </div>
 </div>
 
-<div class="row" *ngIf="hasCorrespondingAccountItems">
+<div class="row" *ngIf="showInUseMessage">
     <div class="col-12 alert alert-info text-center">
+        <button type="button" class="btn-close" aria-label="Close" (click)="hideInUseMessage()"></button>
         This analysis is used in one or more account analysis. Click the "Account Analysis" tab to view and navigate
         to the corresponding analysis items. Making changes to this analysis may effect the results of the account
         analysis.

--- a/src/app/facility/analysis/run-analysis/group-analysis/group-analysis-options/group-analysis-options.component.ts
+++ b/src/app/facility/analysis/run-analysis/group-analysis/group-analysis-options/group-analysis-options.component.ts
@@ -26,7 +26,7 @@ export class GroupAnalysisOptionsComponent implements OnInit {
   yearOptions: Array<number>;
   analysisItem: IdbAnalysisItem;
   facility: IdbFacility;
-  hasCorrespondingAccountItems: boolean;
+  showInUseMessage: boolean;
   constructor(private analysisService: AnalysisService, private analysisDbService: AnalysisDbService,
     private accountDbService: AccountdbService, private facilityDbService: FacilitydbService,
     private dbChangesService: DbChangesService,
@@ -38,8 +38,7 @@ export class GroupAnalysisOptionsComponent implements OnInit {
   ngOnInit(): void {
     this.facility = this.facilityDbService.selectedFacility.getValue();
     this.analysisItem = this.analysisDbService.selectedAnalysisItem.getValue();
-    let accountAnalysisItems = this.accountAnalysisDbService.getCorrespondingAccountAnalysisItems(this.analysisItem.guid);
-    this.hasCorrespondingAccountItems = accountAnalysisItems.length != 0;
+    this.setShowInUseMessage();
     this.yearOptions = this.calanderizationService.getYearOptionsFacility(this.facility.guid, this.analysisItem.analysisCategory);
     this.selectedGroupSub = this.analysisService.selectedGroup.subscribe(group => {
       this.group = group;
@@ -90,4 +89,17 @@ export class GroupAnalysisOptionsComponent implements OnInit {
     let facility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
     this.router.navigateByUrl('facility/' + facility.id + '/utility/meter-groups');
   }
+
+  setShowInUseMessage() {
+    let accountAnalysisItems = this.accountAnalysisDbService.getCorrespondingAccountAnalysisItems(this.analysisItem.guid);
+    if (accountAnalysisItems.length != 0 && this.analysisService.hideInUseMessage == false) {
+      this.showInUseMessage = true;
+    }
+  }
+
+  hideInUseMessage() {
+    this.showInUseMessage = false;
+    this.analysisService.hideInUseMessage = true;
+  }
+
 }

--- a/src/app/facility/analysis/run-analysis/group-analysis/group-analysis-options/group-analysis-options.component.ts
+++ b/src/app/facility/analysis/run-analysis/group-analysis/group-analysis-options/group-analysis-options.component.ts
@@ -11,6 +11,7 @@ import { Router } from '@angular/router';
 import { AnalysisGroup } from 'src/app/models/analysis';
 import { AnalysisValidationService } from 'src/app/shared/helper-services/analysis-validation.service';
 import { CalanderizationService } from 'src/app/shared/helper-services/calanderization.service';
+import { AccountAnalysisDbService } from 'src/app/indexedDB/account-analysis-db.service';
 
 @Component({
   selector: 'app-group-analysis-options',
@@ -25,16 +26,20 @@ export class GroupAnalysisOptionsComponent implements OnInit {
   yearOptions: Array<number>;
   analysisItem: IdbAnalysisItem;
   facility: IdbFacility;
+  hasCorrespondingAccountItems: boolean;
   constructor(private analysisService: AnalysisService, private analysisDbService: AnalysisDbService,
     private accountDbService: AccountdbService, private facilityDbService: FacilitydbService,
     private dbChangesService: DbChangesService,
     private analysisValidationService: AnalysisValidationService,
     private calanderizationService: CalanderizationService,
-    private router: Router) { }
+    private router: Router,
+    private accountAnalysisDbService: AccountAnalysisDbService) { }
 
   ngOnInit(): void {
     this.facility = this.facilityDbService.selectedFacility.getValue();
     this.analysisItem = this.analysisDbService.selectedAnalysisItem.getValue();
+    let accountAnalysisItems = this.accountAnalysisDbService.getCorrespondingAccountAnalysisItems(this.analysisItem.guid);
+    this.hasCorrespondingAccountItems = accountAnalysisItems.length != 0;
     this.yearOptions = this.calanderizationService.getYearOptionsFacility(this.facility.guid, this.analysisItem.analysisCategory);
     this.selectedGroupSub = this.analysisService.selectedGroup.subscribe(group => {
       this.group = group;

--- a/src/app/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-menu/regression-model-menu.component.ts
+++ b/src/app/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-menu/regression-model-menu.component.ts
@@ -77,8 +77,8 @@ export class RegressionModelMenuComponent implements OnInit {
     this.isFormChange = true;
     let groupIndex: number = this.analysisItem.groups.findIndex(group => { return group.idbGroupId == this.group.idbGroupId });
     this.group.groupErrors = this.analysisValidationService.getGroupErrors(this.group);
-
     this.analysisItem.groups[groupIndex] = this.group;
+    this.analysisItem.setupErrors = this.analysisValidationService.getAnalysisItemErrors(this.analysisItem);
     await firstValueFrom(this.analysisDbService.updateWithObservable(this.analysisItem));
     let selectedAccount: IdbAccount = this.accountDbService.selectedAccount.getValue();
     this.dbChangesService.setAnalysisItems(selectedAccount, false, this.selectedFacility);

--- a/src/app/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-selection.component.html
+++ b/src/app/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-selection.component.html
@@ -1,3 +1,12 @@
+
+<div class="row" *ngIf="hasCorrespondingAccountItems">
+    <div class="col-12 alert alert-info text-center">
+        This analysis is used in one or more account analysis. Click the "Account Analysis" tab to view and navigate
+        to the corresponding analysis items. Making changes to this analysis may effect the results of the account
+        analysis.
+    </div>
+</div>
+
 <ng-container *ngIf="!selectedInspectModel">
     <ng-container *ngIf="selectedGroup.groupErrors?.hasInvalidRegressionModel">
         <div class="alert alert-warning w-100 text-center">

--- a/src/app/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-selection.component.html
+++ b/src/app/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-selection.component.html
@@ -1,6 +1,8 @@
 
-<div class="row" *ngIf="hasCorrespondingAccountItems">
+
+<div class="row" *ngIf="showInUseMessage">
     <div class="col-12 alert alert-info text-center">
+        <button type="button" class="btn-close" aria-label="Close" (click)="hideInUseMessage()"></button>
         This analysis is used in one or more account analysis. Click the "Account Analysis" tab to view and navigate
         to the corresponding analysis items. Making changes to this analysis may effect the results of the account
         analysis.

--- a/src/app/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-selection.component.ts
+++ b/src/app/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-selection.component.ts
@@ -24,7 +24,7 @@ export class RegressionModelSelectionComponent implements OnInit {
   selectedGroupSub: Subscription;
   selectedFacility: IdbFacility;
   selectedInspectModel: JStatRegressionModel;
-  hasCorrespondingAccountItems: boolean;
+  showInUseMessage: boolean;
   constructor(private analysisService: AnalysisService,
     private analysisDbService: AnalysisDbService, private facilityDbService: FacilitydbService, private dbChangesService: DbChangesService,
     private accountDbService: AccountdbService,
@@ -40,9 +40,7 @@ export class RegressionModelSelectionComponent implements OnInit {
     this.showInvalidSub = this.analysisService.showInvalidModels.subscribe(val => {
       this.showInvalid = val;
     });
-    let analysisItem: IdbAnalysisItem = this.analysisDbService.selectedAnalysisItem.getValue();
-    let accountAnalysisItems = this.accountAnalysisDbService.getCorrespondingAccountAnalysisItems(analysisItem.guid);
-    this.hasCorrespondingAccountItems = accountAnalysisItems.length != 0;
+    this.setShowInUseMessage();
 
   }
   ngOnDestroy() {
@@ -102,5 +100,18 @@ export class RegressionModelSelectionComponent implements OnInit {
     this.selectedGroup.selectedModelId = this.selectedInspectModel.modelId;
     await this.selectModel();
     this.cancelInspectModel();
+  }
+
+  setShowInUseMessage() {
+    let analysisItem: IdbAnalysisItem = this.analysisDbService.selectedAnalysisItem.getValue();
+    let accountAnalysisItems = this.accountAnalysisDbService.getCorrespondingAccountAnalysisItems(analysisItem.guid);
+    if (accountAnalysisItems.length != 0 && this.analysisService.hideInUseMessage == false) {
+      this.showInUseMessage = true;
+    }
+  }
+
+  hideInUseMessage() {
+    this.showInUseMessage = false;
+    this.analysisService.hideInUseMessage = true;
   }
 }

--- a/src/app/indexedDB/account-analysis-db.service.ts
+++ b/src/app/indexedDB/account-analysis-db.service.ts
@@ -155,4 +155,17 @@ export class AccountAnalysisDbService {
       this.accountAnalysisItems.next(accountAnalysisItems);
     }
   }
+
+  getCorrespondingAccountAnalysisItems(facilityAnalysisItemId: string): Array<IdbAccountAnalysisItem> {
+    let allAccountAnalysisItems: Array<IdbAccountAnalysisItem> = this.accountAnalysisItems.getValue();
+    let correspondingItems: Array<IdbAccountAnalysisItem> = new Array();
+    allAccountAnalysisItems.forEach(accountItem => {
+      accountItem.facilityAnalysisItems.forEach(facilityItem => {
+        if (facilityItem.analysisItemId == facilityAnalysisItemId) {
+          correspondingItems.push(accountItem);
+        }
+      });
+    });
+    return correspondingItems;
+  }
 }

--- a/src/app/indexedDB/account-report-db.service.ts
+++ b/src/app/indexedDB/account-report-db.service.ts
@@ -142,4 +142,12 @@ export class AccountReportDbService {
     }
   }
 
+  getHasCorrespondingReport(analysisId: string): boolean {
+    let accountReports: Array<IdbAccountReport> = this.accountReports.getValue();
+    let hasReport: IdbAccountReport = accountReports.find(report => {
+      return (report.reportType == 'betterPlants' && report.betterPlantsReportSetup.analysisItemId == analysisId);
+    });
+    return (hasReport != undefined);
+  }
+
 }

--- a/src/app/models/idb.ts
+++ b/src/app/models/idb.ts
@@ -316,7 +316,8 @@ export interface IdbAccountAnalysisItem {
     analysisCategory: AnalysisCategory,
     waterUnit: string,
     baselineYear: number,
-    setupErrors: AccountAnalysisSetupErrors
+    setupErrors: AccountAnalysisSetupErrors,
+    facilityItemsInitialized?: boolean
 }
 
 


### PR DESCRIPTION
connects #1182 

- lock facility analysis setup options if regression models generated
- lock account analysis setup options if facility items selected
- add messaging to analysis when they are used in other areas of the application
- set selected if analysis item is the only one for that year