### PR TITLE
Grouping Enhancements

### DIFF
--- a/src/app/facility/utility-data/meter-grouping/edit-meter-group-form/edit-meter-group-form.component.html
+++ b/src/app/facility/utility-data/meter-grouping/edit-meter-group-form/edit-meter-group-form.component.html
@@ -10,7 +10,7 @@
 
     <ng-container *ngIf="meterGroupTypes.length > 1">
         <label for="groupType">Group Type <span class="required">*</span></label>
-        <select id="groupType" class="form-control mb-3" formControlName="groupType">
+        <select id="groupType" class="form-select mb-3" formControlName="groupType">
             <option [value]="'Energy'">Energy</option>
             <option [value]="'Water'">Water</option>
             <option [value]="'Other'">Other</option>
@@ -20,7 +20,7 @@
 
     <label for="name">Description</label>
     <div class="input-group mb-3">
-        <textarea formControlName="description" minlength="1" maxlength="65"></textarea>
+        <textarea class="form-control" formControlName="description" minlength="1" maxlength="65"></textarea>
     </div>
 </form>
 <div class="saveCancel item-right">

--- a/src/app/facility/utility-data/meter-grouping/edit-meter-in-group-form/edit-meter-in-group-form.component.html
+++ b/src/app/facility/utility-data/meter-grouping/edit-meter-in-group-form/edit-meter-in-group-form.component.html
@@ -1,0 +1,18 @@
+<h4>Select Group For {{meterToEdit.name}}</h4>
+<br>
+<form>
+    <label for="groupId">Group <span class="required">*</span></label>
+    <select id="groupId" name="groupId" class="form-select" [(ngModel)]="meterToEdit.groupId">
+        <ng-container *ngFor="let meterGroupType of meterGroupTypes">
+            <optgroup [label]="meterGroupType.groupType">
+                <option *ngFor="let meterGroup of meterGroupType.meterGroups" [ngValue]="meterGroup.guid">
+                    {{meterGroup.name}}</option>
+            </optgroup>
+        </ng-container>
+    </select>
+</form>
+<br>
+<div class="saveCancel item-right">
+    <button class="btn btn-secondary" (click)="cancel()">Cancel</button>
+    <button class="btn btn-primary" (click)="save()">Save</button>
+</div>

