### PR TITLE
Update account overview pages with breakdowns by utility

### DIFF
--- a/src/app/account/account-overview/costs-overview/costs-overview.component.html
+++ b/src/app/account/account-overview/costs-overview/costs-overview.component.html
@@ -32,6 +32,16 @@
                                 [accountOverviewFacilities]="accountOverviewData.facilitiesCost"></app-facility-usage-donut>
                         </div>
                     </div>
+                    <div class="row">
+                        <div class="col-6">
+                            <app-account-utility-usage-table [dataType]="'cost'"
+                                [accountOverviewData]="accountOverviewData"></app-account-utility-usage-table>
+                        </div>
+                        <div class="col-6">
+                            <app-account-utility-usage-donut [dataType]="'cost'"
+                                [accountOverviewData]="accountOverviewData"></app-account-utility-usage-donut>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/app/account/account-overview/energy-overview/energy-overview.component.html
+++ b/src/app/account/account-overview/energy-overview/energy-overview.component.html
@@ -33,7 +33,8 @@
                                 [accountOverviewFacilities]="accountOverviewData.facilitiesEnergy"
                                 [accountOverviewData]="accountOverviewData"
                                 [energyUnit]="energyUnit"></app-facilities-usage-table> -->
-                            <app-account-utility-usage-table></app-account-utility-usage-table>
+                            <app-account-utility-usage-table [accountOverviewData]="accountOverviewData"
+                                [energyUnit]="energyUnit"></app-account-utility-usage-table>
                         </div>
                         <div class="col-6">
                             <!-- <app-facility-usage-donut [dataType]="'energyUse'"

--- a/src/app/account/account-overview/energy-overview/energy-overview.component.html
+++ b/src/app/account/account-overview/energy-overview/energy-overview.component.html
@@ -27,6 +27,22 @@
                                 [energyUnit]="energyUnit"></app-facility-usage-donut>
                         </div>
                     </div>
+                    <div class="row">
+                        <div class="col-6">
+                            <!-- <app-facilities-usage-table [dataType]="'energyUse'"
+                                [accountOverviewFacilities]="accountOverviewData.facilitiesEnergy"
+                                [accountOverviewData]="accountOverviewData"
+                                [energyUnit]="energyUnit"></app-facilities-usage-table> -->
+                            <app-account-utility-usage-table></app-account-utility-usage-table>
+                        </div>
+                        <div class="col-6">
+                            <!-- <app-facility-usage-donut [dataType]="'energyUse'"
+                                [accountOverviewFacilities]="accountOverviewData.facilitiesEnergy"
+                                [energyUnit]="energyUnit"></app-facility-usage-donut> -->
+                            <app-account-utility-usage-donut [accountOverviewData]="accountOverviewData"
+                                [energyUnit]="energyUnit"></app-account-utility-usage-donut>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -41,8 +57,9 @@
                 <div class="card-body">
                     <app-utility-consumption-table [dataType]="'energyUse'"
                         [sourcesUseAndCost]="utilityUseAndCost.energyUseAndCost"
-                        [useAndCostTotal]="utilityUseAndCost.energyTotal" [previousYear]="utilityUseAndCost.previousYear"
-                        [dateRange]="dateRange" [energyUnit]="energyUnit"></app-utility-consumption-table>
+                        [useAndCostTotal]="utilityUseAndCost.energyTotal"
+                        [previousYear]="utilityUseAndCost.previousYear" [dateRange]="dateRange"
+                        [energyUnit]="energyUnit"></app-utility-consumption-table>
                 </div>
             </div>
         </div>
@@ -56,8 +73,7 @@
                 </div>
                 <div class="card-body">
                     <app-facilities-usage-stacked-bar-chart [dataType]="'energyUse'"
-                        [calanderizedMeters]="accountOverviewData.calanderizedMeters"
-                        [energyUnit]="energyUnit"
+                        [calanderizedMeters]="accountOverviewData.calanderizedMeters" [energyUnit]="energyUnit"
                         [dateRange]="dateRange"></app-facilities-usage-stacked-bar-chart>
                 </div>
             </div>

--- a/src/app/account/account-overview/energy-overview/energy-overview.component.html
+++ b/src/app/account/account-overview/energy-overview/energy-overview.component.html
@@ -29,19 +29,12 @@
                     </div>
                     <div class="row">
                         <div class="col-6">
-                            <!-- <app-facilities-usage-table [dataType]="'energyUse'"
-                                [accountOverviewFacilities]="accountOverviewData.facilitiesEnergy"
-                                [accountOverviewData]="accountOverviewData"
-                                [energyUnit]="energyUnit"></app-facilities-usage-table> -->
                             <app-account-utility-usage-table [accountOverviewData]="accountOverviewData"
-                                [energyUnit]="energyUnit"></app-account-utility-usage-table>
+                                [energyUnit]="energyUnit" [dataType]="'energyUse'"></app-account-utility-usage-table>
                         </div>
                         <div class="col-6">
-                            <!-- <app-facility-usage-donut [dataType]="'energyUse'"
-                                [accountOverviewFacilities]="accountOverviewData.facilitiesEnergy"
-                                [energyUnit]="energyUnit"></app-facility-usage-donut> -->
                             <app-account-utility-usage-donut [accountOverviewData]="accountOverviewData"
-                                [energyUnit]="energyUnit"></app-account-utility-usage-donut>
+                                [energyUnit]="energyUnit" [dataType]="'energyUse'"></app-account-utility-usage-donut>
                         </div>
                     </div>
                 </div>

--- a/src/app/account/account-reports/data-overview-report/data-overview-account-report/account-section-report/account-section-report.component.html
+++ b/src/app/account/account-reports/data-overview-report/data-overview-account-report/account-section-report/account-section-report.component.html
@@ -53,7 +53,7 @@
             <app-facilities-emissions-stacked-bar-chart
                 [accountOverviewFacilities]="accountOverviewData.facilitiesCost"></app-facilities-emissions-stacked-bar-chart>
         </ng-container>
