### PR TITLE
fix upload meter without source bug

### DIFF
--- a/src/app/upload-data/upload-data.service.ts
+++ b/src/app/upload-data/upload-data.service.ts
@@ -311,7 +311,7 @@ export class UploadDataService {
     //we can still access the data using this value
     newMeter.importWizardName = groupItem.value;
     //start with random meter number
-    newMeter.meterNumber = selectedFacility.name.replace(' ', '_') + '_' + newMeter.source.replace(' ', '_') + '_' + Math.random().toString(36).substr(2, 3);
+    newMeter.meterNumber = selectedFacility.name.replace(' ', '_') + '_' + newMeter.source?.replace(' ', '_') + '_' + Math.random().toString(36).substr(2, 3);
 
     //set emissions mulitpliers
     newMeter = this.editMeterFormService.setMultipliers(newMeter);


### PR DESCRIPTION
connects #1646 

meter number was being set using source. If there was no source then it was causing an error that was preventing from continuing. This patches that and removes the bug