### PR TITLE
Bump upload, download-artifact to v4, additional artifact tweaks

### DIFF
--- a/.github/workflows/electron.yml
+++ b/.github/workflows/electron.yml
@@ -75,15 +75,17 @@ jobs:
           VERSION=$(grep -A3 'version:' ../output/verifi/latest-mac.yml | head -n1 | awk '{print $2}')
           echo "BUILD_VERSION=$VERSION" >> "$GITHUB_OUTPUT"
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: build-mac
+          name: final-mac-output
           path: |
             /Users/runner/work/VERIFI/output/verifi/*
             !/Users/runner/work/VERIFI/output/verifi/.icon-ico
             !/Users/runner/work/VERIFI/output/verifi/builder-debug.yml
             !/Users/runner/work/VERIFI/output/verifi/*-unpacked
-          retention-days: 7
+          compression-level: 1
+          if-no-files-found: error
+          retention-days: 1
     outputs:
       BUILD_VERSION: ${{ steps.output.outputs.BUILD_VERSION }}
 
@@ -117,15 +119,17 @@ jobs:
       - name: Package [Linux]
         run: npm run dist-nopublish
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: build-winux
+          name: final-winux-output
           path: |
             /__w/VERIFI/output/verifi/*
             !/__w/VERIFI/output/verifi/.icon-ico
             !/__w/VERIFI/output/verifi/builder-debug.yml
             !/__w/VERIFI/output/verifi/*-unpacked
-          retention-days: 7
+          compression-level: 1
+          if-no-files-found: error
+          retention-days: 1
 
   release:
     if: github.ref_name == 'master'
@@ -135,7 +139,9 @@ jobs:
       VERSION: ${{ needs.build-mac.outputs.BUILD_VERSION }}
     steps:
       - name: Get artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
+        with:
+          pattern: final-*
       - name: Release
         uses: softprops/action-gh-release@v1
         # if: startsWith(github.ref, 'refs/tags/') # Uncomment if enabling tag gating
@@ -144,5 +150,5 @@ jobs:
           draft: true # Comment out if enabling tag gating and publishing via action
           generate_release_notes: true
           files: |
-            build-mac/*
-            build-winux/*
+            final-mac-output/*
+            final-winux-output/*

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -32,10 +32,12 @@ jobs:
       - name: Build
         run: npm run build-prod
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: ./dist
+          if-no-files-found: error
+          retention-days: 3
 
   deploy-dev:
     if: github.ref_name == 'develop'
@@ -46,7 +48,7 @@ jobs:
       BACKUP_DIR: /opt/actions-runner/backups
     steps:
       - name: Get artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
            name: dist
       - name: Deploy
@@ -64,7 +66,7 @@ jobs:
       BACKUP_DIR: /opt/actions-runner/backups
     steps:
       - name: Get artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
            name: dist
       - name: Deploy


### PR DESCRIPTION
Bump versions for `upload-artifact` and `download-artifact` actions  from `v3` to `v4`. 

Add additional artifact upload params and reduce retention periods of all artifacts.