-        <ng-container *ngIf="dataType == 'cost' || dataType == 'energyUse'">
+        <ng-container *ngIf="dataType != 'emissions'">
             <app-facilities-usage-stacked-bar-chart [dataType]="dataType"
                 [calanderizedMeters]="accountOverviewData.calanderizedMeters" [energyUnit]="energyUnit"
                 [dateRange]="dateRange"></app-facilities-usage-stacked-bar-chart>

--- a/src/app/account/account-reports/data-overview-report/data-overview-account-report/account-section-report/account-section-report.component.html
+++ b/src/app/account/account-reports/data-overview-report/data-overview-account-report/account-section-report/account-section-report.component.html
@@ -13,13 +13,27 @@
         <app-facility-usage-donut [dataType]="dataType " [accountOverviewFacilities]="accountOverviewFacilities"
             [waterUnit]="waterUnit" [energyUnit]="energyUnit"></app-facility-usage-donut>
     </div>
-    <div class="print-break-before" *ngIf="sectionOptions.includeFacilityTable"
-        [ngClass]="{'col-10': print, 'col-6': !print}">
-        <app-emissions-usage-table [overviewData]="accountOverviewData" [inAccount]="true"></app-emissions-usage-table>
-    </div>
-    <div *ngIf="sectionOptions.includeFacilityDonut" [ngClass]="{'col-10': print, 'col-6': !print}">
-        <app-emissions-donut [accountOverviewFacility]="accountOverviewData.facilitiesCost"></app-emissions-donut>
-    </div>
+    <ng-container *ngIf="dataType == 'emissions'">
+        <div class="print-break-before" *ngIf="sectionOptions.includeFacilityTable"
+            [ngClass]="{'col-10': print, 'col-6': !print}">
+            <app-emissions-usage-table [overviewData]="accountOverviewData"
+                [inAccount]="true"></app-emissions-usage-table>
+        </div>
+        <div *ngIf="sectionOptions.includeFacilityDonut" [ngClass]="{'col-10': print, 'col-6': !print}">
+            <app-emissions-donut [accountOverviewFacility]="accountOverviewData.facilitiesCost"></app-emissions-donut>
+        </div>
+    </ng-container>
+    <ng-container *ngIf="dataType == 'cost' || dataType == 'energyUse'">
+        <div class="print-break-before" *ngIf="sectionOptions.includeFacilityTable"
+            [ngClass]="{'col-10': print, 'col-6': !print}">
+            <app-account-utility-usage-table [accountOverviewData]="accountOverviewData" [energyUnit]="energyUnit"
+                [dataType]="dataType"></app-account-utility-usage-table>
+        </div>
+        <div *ngIf="sectionOptions.includeFacilityDonut" [ngClass]="{'col-10': print, 'col-6': !print}">
+            <app-account-utility-usage-donut [accountOverviewData]="accountOverviewData" [energyUnit]="energyUnit"
+                [dataType]="dataType"></app-account-utility-usage-donut>
+        </div>
+    </ng-container>
 </div>
 <div class="row hide-print">
     <div class="col-12">
@@ -35,8 +49,15 @@
 </div>
 <div class="row print-break-avoid" *ngIf="sectionOptions.includeStackedBarChart">
     <div class="col-12">
-        <app-facilities-emissions-stacked-bar-chart
-            [accountOverviewFacilities]="accountOverviewData.facilitiesCost"></app-facilities-emissions-stacked-bar-chart>
+        <ng-container *ngIf="dataType == 'emissions'">
+            <app-facilities-emissions-stacked-bar-chart
+                [accountOverviewFacilities]="accountOverviewData.facilitiesCost"></app-facilities-emissions-stacked-bar-chart>
+        </ng-container>
+        <ng-container *ngIf="dataType == 'cost' || dataType == 'energyUse'">
+            <app-facilities-usage-stacked-bar-chart [dataType]="dataType"
+                [calanderizedMeters]="accountOverviewData.calanderizedMeters" [energyUnit]="energyUnit"
+                [dateRange]="dateRange"></app-facilities-usage-stacked-bar-chart>
+        </ng-container>
     </div>
 </div>
 <div class="row print-break-avoid" *ngIf="sectionOptions.includeMonthlyLineChart">

--- a/src/app/account/account-reports/data-overview-report/data-overview-facility-report/facility-section-report/facility-section-report.component.html
+++ b/src/app/account/account-reports/data-overview-report/data-overview-facility-report/facility-section-report/facility-section-report.component.html
@@ -1,15 +1,30 @@
 <div class="row justify-content-center">
     <div class="col-12" *ngIf="sectionOptions.includeMeterUsageStackedLineChart">
-        <app-emissions-stacked-line-chart [calanderizedMeters]="calanderizedMeters"
-            [dateRange]="dateRange"></app-emissions-stacked-line-chart>
+        <ng-container *ngIf="dataType == 'emissions'">
+            <app-emissions-stacked-line-chart [calanderizedMeters]="calanderizedMeters"
+                [dateRange]="dateRange"></app-emissions-stacked-line-chart>
+        </ng-container>
+        <ng-container *ngIf="dataType == 'cost' || dataType == 'energyUse'">
+            <app-meters-overview-stacked-line-chart [dataType]="dataType" [facilityId]="facility.guid"
+                [calanderizedMeters]="facilityOverviewData.calanderizedMeters"
+                [dateRange]="dateRange"></app-meters-overview-stacked-line-chart>
+        </ng-container>
+
     </div>
     <div class="print-break-before" *ngIf="sectionOptions.includeMeterUsageTable"
         [ngClass]="{'col-10': print, 'col-6': !print}">
         <app-emissions-usage-table [overviewData]="facilityOverviewData"></app-emissions-usage-table>
     </div>
     <div *ngIf="sectionOptions.includeMeterUsageTable" [ngClass]="{'col-10': print, 'col-6': !print}">
