### PR TITLE
Add deployment pipeline for web and desktop releases

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -1,0 +1,134 @@
+name: Electron
+
+on:
+  workflow_call:
+
+permissions:
+  contents: write
+
+jobs:
+  build-mac:
+    runs-on: macos-12
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Node setup
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.14.2
+      - name: Cache setup
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+      - name: Cert setup
+        env:
+          APPLE_CERT_A_BASE64: ${{ secrets.APPLE_CERT_A_BASE64 }}
+          APPLE_CERT_I_BASE64: ${{ secrets.APPLE_CERT_I_BASE64 }}
+          APPLE_PROV_PROF_BASE64: ${{ secrets.APPLE_PROV_PROF_BASE64 }}
+          APPLE_CERT_SECRET: ${{ secrets.APPLE_CERT_SECRET }}
+          APPLE_KEYCHAIN_SECRET: ${{ secrets.APPLE_KEYCHAIN_SECRET }}
+        run: |
+          CERT_A_PATH=$RUNNER_TEMP/app_certificate.p12
+          CERT_I_PATH=$RUNNER_TEMP/ins_certificate.p12
+          PROV_PROF_PATH=$RUNNER_TEMP/AMO.provisionprofile
+          KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain
+
+          echo -n "$APPLE_CERT_A_BASE64" | base64 --decode -o $CERT_A_PATH
+          echo -n "$APPLE_CERT_I_BASE64" | base64 --decode -o $CERT_I_PATH
+          echo -n "$APPLE_PROV_PROF_BASE64" | base64 --decode -o $PROV_PROF_PATH
+
+          security -v create-keychain -p "$APPLE_KEYCHAIN_SECRET" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security -v default-keychain -s $KEYCHAIN_PATH
+          security -v unlock-keychain -p "$APPLE_KEYCHAIN_SECRET" $KEYCHAIN_PATH
+
+          security -v import $CERT_A_PATH -P "$APPLE_CERT_SECRET" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security -v import $CERT_I_PATH -P "$APPLE_CERT_SECRET" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$APPLE_KEYCHAIN_SECRET" $KEYCHAIN_PATH
+
+          cp "$PROV_PROF_PATH" ./embedded.provisionprofile
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build-prod-electron
+      - name: Package [Mac]
+        run: npm run dist-nopub
+      - name: Prepare output
+        id: output
+        run: |
+          VERSION=$(grep -A3 'version:' ../output/verifi/latest-mac.yml | tail -n1 | awk '{ print $2}')
+          echo "BUILD_VERSION=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-mac
+          path: |
+            /Users/runner/work/VERIFI/output/verifi/*
+            !/Users/runner/work/VERIFI/output/verifi/.icon-ico
+            !/Users/runner/work/VERIFI/output/verifi/builder-debug.yml
+            !/Users/runner/work/VERIFI/output/verifi/*-unpacked
+          retention-days: 7
+    outputs:
+      BUILD_VERSION: ${{ steps.output.outputs.BUILD_VERSION }}
+
+  build-winux:
+    runs-on: ubuntu-22.04
+    container:
+      image: electronuserland/builder:wine
+      options: --user 1001
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Node setup
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.14.2
+      - name: Cache setup
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build-prod-electron
+      - name: Package [Win]
+        run: node ./node_modules/.bin/electron-builder --win --publish never
+      - name: Package [Linux]
+        run: npm run dist-nopub
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-winux
+          path: |
+            /__w/VERIFI/output/verifi/*
+            !/__w/VERIFI/output/verifi/.icon-ico
+            !/__w/VERIFI/output/verifi/builder-debug.yml
+            !/__w/VERIFI/output/verifi/*-unpacked
+          retention-days: 7
+          
+  release:
+    runs-on: ubuntu-22.04
+    needs: [build-mac, build-winux]
+    steps:
+      - name: Get artifacts
+        uses: actions/download-artifact@v3
+      - name: Release
+        env:
+          VERSION: ${{ needs.build-mac.outputs.BUILD_VERSION }}
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          name: VERIFI v${{ env.VERSION }}
+          draft: true
+          generate_release_notes: true
+          files: |
+            build-mac/*
+            build-winux/*

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Build
         run: npm run build-prod-electron
       - name: Package [Mac]
-        run: npm run dist-nopub
+        run: npm run dist-nopublish
       - name: Prepare output
         id: output
         run: |
@@ -102,7 +102,7 @@ jobs:
       - name: Package [Win]
         run: node ./node_modules/.bin/electron-builder --win --publish never
       - name: Package [Linux]
-        run: npm run dist-nopub
+        run: npm run dist-nopublish
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -113,22 +113,25 @@ jobs:
             !/__w/VERIFI/output/verifi/builder-debug.yml
             !/__w/VERIFI/output/verifi/*-unpacked
           retention-days: 7
-          
-  release:
-    runs-on: ubuntu-22.04
-    needs: [build-mac, build-winux]
-    steps:
-      - name: Get artifacts
-        uses: actions/download-artifact@v3
-      - name: Release
-        env:
-          VERSION: ${{ needs.build-mac.outputs.BUILD_VERSION }}
-        uses: softprops/action-gh-release@v1
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          name: VERIFI v${{ env.VERSION }}
-          draft: true
-          generate_release_notes: true
-          files: |
-            build-mac/*
-            build-winux/*
+
+  ###
+  # TODO: Test stage before using. Artifacts will have to be downloaded and uploaded to releases manually for now. 
+  ###
+  # release:
+  #   runs-on: ubuntu-22.04
+  #   needs: [build-mac, build-winux]
+  #   steps:
+  #     - name: Get artifacts
+  #       uses: actions/download-artifact@v3
+  #     - name: Release
+  #       env:
+  #         VERSION: ${{ needs.build-mac.outputs.BUILD_VERSION }}
+  #       uses: softprops/action-gh-release@v1
+  #       if: startsWith(github.ref, 'refs/tags/')
+  #       with:
+  #         name: VERIFI v${{ env.VERSION }}
+  #         draft: true
+  #         generate_release_notes: true
+  #         files: |
+  #           build-mac/*
+  #           build-winux/*

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+name: CI/CD
+on:
+  push:
+    branches:
+      - 'main'
+  workflow_dispatch:
+    
+jobs:
+  web:
+    uses: ./.github/workflows/web.yml
+
+  # Do not enable yet - not yet implemented
+  # electron:
+  #   uses: ./.github/workflows/electron.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI/CD
 on:
   push:
     branches:
-      - 'main'
+      - 'master'
   workflow_dispatch:
     
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,6 @@ jobs:
   web:
     uses: ./.github/workflows/web.yml
 
-  # Do not enable yet - not yet implemented
-  # electron:
-  #   uses: ./.github/workflows/electron.yml
+  electron:
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    uses: ./.github/workflows/electron.yml

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,0 +1,49 @@
+name: Web
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Node setup
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.14.2
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build-prod
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: ./dist
+
+  deploy:
+    runs-on: [self-hosted, amo-tools]
+    needs: build
+    env:
+      APACHE_DIR: /var/www/html
+      BACKUP_DIR: /opt/actions-runner/backups
+    steps:
+      - name: Get artifact
+        uses: actions/download-artifact@v3
+        with:
+           name: dist
+      - name: Deploy
+        run: |
+          tar -czf $BACKUP_DIR/verifi_$(printf '%(%Y-%m-%d)T\n' -1)_${GITHUB_SHA::7}.tar.gz $APACHE_DIR/verifi
+          rm -rf $APACHE_DIR/verifi/*
+          chgrp -R apache ./verifi
+          mv -v ./verifi/* $APACHE_DIR/verifi/

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "electron": "electron .",
     "pack": "electron-builder --dir",
     "dist": "electron-builder",
-    "dist-nopub": "electron-builder --publish never"
+    "dist-nopublish": "electron-builder --publish never"
   },
   "private": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
       ],
       "icon": "src/assets/electron-icons/icon-512x512.png",
       "hardenedRuntime": true,
-      "provisioningProfile": "embedded.provisionprofile",
+      "provisioningProfile": "./embedded.provisionprofile",
       "entitlements": "entitlements.mac.inherit.plist",
       "entitlementsInherit": "entitlements.mac.inherit.plist",
       "gatekeeperAssess": false
@@ -58,7 +58,8 @@
     "e2e": "ng e2e",
     "electron": "electron .",
     "pack": "electron-builder --dir",
-    "dist": "electron-builder"
+    "dist": "electron-builder",
+    "dist-nopub": "electron-builder --publish never"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Does not automatically create a new release and upload build assets to it. Further testing is going to be done prior to integrating the release stage. 