--- a/src/app/facility/utility-data/meter-grouping/edit-meter-in-group-form/edit-meter-in-group-form.component.spec.ts
+++ b/src/app/facility/utility-data/meter-grouping/edit-meter-in-group-form/edit-meter-in-group-form.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EditMeterInGroupFormComponent } from './edit-meter-in-group-form.component';
+
+describe('EditMeterInGroupFormComponent', () => {
+  let component: EditMeterInGroupFormComponent;
+  let fixture: ComponentFixture<EditMeterInGroupFormComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [EditMeterInGroupFormComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(EditMeterInGroupFormComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/facility/utility-data/meter-grouping/edit-meter-in-group-form/edit-meter-in-group-form.component.ts
+++ b/src/app/facility/utility-data/meter-grouping/edit-meter-in-group-form/edit-meter-in-group-form.component.ts
@@ -1,7 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { UtilityMeterGroupdbService } from 'src/app/indexedDB/utilityMeterGroup-db.service';
 import { MeterGroupType } from 'src/app/models/calanderization';
-import { IdbUtilityMeter, IdbUtilityMeterGroup } from 'src/app/models/idb';
+import { IdbUtilityMeter } from 'src/app/models/idb';
 import { getIsEnergyMeter } from 'src/app/shared/sharedHelperFuntions';
 
 @Component({
@@ -19,19 +18,21 @@ export class EditMeterInGroupFormComponent {
   @Output('emitSave')
   emitSave: EventEmitter<boolean> = new EventEmitter<boolean>();
 
-  meterGroupTypes: Array<MeterGroupType>
+  meterGroupTypes: Array<MeterGroupType>;
+  originalGroupId: string;
   constructor() {
 
   }
 
   ngOnInit() {
+    this.originalGroupId = this.meterToEdit.groupId;
     this.meterGroupTypes = new Array();
     this.allMeterGroupTypes.forEach(meterGroupType => {
-      if(meterGroupType.groupType == 'Other'){
+      if (meterGroupType.groupType == 'Other') {
         this.meterGroupTypes.push(meterGroupType);
-      }else if(meterGroupType.groupType == 'Energy' && getIsEnergyMeter(this.meterToEdit.source)){
+      } else if (meterGroupType.groupType == 'Energy' && getIsEnergyMeter(this.meterToEdit.source)) {
         this.meterGroupTypes.push(meterGroupType);
-      }else if(meterGroupType.groupType == 'Water' && (this.meterToEdit.source == 'Water Intake' || this.meterToEdit.source == 'Water Discharge')){
+      } else if (meterGroupType.groupType == 'Water' && (this.meterToEdit.source == 'Water Intake' || this.meterToEdit.source == 'Water Discharge')) {
         this.meterGroupTypes.push(meterGroupType);
       }
     })
@@ -42,6 +43,7 @@ export class EditMeterInGroupFormComponent {
   }
 
   cancel() {
+    this.meterToEdit.groupId = this.originalGroupId;
     this.emitClose.emit(true);
   }
 }

--- a/src/app/facility/utility-data/meter-grouping/edit-meter-in-group-form/edit-meter-in-group-form.component.ts
+++ b/src/app/facility/utility-data/meter-grouping/edit-meter-in-group-form/edit-meter-in-group-form.component.ts
@@ -1,0 +1,47 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { UtilityMeterGroupdbService } from 'src/app/indexedDB/utilityMeterGroup-db.service';
+import { MeterGroupType } from 'src/app/models/calanderization';
+import { IdbUtilityMeter, IdbUtilityMeterGroup } from 'src/app/models/idb';
+import { getIsEnergyMeter } from 'src/app/shared/sharedHelperFuntions';
+
+@Component({
+  selector: 'app-edit-meter-in-group-form',
+  templateUrl: './edit-meter-in-group-form.component.html',
+  styleUrl: './edit-meter-in-group-form.component.css'
+})
+export class EditMeterInGroupFormComponent {
+  @Input()
+  meterToEdit: IdbUtilityMeter;
+  @Output('emitClose')
+  emitClose: EventEmitter<boolean> = new EventEmitter<boolean>();
+  @Input()
+  allMeterGroupTypes: Array<MeterGroupType>;
+  @Output('emitSave')
+  emitSave: EventEmitter<boolean> = new EventEmitter<boolean>();
+
+  meterGroupTypes: Array<MeterGroupType>
+  constructor() {
+
+  }
+
+  ngOnInit() {
+    this.meterGroupTypes = new Array();
+    this.allMeterGroupTypes.forEach(meterGroupType => {
+      if(meterGroupType.groupType == 'Other'){
+        this.meterGroupTypes.push(meterGroupType);
+      }else if(meterGroupType.groupType == 'Energy' && getIsEnergyMeter(this.meterToEdit.source)){
+        this.meterGroupTypes.push(meterGroupType);
+      }else if(meterGroupType.groupType == 'Water' && (this.meterToEdit.source == 'Water Intake' || this.meterToEdit.source == 'Water Discharge')){
+        this.meterGroupTypes.push(meterGroupType);
+      }
+    })
+  }
+
+  save() {
+    this.emitSave.emit(true);
+  }
+
+  cancel() {
+    this.emitClose.emit(true);
+  }
+}

--- a/src/app/facility/utility-data/meter-grouping/meter-grouping.component.html
+++ b/src/app/facility/utility-data/meter-grouping/meter-grouping.component.html
@@ -163,7 +163,9 @@
 
                     <div [cdkDragData]="meter" class="group-meters" *ngFor="let meter of meterGroup.groupData" cdkDrag>
                         <!-- id={{meter.id}}> -->
-                        <i class="fa fa-th"></i>
+                        <button class="btn btn-sm text-center btn-outline" (click)="openEditMeterModal(meter)">
+                            <span class="fa fa-pencil"></span>
+                        </button>
                         <span> {{meter.name}}</span>
                         <span class="item-right">{{meter.source}}</span>
                     </div>
@@ -196,7 +198,16 @@
     </div>
 </div>
 
-<div [ngClass]="{'windowOverlay': groupToDelete || groupToEdit}"></div>
+<div class="window" [class.open]="showEditMeterModal">
+    <div class="windowContent">
+        <app-edit-meter-in-group-form *ngIf="showEditMeterModal" [meterToEdit]="meterToEdit"
+            (emitClose)="closeEditMeter()" [allMeterGroupTypes]="meterGroupTypes" (emitSave)="saveMeterEdit()">
+        </app-edit-meter-in-group-form>
+    </div>
+</div>
+
+
+<div [ngClass]="{'windowOverlay': groupToDelete || groupToEdit || showEditMeterModal}"></div>
 <div class="popup" [class.open]="groupToDelete">
     <div class="popup-header" *ngIf="groupToDelete">Delete Meter Data {{groupToDelete.name}}
         <button class="item-right" (click)="closeDeleteGroup()">x</button>

--- a/src/app/facility/utility-data/meter-grouping/meter-grouping.component.ts
+++ b/src/app/facility/utility-data/meter-grouping/meter-grouping.component.ts
@@ -249,7 +249,7 @@ export class MeterGroupingComponent implements OnInit {
   }
 
   openEditMeterModal(meter: IdbUtilityMeter){
-    this.meterToEdit = JSON.parse(JSON.stringify(meter));
+    this.meterToEdit = meter;
     this.showEditMeterModal = true;
     this.sharedDataService.modalOpen.next(true);
   }

--- a/src/app/facility/utility-data/meter-grouping/meter-grouping.component.ts
+++ b/src/app/facility/utility-data/meter-grouping/meter-grouping.component.ts
@@ -53,6 +53,8 @@ export class MeterGroupingComponent implements OnInit {
   selectedFacility: IdbFacility;
   facilityMeterGroups: Array<IdbUtilityMeterGroup>;
   calanderizedMeters: Array<CalanderizedMeter>;
+  showEditMeterModal: boolean = false;
+  meterToEdit: IdbUtilityMeter;
   constructor(private utilityMeterGroupDbService: UtilityMeterGroupdbService,
     private utilityMeterDbService: UtilityMeterdbService, private facilityDbService: FacilitydbService,
     private loadingService: LoadingService, private toastNoticationService: ToastNotificationsService,
@@ -244,5 +246,27 @@ export class MeterGroupingComponent implements OnInit {
       this.selectedFacility.energyIsSource = energyIsSource;
       await this.dbChangesService.updateFacilities(this.selectedFacility);
     }
+  }
+
+  openEditMeterModal(meter: IdbUtilityMeter){
+    this.meterToEdit = JSON.parse(JSON.stringify(meter));
+    this.showEditMeterModal = true;
+    this.sharedDataService.modalOpen.next(true);
+  }
+
+  closeEditMeter(){
+    this.meterToEdit = undefined;
+    this.showEditMeterModal = false;
+    this.sharedDataService.modalOpen.next(false);
+  }
+
+  async saveMeterEdit(){    
+    await firstValueFrom(this.utilityMeterDbService.updateWithObservable(this.meterToEdit));
+    let selectedAccount: IdbAccount = this.accountDbService.selectedAccount.getValue();
+    await this.dbChangesService.setMeters(selectedAccount, this.selectedFacility);
+    await this.dbChangesService.setAnalysisItems(selectedAccount, false, this.selectedFacility);
+    this.setCalanderizedMeters();
+    this.setGroupTypes();
+    this.closeEditMeter();
   }
 }

--- a/src/app/facility/utility-data/meter-grouping/meter-grouping.module.ts
+++ b/src/app/facility/utility-data/meter-grouping/meter-grouping.module.ts
@@ -10,6 +10,7 @@ import { DragDropModule } from '@angular/cdk/drag-drop';
 import { HelperPipesModule } from 'src/app/shared/helper-pipes/helper-pipes.module';
 import { NgbPaginationModule } from '@ng-bootstrap/ng-bootstrap';
 import { TableItemsDropdownModule } from 'src/app/shared/table-items-dropdown/table-items-dropdown.module';
+import { EditMeterInGroupFormComponent } from './edit-meter-in-group-form/edit-meter-in-group-form.component';
 
 
 
@@ -19,7 +20,8 @@ import { TableItemsDropdownModule } from 'src/app/shared/table-items-dropdown/ta
     EnergyUnitDropdownComponent,
     MeterGroupChartComponent,
     MeterGroupTableComponent,
-    MeterGroupingComponent
+    MeterGroupingComponent,
+    EditMeterInGroupFormComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/facility/utility-data/meter-grouping/meter-grouping.service.ts
+++ b/src/app/facility/utility-data/meter-grouping/meter-grouping.service.ts
@@ -7,6 +7,7 @@ import { BehaviorSubject } from 'rxjs';
 import { Month, Months } from 'src/app/shared/form-data/months';
 import { FacilitydbService } from 'src/app/indexedDB/facility-db.service';
 import { getFirstBillEntryFromCalanderizedMeterData, getFiscalYear, getLastBillEntryFromCalanderizedMeterData } from 'src/app/calculations/shared-calculations/calanderizationFunctions';
+import { getIsEnergyMeter } from 'src/app/shared/sharedHelperFuntions';
 @Injectable({
   providedIn: 'root'
 })
@@ -38,7 +39,7 @@ export class MeterGroupingService {
     //set no groups
     let metersWithoutGroups: Array<CalanderizedMeter> = calanderizedMeters.filter(cMeter => { return !meterGroupIds.includes(cMeter.meter.groupId) });
     //Energy (Electricity/Natural Gas)
-    let energyMeters: Array<CalanderizedMeter> = metersWithoutGroups.filter(cMeter => { return cMeter.meter.source == 'Electricity' || cMeter.meter.source == 'Natural Gas' || cMeter.meter.source == 'Other Fuels' || cMeter.meter.source == 'Other Energy' });
+    let energyMeters: Array<CalanderizedMeter> = metersWithoutGroups.filter(cMeter => { return getIsEnergyMeter(cMeter.meter.source)});
     if (energyMeters.length != 0) {
       meterGroupTypes = this.addEnergyMetersWithoutGroups(energyMeters, 'Energy', meterGroupTypes);
     }

--- a/src/app/facility/utility-data/meter-grouping/meter-grouping.service.ts
+++ b/src/app/facility/utility-data/meter-grouping/meter-grouping.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { UtilityMeterGroupdbService } from 'src/app/indexedDB/utilityMeterGroup-db.service';
 import { CalanderizedMeter, MeterGroupType, MonthlyData } from 'src/app/models/calanderization';
-import { IdbFacility, IdbUtilityMeterGroup } from 'src/app/models/idb';
+import { IdbFacility, IdbUtilityMeter, IdbUtilityMeterGroup } from 'src/app/models/idb';
 import * as _ from 'lodash';
 import { BehaviorSubject } from 'rxjs';
 import { Month, Months } from 'src/app/shared/form-data/months';
@@ -39,7 +39,7 @@ export class MeterGroupingService {
     //set no groups
     let metersWithoutGroups: Array<CalanderizedMeter> = calanderizedMeters.filter(cMeter => { return !meterGroupIds.includes(cMeter.meter.groupId) });
     //Energy (Electricity/Natural Gas)
-    let energyMeters: Array<CalanderizedMeter> = metersWithoutGroups.filter(cMeter => { return getIsEnergyMeter(cMeter.meter.source)});
+    let energyMeters: Array<CalanderizedMeter> = metersWithoutGroups.filter(cMeter => { return this.getIsEnergyGroup(cMeter.meter) });
     if (energyMeters.length != 0) {
       meterGroupTypes = this.addEnergyMetersWithoutGroups(energyMeters, 'Energy', meterGroupTypes);
     }
@@ -49,9 +49,17 @@ export class MeterGroupingService {
       meterGroupTypes = this.addEnergyMetersWithoutGroups(waterMeters, 'Water', meterGroupTypes);
     }
     //Other
-    let otherMeters: Array<CalanderizedMeter> = metersWithoutGroups.filter(cMeter => { return cMeter.meter.source == 'Other' });
+    let otherMeters: Array<CalanderizedMeter> = metersWithoutGroups.filter(cMeter => { return this.getIsOtherGroup(cMeter.meter) });
     if (otherMeters.length != 0) {
       meterGroupTypes = this.addEnergyMetersWithoutGroups(otherMeters, 'Other', meterGroupTypes);
+    } else {
+      meterGroupTypes.push({
+        groupType: "Other",
+        meterGroups: [],
+        id: Math.random().toString(36).substr(2, 9),
+        meterGroupIds: [],
+        totalUsage: 0
+      });
     }
     //set fraction usage
     for (let i = 0; i < meterGroupTypes.length; i++) {
@@ -187,5 +195,30 @@ export class MeterGroupingService {
       startDate = new Date(startDate.getFullYear(), startDate.getMonth() + 1);
     }
     return combinedMeterData;
+  }
+
+  getIsEnergyGroup(meter: IdbUtilityMeter): boolean {
+    if (getIsEnergyMeter(meter.source)) {
+      if (meter.source != 'Electricity') {
+        return true;
+      } else if ((meter.agreementType != 4) && (meter.agreementType != 6)) {
+        //Don't include VPPA and RECs
+        return true;
+      }
+    }
+    return false;
+  }
+
+
+  getIsOtherGroup(meter: IdbUtilityMeter): boolean {
+    if (meter.source == 'Other') {
+      return true;
+    } else if (meter.source == 'Electricity') {
+      //VPPA and RECs in other
+      if (meter.agreementType == 4 || meter.agreementType == 6) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/app/facility/utility-data/meter-grouping/meter-grouping.service.ts
+++ b/src/app/facility/utility-data/meter-grouping/meter-grouping.service.ts
@@ -53,13 +53,18 @@ export class MeterGroupingService {
     if (otherMeters.length != 0) {
       meterGroupTypes = this.addEnergyMetersWithoutGroups(otherMeters, 'Other', meterGroupTypes);
     } else {
-      meterGroupTypes.push({
-        groupType: "Other",
-        meterGroups: [],
-        id: Math.random().toString(36).substr(2, 9),
-        meterGroupIds: [],
-        totalUsage: 0
+      let hasOther: MeterGroupType = meterGroupTypes.find(mGroupType => {
+        return mGroupType.groupType == 'Other'
       });
+      if (!hasOther) {
+        meterGroupTypes.push({
+          groupType: "Other",
+          meterGroups: [],
+          id: Math.random().toString(36).substr(2, 9),
+          meterGroupIds: [],
+          totalUsage: 0
+        });
+      }
     }
     //set fraction usage
     for (let i = 0; i < meterGroupTypes.length; i++) {

--- a/src/app/upload-data/data-setup/file-setup/manage-meters/manage-meters.component.html
+++ b/src/app/upload-data/data-setup/file-setup/manage-meters/manage-meters.component.html
@@ -120,8 +120,24 @@
                 </td>
                 <td>
                     <select class="form-select" id="meterGroup" [(ngModel)]="meter.groupId">
-                        <option *ngFor="let group of getFacilityMeterGroups(meter.facilityId)" [ngValue]="group.guid">
-                            {{group.name}}</option>
+                        <optgroup [label]="'Energy'"
+                            *ngIf="meter.source != 'Water Intake' && meter.source != 'Water Discharge'">
+                            <option
+                                *ngFor="let meterGroup of facilityGroups|meterGroupOptions:meter.facilityId:'Energy'"
+                                [ngValue]="meterGroup.guid">
+                                {{meterGroup.name}}</option>
+                        </optgroup>
+                        <optgroup [label]="'Water'"
+                            *ngIf="meter.source == 'Water Intake' || meter.source == 'Water Discharge'">
+                            <option *ngFor="let meterGroup of facilityGroups|meterGroupOptions:meter.facilityId:'Water'"
+                                [ngValue]="meterGroup.guid">
+                                {{meterGroup.name}}</option>
+                        </optgroup>
+                        <optgroup [label]="'Other'">
+                            <option *ngFor="let meterGroup of facilityGroups|meterGroupOptions:meter.facilityId:'Other'"
+                                [ngValue]="meterGroup.guid">
+                                {{meterGroup.name}}</option>
+                        </optgroup>
                     </select>
                 </td>
                 <td>

--- a/src/app/upload-data/data-setup/file-setup/manage-meters/manage-meters.component.ts
+++ b/src/app/upload-data/data-setup/file-setup/manage-meters/manage-meters.component.ts
@@ -138,10 +138,10 @@ export class ManageMetersComponent implements OnInit {
         if (mData.meterId == this.editMeterPrevGUID) {
           mData.guid = this.editMeter.guid;
         }
-        if(!mData.heatCapacity){
+        if (!mData.heatCapacity) {
           mData.heatCapacity = this.editMeter.heatCapacity;
         }
-        if(this.editMeter.scope == 2 && mData.vehicleFuelEfficiency){
+        if (this.editMeter.scope == 2 && mData.vehicleFuelEfficiency) {
           mData.vehicleFuelEfficiency = this.editMeter.vehicleFuelEfficiency;
         }
       });
@@ -285,7 +285,11 @@ export class ManageMetersComponent implements OnInit {
       if (!meter.groupId) {
         let groupOptions: Array<IdbUtilityMeterGroup> = this.getFacilityMeterGroups(meter.facilityId);
         let findGroup: IdbUtilityMeterGroup = groupOptions.find(group => {
-          return group.name == meter.source;
+          if (meter.source == 'Electricity' && (meter.agreementType == 4 || meter.agreementType == 6)) {
+            return group.name == 'Other (non-energy)';
+          } else {
+            return group.name == meter.source;
+          }
         });
         if (findGroup) {
           meter.groupId = findGroup.guid;

--- a/src/app/upload-data/data-setup/file-setup/manage-meters/meter-group-options.pipe.spec.ts
+++ b/src/app/upload-data/data-setup/file-setup/manage-meters/meter-group-options.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { MeterGroupOptionsPipe } from './meter-group-options.pipe';
+
+describe('MeterGroupOptionsPipe', () => {
+  it('create an instance', () => {
+    const pipe = new MeterGroupOptionsPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/src/app/upload-data/data-setup/file-setup/manage-meters/meter-group-options.pipe.ts
+++ b/src/app/upload-data/data-setup/file-setup/manage-meters/meter-group-options.pipe.ts
@@ -1,0 +1,24 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { IdbUtilityMeterGroup } from 'src/app/models/idb';
+
+@Pipe({
+  name: 'meterGroupOptions'
+})
+export class MeterGroupOptionsPipe implements PipeTransform {
+
+  transform(groupOptions: Array<{ facilityId: string, groupOptions: Array<IdbUtilityMeterGroup> }>, facilityId: string, groupType: 'Energy' | 'Other' | 'Water'): Array<IdbUtilityMeterGroup> {
+    let facilityOptions = groupOptions.filter(option => {
+      return option.facilityId == facilityId
+    });
+    let typeOptions: Array<IdbUtilityMeterGroup> = new Array();
+    facilityOptions.forEach(facilityOption => {
+      facilityOption.groupOptions.forEach(option => {
+        if (option.groupType == groupType) {
+          typeOptions.push(option);
+        }
+      })
+    });
+    return typeOptions;
+  }
+
+}

--- a/src/app/upload-data/upload-data-shared-functions.service.ts
+++ b/src/app/upload-data/upload-data-shared-functions.service.ts
@@ -17,12 +17,30 @@ export class UploadDataSharedFunctionsService {
   getMeterGroup(groupName: string, facilityId: string, newGroups: Array<IdbUtilityMeterGroup>, account: IdbAccount, meterSource: MeterSource): { group: IdbUtilityMeterGroup, newGroups: Array<IdbUtilityMeterGroup> } {
     let accountGroups: Array<IdbUtilityMeterGroup> = this.utilityMeterGroupDbService.getAccountMeterGroupsCopy();
     let facilityGroups: Array<IdbUtilityMeterGroup> = accountGroups.filter(accountGroup => { return accountGroup.facilityId == facilityId });
-    let dbGroup: IdbUtilityMeterGroup = facilityGroups.find(group => { return group.name == groupName || group.guid == groupName });
+    let dbGroup: IdbUtilityMeterGroup = facilityGroups.find(group => {
+      if (group.groupType == 'Energy' && (meterSource == 'Electricity' || meterSource == 'Natural Gas' || meterSource == 'Other Energy' || meterSource == 'Other Fuels')) {
+        return group.name == groupName || group.guid == groupName
+      } else if (group.groupType == 'Water' && (meterSource == 'Water Intake' || meterSource == 'Water Discharge')) {
+        return group.name == groupName || group.guid == groupName
+      } else if (group.groupType == 'Other') {
+        return group.name == groupName || group.guid == groupName
+      }
+      return false;
+    });
     if (dbGroup) {
       return { group: dbGroup, newGroups: newGroups }
     } else {
       let newFacilityGroups: Array<IdbUtilityMeterGroup> = newGroups.filter(group => { return group.facilityId == facilityId });
-      dbGroup = newFacilityGroups.find(newGroup => { return newGroup.name == groupName });
+      dbGroup = newFacilityGroups.find(newGroup => {
+        if (newGroup.groupType == 'Energy' && (meterSource == 'Electricity' || meterSource == 'Natural Gas' || meterSource == 'Other Energy' || meterSource == 'Other Fuels')) {
+          return newGroup.name == groupName || newGroup.guid == groupName
+        } else if (newGroup.groupType == 'Water' && (meterSource == 'Water Intake' || meterSource == 'Water Discharge')) {
+          return newGroup.name == groupName || newGroup.guid == groupName
+        } else if (newGroup.groupType == 'Other') {
+          return newGroup.name == groupName || newGroup.guid == groupName
+        }
+        return false;
+      });
       if (dbGroup) {
         return { group: dbGroup, newGroups: newGroups }
       } else if (groupName) {

--- a/src/app/upload-data/upload-data.module.ts
+++ b/src/app/upload-data/upload-data.module.ts
@@ -20,6 +20,7 @@ import { ConfirmPredictorsComponent } from './data-setup/file-setup/confirm-pred
 import { ConfirmAndSubmitComponent } from './data-setup/file-setup/confirm-and-submit/confirm-and-submit.component';
 import { LabelWithTooltipModule } from '../shared/label-with-tooltip/label-with-tooltip.module';
 import { HelperPipesModule } from '../shared/helper-pipes/helper-pipes.module';
+import { MeterGroupOptionsPipe } from './data-setup/file-setup/manage-meters/meter-group-options.pipe';
 
 
 
@@ -38,7 +39,8 @@ import { HelperPipesModule } from '../shared/helper-pipes/helper-pipes.module';
     TemplateFacilitiesComponent,
     ConfirmReadingsComponent,
     ConfirmPredictorsComponent,
-    ConfirmAndSubmitComponent
+    ConfirmAndSubmitComponent,
+    MeterGroupOptionsPipe
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
connects #1436 

Updated grouping to add modal for selecting which group to move the meter too, this allows the meter to be changed from an Energy group to Other. Or Water to other and other to water/energy depending on meter type.

Can still drag/drop within a group type

Updated auto grouping to put VPPA and RECs into "Other (non-energy)"

Updated import to show group options by category (Other/Energy/Water)