-        <app-emissions-donut [facilityId]="facility.guid"
-            [facilityOverviewMeters]="facilityOverviewMeters"></app-emissions-donut>
+        <ng-container *ngIf="dataType == 'emissions'">
+            <app-emissions-donut [facilityId]="facility.guid"
+                [facilityOverviewMeters]="facilityOverviewMeters"></app-emissions-donut>
+        </ng-container>
+        <ng-container *ngIf="dataType == 'cost' || dataType == 'energyUse'">
+            <app-meter-usage-donut [dataType]="dataType" [facilityId]="facility.guid"
+                [facilityOverviewMeters]="facilityOverviewData.energyMeters"></app-meter-usage-donut>
+        </ng-container>
+
     </div>
 </div>
 <div class="row hide-print">
@@ -26,8 +41,14 @@
 </div>
 <div class="row print-break-avoid" *ngIf="sectionOptions.includeAnnualBarChart">
     <div class="col-12">
-        <app-emissions-usage-chart [facilityId]="facility.guid"
-            [annualSourceData]="annualSourceData"></app-emissions-usage-chart>
+        <ng-container *ngIf="dataType == 'emissions'">
+            <app-emissions-usage-chart [facilityId]="facility.guid"
+                [annualSourceData]="annualSourceData"></app-emissions-usage-chart>
+        </ng-container>
+        <ng-container *ngIf="dataType == 'cost' || dataType == 'energyUse'">
+            <app-utilities-usage-chart [dataType]="'energyUse'" [facilityId]="facility.guid"
+                [annualSourceData]="facilityOverviewData.annualSourceData"></app-utilities-usage-chart>
+        </ng-container>
     </div>
 </div>
 <div class="row print-break-avoid" *ngIf="sectionOptions.includeMonthlyLineChartForFacility">

--- a/src/app/account/account-reports/data-overview-report/data-overview-facility-report/facility-section-report/facility-section-report.component.html
+++ b/src/app/account/account-reports/data-overview-report/data-overview-facility-report/facility-section-report/facility-section-report.component.html
@@ -4,7 +4,7 @@
             <app-emissions-stacked-line-chart [calanderizedMeters]="calanderizedMeters"
                 [dateRange]="dateRange"></app-emissions-stacked-line-chart>
         </ng-container>
-        <ng-container *ngIf="dataType == 'cost' || dataType == 'energyUse'">
+        <ng-container *ngIf="dataType != 'emissions'">
             <app-meters-overview-stacked-line-chart [dataType]="dataType" [facilityId]="facility.guid"
                 [calanderizedMeters]="facilityOverviewData.calanderizedMeters"
                 [dateRange]="dateRange"></app-meters-overview-stacked-line-chart>
@@ -20,7 +20,7 @@
             <app-emissions-donut [facilityId]="facility.guid"
                 [facilityOverviewMeters]="facilityOverviewMeters"></app-emissions-donut>
         </ng-container>
-        <ng-container *ngIf="dataType == 'cost' || dataType == 'energyUse'">
+        <ng-container *ngIf="dataType != 'emissions'">
             <app-meter-usage-donut [dataType]="dataType" [facilityId]="facility.guid"
                 [facilityOverviewMeters]="facilityOverviewData.energyMeters"></app-meter-usage-donut>
         </ng-container>
@@ -45,8 +45,8 @@
             <app-emissions-usage-chart [facilityId]="facility.guid"
                 [annualSourceData]="annualSourceData"></app-emissions-usage-chart>
         </ng-container>
-        <ng-container *ngIf="dataType == 'cost' || dataType == 'energyUse'">
-            <app-utilities-usage-chart [dataType]="'energyUse'" [facilityId]="facility.guid"
+        <ng-container *ngIf="dataType != 'emissions'">
+            <app-utilities-usage-chart [dataType]="dataType" [facilityId]="facility.guid"
                 [annualSourceData]="facilityOverviewData.annualSourceData"></app-utilities-usage-chart>
         </ng-container>
     </div>

