### PR TITLE
Issue 1746: remove SEP from notes for model

### DIFF
--- a/src/app/shared/shared-analysis/calculations/regression-models.service.ts
+++ b/src/app/shared/shared-analysis/calculations/regression-models.service.ts
@@ -402,10 +402,10 @@ export class RegressionModelsService {
       }
 
       if (baselineYearError) {
-        variableNotes.push(variable.name + ' failed SEP Validation for the baseline year.');
+        variableNotes.push(variable.name + ' failed data validation for the baseline year.');
       }
       if (reportYear) {
-        variableNotes.push(variable.name + ' failed SEP Validation for the report year.');
+        variableNotes.push(variable.name + ' failed data validation for the report year.');
       }
 
       SEPValidation.push({


### PR DESCRIPTION
connects #1746 

Instead of "failed SEP validation for report year" is says "failed data validation for report year" in the model notes. 

Same for baseline year.