### PR TITLE
Update NodeJS version for Electron Builds

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Node setup
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.2
+          node-version: 20.10.0
       - name: Cache setup
         uses: actions/cache@v3
         with:
@@ -97,7 +97,7 @@ jobs:
       - name: Node setup
         uses: actions/setup-node@v3
         with:
-          node-version: 16.14.2
+          node-version: 20.10.0
       - name: Cache setup
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Statically set NodeJS version for pipeline to use when building desktop binaries. This will be replaced at a later time with dynamic Node version setup due to lack of Perl Grep on MacOS.