--- a/src/app/account/account-reports/data-overview-report/data-overview-report.component.ts
+++ b/src/app/account/account-reports/data-overview-report/data-overview-report.component.ts
@@ -96,7 +96,6 @@ export class DataOverviewReportComponent {
   calculateFacilitiesSummary(facilityIndex: number, accountFacilities: Array<IdbFacility>, accountMeterGroups: Array<IdbUtilityMeterGroup>, startDate: Date, endDate: Date) {
     let facilityId: string = this.includedFacilities[facilityIndex];
     let facility: IdbFacility = accountFacilities.find(facility => { return facility.guid == facilityId });
-    console.log(facility.name);
     let accountMeters: Array<IdbUtilityMeter> = this.utilityMeterDbService.accountMeters.getValue();
     let facilityMeters: Array<IdbUtilityMeter> = accountMeters.filter(meter => { return meter.facilityId == facilityId });
     let meterData: Array<IdbUtilityMeterData> = this.utilityMeterDataDbService.accountMeterData.getValue();

--- a/src/app/calculations/dashboard-calculations/accountOverviewClass.ts
+++ b/src/app/calculations/dashboard-calculations/accountOverviewClass.ts
@@ -6,6 +6,7 @@ import { getYearlyUsageNumbers } from "../shared-calculations/calanderizationFun
 import { EnergySources, WaterSources } from "src/app/models/constantsAndTypes";
 import { EmissionsResults } from "src/app/models/eGridEmissions";
 import { getEmissionsTotalsFromMonthlyData } from "../shared-calculations/calculationsHelpers";
+import { SourceTotals } from "./sourceTotalsClass";
 
 export class AccountOverviewData {
 
@@ -26,6 +27,9 @@ export class AccountOverviewData {
     totalWaterCost: number;
     calanderizedMeters: Array<CalanderizedMeter>;
     numberOfMeters: number;
+
+
+    sourceTotals: SourceTotals;
     constructor(calanderizedMeters: Array<CalanderizedMeter>, facilities: Array<IdbFacility>, account: IdbAccount, dateRange: { startDate: Date, endDate: Date }) {
         this.calanderizedMeters = calanderizedMeters;
         this.numberOfMeters = this.calanderizedMeters?.length;
@@ -47,6 +51,8 @@ export class AccountOverviewData {
             this.setTotalWaterCost();
             this.setWaterYearMonthData(calanderizedMeters);
         }
+
+        this.sourceTotals = new SourceTotals(calanderizedMeters);
     }
 
     setEnergyYearMonthData(calanderizedMeters: Array<CalanderizedMeter>) {

--- a/src/app/calculations/dashboard-calculations/accountOverviewClass.ts
+++ b/src/app/calculations/dashboard-calculations/accountOverviewClass.ts
@@ -52,7 +52,7 @@ export class AccountOverviewData {
             this.setWaterYearMonthData(calanderizedMeters);
         }
 
-        this.sourceTotals = new SourceTotals(calanderizedMeters);
+        this.sourceTotals = new SourceTotals(calanderizedMeters, dateRange);
     }
 
     setEnergyYearMonthData(calanderizedMeters: Array<CalanderizedMeter>) {
@@ -176,9 +176,11 @@ export class AccountOverviewFacility {
     totalCost: number;
     emissions: EmissionsResults;
     facility: IdbFacility;
+    numberOfMeters: number;
     constructor(calanderizedMeters: Array<CalanderizedMeter>, facility: IdbFacility, dateRange: { startDate: Date, endDate: Date }, dataType: 'energy' | 'cost' | 'water') {
         this.facility = facility;
         let facilityMeters: Array<CalanderizedMeter> = calanderizedMeters.filter(cMeter => { return cMeter.meter.facilityId == facility.guid });
+        this.numberOfMeters = facilityMeters.length;
         this.setMonthlyData(facilityMeters, new Date(dateRange.startDate), new Date(dateRange.endDate));
         this.setTotalUsage(dataType);
         this.setTotalCost();

--- a/src/app/calculations/dashboard-calculations/sourceTotalsClass.ts
+++ b/src/app/calculations/dashboard-calculations/sourceTotalsClass.ts
@@ -1,0 +1,48 @@
+import { CalanderizedMeter, MonthlyData } from "src/app/models/calanderization";
+import { MeterSource } from "src/app/models/constantsAndTypes";
+import * as _ from 'lodash';
+
+export class SourceTotals {
+
+    electricity: SourceTotal;
+    naturalGas: SourceTotal;
+    otherFuels: SourceTotal;
+    otherEnergy: SourceTotal;
+    waterIntake: SourceTotal;
+    waterDischarge: SourceTotal;
+    other: SourceTotal;
+    constructor(calanderizedMeters: Array<CalanderizedMeter>) {
+        this.electricity = this.setTotal(calanderizedMeters, 'Electricity');
+        this.naturalGas = this.setTotal(calanderizedMeters, 'Natural Gas');
+        this.otherFuels = this.setTotal(calanderizedMeters, 'Other Fuels');
+        this.otherEnergy = this.setTotal(calanderizedMeters, 'Other Energy');
+        this.waterIntake = this.setTotal(calanderizedMeters, 'Water Intake');
+        this.waterDischarge = this.setTotal(calanderizedMeters, 'Water Discharge');
+        this.other = this.setTotal(calanderizedMeters, 'Other');
+    }
+
+    setTotal(calanderizedMeters: Array<CalanderizedMeter>, source: MeterSource): SourceTotal {
+        let sourceMeters: Array<CalanderizedMeter> = calanderizedMeters.filter(cMeter => {
+            return cMeter.meter.source == source;
+        });
+        let monthlyData: Array<MonthlyData> = sourceMeters.flatMap(sMeter => {
+            return sMeter.monthlyData;
+        });
+        return {
+            sourceLabel: source,
+            energyUse: _.sumBy(monthlyData, (mData: MonthlyData) => {
+                return mData.energyUse
+            }),
+            cost: _.sumBy(monthlyData, (mData: MonthlyData) => {
+                return mData.energyCost
+            })
+        }
+    }
+}
+
+
+export interface SourceTotal {
+    sourceLabel: string,
+    energyUse: number,
+    cost: number
+}

--- a/src/app/calculations/dashboard-calculations/sourceTotalsClass.ts
+++ b/src/app/calculations/dashboard-calculations/sourceTotalsClass.ts
@@ -25,6 +25,7 @@ export class SourceTotals {
         let sourceMeters: Array<CalanderizedMeter> = calanderizedMeters.filter(cMeter => {
             return cMeter.meter.source == source;
         });
+        let numberOfMeters: number = sourceMeters.length;
         let monthlyData: Array<MonthlyData> = sourceMeters.flatMap(sMeter => {
             return sMeter.monthlyData;
         });
@@ -41,7 +42,8 @@ export class SourceTotals {
             }),
             cost: _.sumBy(filteredMonthlyData, (mData: MonthlyData) => {
                 return mData.energyCost
-            })
+            }),
+            numberOfMeters: numberOfMeters
         }
     }
 }
@@ -50,5 +52,6 @@ export class SourceTotals {
 export interface SourceTotal {
     sourceLabel: string,
     energyUse: number,
-    cost: number
+    cost: number,
+    numberOfMeters: number
 }

--- a/src/app/calculations/dashboard-calculations/sourceTotalsClass.ts
+++ b/src/app/calculations/dashboard-calculations/sourceTotalsClass.ts
@@ -11,29 +11,35 @@ export class SourceTotals {
     waterIntake: SourceTotal;
     waterDischarge: SourceTotal;
     other: SourceTotal;
-    constructor(calanderizedMeters: Array<CalanderizedMeter>) {
-        this.electricity = this.setTotal(calanderizedMeters, 'Electricity');
-        this.naturalGas = this.setTotal(calanderizedMeters, 'Natural Gas');
-        this.otherFuels = this.setTotal(calanderizedMeters, 'Other Fuels');
-        this.otherEnergy = this.setTotal(calanderizedMeters, 'Other Energy');
-        this.waterIntake = this.setTotal(calanderizedMeters, 'Water Intake');
-        this.waterDischarge = this.setTotal(calanderizedMeters, 'Water Discharge');
-        this.other = this.setTotal(calanderizedMeters, 'Other');
+    constructor(calanderizedMeters: Array<CalanderizedMeter>, dateRange: { startDate: Date, endDate: Date }) {
+        this.electricity = this.setTotal(calanderizedMeters, 'Electricity', dateRange);
+        this.naturalGas = this.setTotal(calanderizedMeters, 'Natural Gas', dateRange);
+        this.otherFuels = this.setTotal(calanderizedMeters, 'Other Fuels', dateRange);
+        this.otherEnergy = this.setTotal(calanderizedMeters, 'Other Energy', dateRange);
+        this.waterIntake = this.setTotal(calanderizedMeters, 'Water Intake', dateRange);
+        this.waterDischarge = this.setTotal(calanderizedMeters, 'Water Discharge', dateRange);
+        this.other = this.setTotal(calanderizedMeters, 'Other', dateRange);
     }
 
-    setTotal(calanderizedMeters: Array<CalanderizedMeter>, source: MeterSource): SourceTotal {
+    setTotal(calanderizedMeters: Array<CalanderizedMeter>, source: MeterSource, dateRange: { startDate: Date, endDate: Date }): SourceTotal {
         let sourceMeters: Array<CalanderizedMeter> = calanderizedMeters.filter(cMeter => {
             return cMeter.meter.source == source;
         });
         let monthlyData: Array<MonthlyData> = sourceMeters.flatMap(sMeter => {
             return sMeter.monthlyData;
         });
+        let filteredMonthlyData: Array<MonthlyData> = monthlyData.filter(monthlyData => {
+            let itemDate: Date = new Date(monthlyData.date);
+            if (itemDate >= dateRange.startDate && itemDate <= dateRange.endDate) {
+                return monthlyData;
+            }
+        });
         return {
             sourceLabel: source,
-            energyUse: _.sumBy(monthlyData, (mData: MonthlyData) => {
+            energyUse: _.sumBy(filteredMonthlyData, (mData: MonthlyData) => {
                 return mData.energyUse
             }),
-            cost: _.sumBy(monthlyData, (mData: MonthlyData) => {
+            cost: _.sumBy(filteredMonthlyData, (mData: MonthlyData) => {
                 return mData.energyCost
             })
         }

--- a/src/app/shared/data-overview/account-utility-usage-donut/account-utility-usage-donut.component.html
+++ b/src/app/shared/data-overview/account-utility-usage-donut/account-utility-usage-donut.component.html
@@ -1,0 +1,1 @@
+<div #donutChart id="donutChart"></div>

--- a/src/app/shared/data-overview/account-utility-usage-donut/account-utility-usage-donut.component.spec.ts
+++ b/src/app/shared/data-overview/account-utility-usage-donut/account-utility-usage-donut.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AccountUtilityUsageDonutComponent } from './account-utility-usage-donut.component';
+
+describe('AccountUtilityUsageDonutComponent', () => {
+  let component: AccountUtilityUsageDonutComponent;
+  let fixture: ComponentFixture<AccountUtilityUsageDonutComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [AccountUtilityUsageDonutComponent]
+    });
+    fixture = TestBed.createComponent(AccountUtilityUsageDonutComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/data-overview/account-utility-usage-donut/account-utility-usage-donut.component.ts
+++ b/src/app/shared/data-overview/account-utility-usage-donut/account-utility-usage-donut.component.ts
@@ -1,0 +1,96 @@
+import { Component, ElementRef, Input, SimpleChanges, ViewChild } from '@angular/core';
+import { PlotlyService } from 'angular-plotly.js';
+import { AccountOverviewData } from 'src/app/calculations/dashboard-calculations/accountOverviewClass';
+import { SourceTotal, SourceTotals } from 'src/app/calculations/dashboard-calculations/sourceTotalsClass';
+import { UtilityColors } from '../../utilityColors';
+
+@Component({
+  selector: 'app-account-utility-usage-donut',
+  templateUrl: './account-utility-usage-donut.component.html',
+  styleUrls: ['./account-utility-usage-donut.component.css']
+})
+export class AccountUtilityUsageDonutComponent {
+  @Input()
+  accountOverviewData: AccountOverviewData;
+  @Input()
+  energyUnit: string;
+
+
+  @ViewChild('donutChart', { static: false }) donutChart: ElementRef;
+  constructor(private plotlyService: PlotlyService) {
+
+  }
+
+  ngAfterViewInit() {
+    this.drawChart();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (!changes.dataType && (changes.accountOverviewData && !changes.accountOverviewData.isFirstChange())) {
+      this.drawChart();
+    }
+  }
+
+  drawChart() {
+    if (this.donutChart && this.accountOverviewData) {
+      let sourceTotals: Array<SourceTotal> = this.getSourceTotals(this.accountOverviewData.sourceTotals);
+      if (this.accountOverviewData.sourceTotals)
+        var data = [{
+          values: sourceTotals.map(sTotal => { return sTotal.energyUse }),
+          labels: sourceTotals.map(sTotal => { return sTotal.sourceLabel }),
+          marker: {
+            colors: sourceTotals.map(sTotal => { return UtilityColors[sTotal.sourceLabel]?.color }),
+            line: {
+              color: '#fff',
+              width: 5
+            }
+          },
+          texttemplate: '%{label}: (%{percent:.1%})',
+          textposition: 'auto',
+          insidetextorientation: "horizontal",
+          hovertemplate: '%{label}: %{value:,.0f} ' + this.energyUnit + ' <extra></extra>',
+          hole: .5,
+          type: 'pie',
+          automargin: true,
+          sort: false
+        }];
+
+      var layout = {
+        margin: { "t": 50, "b": 50, "l": 50, "r": 50 },
+        showlegend: false
+      };
+
+      let config = {
+        displaylogo: false,
+        responsive: true
+      }
+      this.plotlyService.newPlot(this.donutChart.nativeElement, data, layout, config);
+    }
+  }
+
+  getSourceTotals(sourceTotals: SourceTotals): Array<SourceTotal> {
+    let sourceTotalsArr: Array<SourceTotal> = new Array();
+    if (sourceTotals.electricity.energyUse) {
+      sourceTotalsArr.push(sourceTotals.electricity);
+    }
+    if (sourceTotals.naturalGas.energyUse) {
+      sourceTotalsArr.push(sourceTotals.naturalGas);
+    }
+    if (sourceTotals.otherFuels.energyUse) {
+      sourceTotalsArr.push(sourceTotals.otherFuels);
+    }
+    if (sourceTotals.otherEnergy.energyUse) {
+      sourceTotalsArr.push(sourceTotals.otherEnergy);
+    }
+    if (sourceTotals.waterIntake.energyUse) {
+      sourceTotalsArr.push(sourceTotals.waterIntake);
+    }
+    if (sourceTotals.waterDischarge.energyUse) {
+      sourceTotalsArr.push(sourceTotals.waterDischarge);
+    }
+    if (sourceTotals.other.energyUse) {
+      sourceTotalsArr.push(sourceTotals.other);
+    }
+    return sourceTotalsArr;
+  }
+}

--- a/src/app/shared/data-overview/account-utility-usage-donut/account-utility-usage-donut.component.ts
+++ b/src/app/shared/data-overview/account-utility-usage-donut/account-utility-usage-donut.component.ts
@@ -14,6 +14,8 @@ export class AccountUtilityUsageDonutComponent {
   accountOverviewData: AccountOverviewData;
   @Input()
   energyUnit: string;
+  @Input()
+  dataType: 'energyUse' | 'cost';
 
 
   @ViewChild('donutChart', { static: false }) donutChart: ElementRef;
@@ -36,7 +38,7 @@ export class AccountUtilityUsageDonutComponent {
       let sourceTotals: Array<SourceTotal> = this.getSourceTotals(this.accountOverviewData.sourceTotals);
       if (this.accountOverviewData.sourceTotals)
         var data = [{
-          values: sourceTotals.map(sTotal => { return sTotal.energyUse }),
+          values: sourceTotals.map(sTotal => { return this.getSourceValue(sTotal) }),
           labels: sourceTotals.map(sTotal => { return sTotal.sourceLabel }),
           marker: {
             colors: sourceTotals.map(sTotal => { return UtilityColors[sTotal.sourceLabel]?.color }),
@@ -68,7 +70,15 @@ export class AccountUtilityUsageDonutComponent {
     }
   }
 
-  getSourceTotals(sourceTotals: SourceTotals): Array<SourceTotal> {
+  getSourceTotals(sourceTotals: SourceTotals): Array<SourceTotal>{
+    if(this.dataType == 'energyUse'){
+      return this.getSourceTotalsEnergy(sourceTotals);
+    }else if(this.dataType == 'cost'){
+      return this.getSourceTotalsCost(sourceTotals);
+    }
+  }
+
+  getSourceTotalsEnergy(sourceTotals: SourceTotals): Array<SourceTotal> {
     let sourceTotalsArr: Array<SourceTotal> = new Array();
     if (sourceTotals.electricity.energyUse) {
       sourceTotalsArr.push(sourceTotals.electricity);
@@ -92,5 +102,39 @@ export class AccountUtilityUsageDonutComponent {
       sourceTotalsArr.push(sourceTotals.other);
     }
     return sourceTotalsArr;
+  }
+
+  getSourceTotalsCost(sourceTotals: SourceTotals): Array<SourceTotal> {
+    let sourceTotalsArr: Array<SourceTotal> = new Array();
+    if (sourceTotals.electricity.cost) {
+      sourceTotalsArr.push(sourceTotals.electricity);
+    }
+    if (sourceTotals.naturalGas.cost) {
+      sourceTotalsArr.push(sourceTotals.naturalGas);
+    }
+    if (sourceTotals.otherFuels.cost) {
+      sourceTotalsArr.push(sourceTotals.otherFuels);
+    }
+    if (sourceTotals.otherEnergy.cost) {
+      sourceTotalsArr.push(sourceTotals.otherEnergy);
+    }
+    if (sourceTotals.waterIntake.cost) {
+      sourceTotalsArr.push(sourceTotals.waterIntake);
+    }
+    if (sourceTotals.waterDischarge.cost) {
+      sourceTotalsArr.push(sourceTotals.waterDischarge);
+    }
+    if (sourceTotals.other.cost) {
+      sourceTotalsArr.push(sourceTotals.other);
+    }
+    return sourceTotalsArr;
+  }
+
+  getSourceValue(sourceTotal: SourceTotal): number{
+    if(this.dataType == 'energyUse'){
+      return sourceTotal.energyUse;
+    }else if(this.dataType == 'cost'){
+      return sourceTotal.cost;
+    }
   }
 }

--- a/src/app/shared/data-overview/account-utility-usage-table/account-utility-usage-table.component.css
+++ b/src/app/shared/data-overview/account-utility-usage-table/account-utility-usage-table.component.css
@@ -1,0 +1,4 @@
+
+thead tr th{
+    width: 33%;
+}

--- a/src/app/shared/data-overview/account-utility-usage-table/account-utility-usage-table.component.html
+++ b/src/app/shared/data-overview/account-utility-usage-table/account-utility-usage-table.component.html
@@ -1,0 +1,1 @@
+<p>account-utility-usage-table works!</p>

--- a/src/app/shared/data-overview/account-utility-usage-table/account-utility-usage-table.component.html
+++ b/src/app/shared/data-overview/account-utility-usage-table/account-utility-usage-table.component.html
@@ -3,21 +3,25 @@
         <thead>
             <tr>
                 <th>Facility</th>
-                <th>Utility Usage<br> (<span [innerHTML]="energyUnit | settingsLabel"></span>)
+                <th *ngIf="dataType == 'energyUse'">Utility Usage<br> (<span [innerHTML]="energyUnit | settingsLabel"></span>)
                 </th>
+                <th *ngIf="dataType == 'cost'"># of Meters</th>
                 <th>Utility Cost </th>
             </tr>
         </thead>
         <tbody class="table-group-divider">
-            <tr *ngFor="let sourceTotal of sourceTotalsArr | orderBy: 'energyUse'">
+            <tr *ngFor="let sourceTotal of sourceTotalsArr">
                 <td>
                     <span class="badge" [ngStyle]="{background: sourceTotal.color, color: sourceTotal.color }">
                         &mdash;
                     </span>
                     {{sourceTotal.sourceLabel}}
                 </td>
-                <td>
+                <td *ngIf="dataType == 'energyUse'">
                     {{sourceTotal.energyUse | customNumber}}
+                </td>
+                <td *ngIf="dataType == 'cost'">
+                    {{sourceTotal.numberOfMeters}}
                 </td>
                 <td>
                     {{sourceTotal.cost | customNumber:true }}
@@ -29,8 +33,11 @@
                 <th>
                     Total
                 </th>
-                <th>
+                <th *ngIf="dataType == 'energyUse'">
                     {{accountOverviewData.totalEnergyUsage | customNumber}}
+                </th>
+                <th *ngIf="dataType == 'cost'">
+                    {{accountOverviewData.numberOfMeters}}
                 </th>
                 <th>
                     {{accountOverviewData.totalEnergyCost | customNumber:true }}

--- a/src/app/shared/data-overview/account-utility-usage-table/account-utility-usage-table.component.html
+++ b/src/app/shared/data-overview/account-utility-usage-table/account-utility-usage-table.component.html
@@ -1,1 +1,41 @@
-<p>account-utility-usage-table works!</p>
+<div class="table-responsive">
+    <table class="table utility-data table-sm table-bordered table-hover">
+        <thead>
+            <tr>
+                <th>Facility</th>
+                <th>Utility Usage<br> (<span [innerHTML]="energyUnit | settingsLabel"></span>)
+                </th>
+                <th>Utility Cost </th>
+            </tr>
+        </thead>
+        <tbody class="table-group-divider">
+            <tr *ngFor="let sourceTotal of sourceTotalsArr | orderBy: 'energyUse'">
+                <td>
+                    <span class="badge" [ngStyle]="{background: sourceTotal.color, color: sourceTotal.color }">
+                        &mdash;
+                    </span>
+                    {{sourceTotal.sourceLabel}}
+                </td>
+                <td>
+                    {{sourceTotal.energyUse | customNumber}}
+                </td>
+                <td>
+                    {{sourceTotal.cost | customNumber:true }}
+                </td>
+            </tr>
+        </tbody>
+        <tfoot>
+            <tr>
+                <th>
+                    Total
+                </th>
+                <th>
+                    {{accountOverviewData.totalEnergyUsage | customNumber}}
+                </th>
+                <th>
+                    {{accountOverviewData.totalEnergyCost | customNumber:true }}
+                </th>
+            </tr>
+        </tfoot>
+    </table>
+</div>

--- a/src/app/shared/data-overview/account-utility-usage-table/account-utility-usage-table.component.spec.ts
+++ b/src/app/shared/data-overview/account-utility-usage-table/account-utility-usage-table.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AccountUtilityUsageTableComponent } from './account-utility-usage-table.component';
+
+describe('AccountUtilityUsageTableComponent', () => {
+  let component: AccountUtilityUsageTableComponent;
+  let fixture: ComponentFixture<AccountUtilityUsageTableComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [AccountUtilityUsageTableComponent]
+    });
+    fixture = TestBed.createComponent(AccountUtilityUsageTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/data-overview/account-utility-usage-table/account-utility-usage-table.component.ts
+++ b/src/app/shared/data-overview/account-utility-usage-table/account-utility-usage-table.component.ts
@@ -1,4 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, Input, SimpleChange, SimpleChanges } from '@angular/core';
+import { AccountOverviewData } from 'src/app/calculations/dashboard-calculations/accountOverviewClass';
+import { SourceTotal } from 'src/app/calculations/dashboard-calculations/sourceTotalsClass';
+import { UtilityColors } from '../../utilityColors';
 
 @Component({
   selector: 'app-account-utility-usage-table',
@@ -6,5 +9,57 @@ import { Component } from '@angular/core';
   styleUrls: ['./account-utility-usage-table.component.css']
 })
 export class AccountUtilityUsageTableComponent {
+  @Input()
+  accountOverviewData: AccountOverviewData;
+  @Input()
+  energyUnit: string;
 
+  sourceTotalsArr: Array<SourceTotalTableItem>;
+  constructor() {
+  }
+
+  ngOnInit() {
+    this.setTotalsArr();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (!changes.dataType && (changes.accountOverviewData && !changes.accountOverviewData.isFirstChange())) {
+      this.setTotalsArr();
+    }
+  }
+
+  setTotalsArr() {
+    this.sourceTotalsArr = new Array();
+    if (this.accountOverviewData.sourceTotals.electricity.energyUse) {
+      this.sourceTotalsArr.push(this.getArrItem(this.accountOverviewData.sourceTotals.electricity));
+    }
+    if (this.accountOverviewData.sourceTotals.naturalGas.energyUse) {
+      this.sourceTotalsArr.push(this.getArrItem(this.accountOverviewData.sourceTotals.naturalGas));
+    }
+    if (this.accountOverviewData.sourceTotals.otherFuels.energyUse) {
+      this.sourceTotalsArr.push(this.getArrItem(this.accountOverviewData.sourceTotals.otherFuels));
+    }
+    if (this.accountOverviewData.sourceTotals.otherEnergy.energyUse) {
+      this.sourceTotalsArr.push(this.getArrItem(this.accountOverviewData.sourceTotals.otherEnergy));
+    }
+    if (this.accountOverviewData.sourceTotals.waterIntake.energyUse) {
+      this.sourceTotalsArr.push(this.getArrItem(this.accountOverviewData.sourceTotals.waterIntake));
+    }
+    if (this.accountOverviewData.sourceTotals.waterDischarge.energyUse) {
+      this.sourceTotalsArr.push(this.getArrItem(this.accountOverviewData.sourceTotals.waterDischarge));
+    }
+    if (this.accountOverviewData.sourceTotals.other.energyUse) {
+      this.sourceTotalsArr.push(this.getArrItem(this.accountOverviewData.sourceTotals.other));
+    }
+  }
+
+  getArrItem(sourceTotal: SourceTotal): SourceTotalTableItem {
+    return { ...sourceTotal, color: UtilityColors[sourceTotal.sourceLabel]?.color }
+  }
 }
+
+
+export interface SourceTotalTableItem extends SourceTotal {
+  color: string
+}
+

--- a/src/app/shared/data-overview/account-utility-usage-table/account-utility-usage-table.component.ts
+++ b/src/app/shared/data-overview/account-utility-usage-table/account-utility-usage-table.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-account-utility-usage-table',
+  templateUrl: './account-utility-usage-table.component.html',
+  styleUrls: ['./account-utility-usage-table.component.css']
+})
+export class AccountUtilityUsageTableComponent {
+
+}

--- a/src/app/shared/data-overview/account-utility-usage-table/account-utility-usage-table.component.ts
+++ b/src/app/shared/data-overview/account-utility-usage-table/account-utility-usage-table.component.ts
@@ -13,6 +13,8 @@ export class AccountUtilityUsageTableComponent {
   accountOverviewData: AccountOverviewData;
   @Input()
   energyUnit: string;
+  @Input()
+  dataType: 'energyUse' | 'cost';
 
   sourceTotalsArr: Array<SourceTotalTableItem>;
   constructor() {
@@ -30,34 +32,23 @@ export class AccountUtilityUsageTableComponent {
 
   setTotalsArr() {
     this.sourceTotalsArr = new Array();
-    if (this.accountOverviewData.sourceTotals.electricity.energyUse) {
-      this.sourceTotalsArr.push(this.getArrItem(this.accountOverviewData.sourceTotals.electricity));
-    }
-    if (this.accountOverviewData.sourceTotals.naturalGas.energyUse) {
-      this.sourceTotalsArr.push(this.getArrItem(this.accountOverviewData.sourceTotals.naturalGas));
-    }
-    if (this.accountOverviewData.sourceTotals.otherFuels.energyUse) {
-      this.sourceTotalsArr.push(this.getArrItem(this.accountOverviewData.sourceTotals.otherFuels));
-    }
-    if (this.accountOverviewData.sourceTotals.otherEnergy.energyUse) {
-      this.sourceTotalsArr.push(this.getArrItem(this.accountOverviewData.sourceTotals.otherEnergy));
-    }
-    if (this.accountOverviewData.sourceTotals.waterIntake.energyUse) {
-      this.sourceTotalsArr.push(this.getArrItem(this.accountOverviewData.sourceTotals.waterIntake));
-    }
-    if (this.accountOverviewData.sourceTotals.waterDischarge.energyUse) {
-      this.sourceTotalsArr.push(this.getArrItem(this.accountOverviewData.sourceTotals.waterDischarge));
-    }
-    if (this.accountOverviewData.sourceTotals.other.energyUse) {
-      this.sourceTotalsArr.push(this.getArrItem(this.accountOverviewData.sourceTotals.other));
-    }
+    this.addArrItem(this.accountOverviewData.sourceTotals.electricity);
+    this.addArrItem(this.accountOverviewData.sourceTotals.naturalGas);
+    this.addArrItem(this.accountOverviewData.sourceTotals.otherFuels);
+    this.addArrItem(this.accountOverviewData.sourceTotals.otherEnergy);
+    this.addArrItem(this.accountOverviewData.sourceTotals.waterIntake);
+    this.addArrItem(this.accountOverviewData.sourceTotals.waterDischarge);
+    this.addArrItem(this.accountOverviewData.sourceTotals.other);
   }
 
-  getArrItem(sourceTotal: SourceTotal): SourceTotalTableItem {
-    return { ...sourceTotal, color: UtilityColors[sourceTotal.sourceLabel]?.color }
+  addArrItem(sourceTotal: SourceTotal) {
+    if (this.dataType == 'energyUse' && sourceTotal.energyUse) {
+      this.sourceTotalsArr.push({ ...sourceTotal, color: UtilityColors[sourceTotal.sourceLabel]?.color })
+    } else if (this.dataType == 'cost' && sourceTotal.cost) {
+      this.sourceTotalsArr.push({ ...sourceTotal, color: UtilityColors[sourceTotal.sourceLabel]?.color })
+    }
   }
 }
-
 
 export interface SourceTotalTableItem extends SourceTotal {
   color: string

--- a/src/app/shared/data-overview/data-overview.module.ts
+++ b/src/app/shared/data-overview/data-overview.module.ts
@@ -21,6 +21,8 @@ import { EmissionsDonutComponent } from './emissions-donut/emissions-donut.compo
 import { EmissionsUsageTableComponent } from './emissions-usage-table/emissions-usage-table.component';
 import { EmissionsUsageChartComponent } from './emissions-usage-chart/emissions-usage-chart.component';
 import { FacilitiesEmissionsStackedBarChartComponent } from './facilities-emissions-stacked-bar-chart/facilities-emissions-stacked-bar-chart.component';
+import { AccountUtilityUsageTableComponent } from './account-utility-usage-table/account-utility-usage-table.component';
+import { AccountUtilityUsageDonutComponent } from './account-utility-usage-donut/account-utility-usage-donut.component';
 
 
 
@@ -44,7 +46,9 @@ import { FacilitiesEmissionsStackedBarChartComponent } from './facilities-emissi
     EmissionsDonutComponent,
     EmissionsUsageTableComponent,
     EmissionsUsageChartComponent,
-    FacilitiesEmissionsStackedBarChartComponent
+    FacilitiesEmissionsStackedBarChartComponent,
+    AccountUtilityUsageTableComponent,
+    AccountUtilityUsageDonutComponent
   ],
   imports: [
     CommonModule,
@@ -65,7 +69,9 @@ import { FacilitiesEmissionsStackedBarChartComponent } from './facilities-emissi
     EmissionsDonutComponent,
     EmissionsUsageTableComponent,
     EmissionsUsageChartComponent,
-    FacilitiesEmissionsStackedBarChartComponent
+    FacilitiesEmissionsStackedBarChartComponent,
+    AccountUtilityUsageTableComponent,
+    AccountUtilityUsageDonutComponent
   ]
 })
 export class DataOverviewModule { }


### PR DESCRIPTION
connects #1396 
connects #1048 

Added math to overview data to get totals by utility source type.
Added donut and table to account overview dashboard and report that display data by utility source type
Fixes to overview report for non emissions pages broken in changes for issue-1048.
