### PR TITLE
#1194: validation on overview date ranges

### DIFF
--- a/src/app/account/account-overview/account-overview-banner/account-overview-banner.component.html
+++ b/src/app/account/account-overview/account-overview-banner/account-overview-banner.component.html
@@ -29,35 +29,40 @@
         </ul>
 
         <div class="d-flex" *ngIf="minMonth != undefined">
-            <div class="pe-1">
-                <select name="minMonth" [(ngModel)]="minMonth" class="form-select" (change)="setDate()">
-                    <option class="pe-2" *ngFor="let month of months" [ngValue]="month.monthNumValue">
-                        {{month.abbreviation}}</option>
-                </select>
+            <div class="d-flex flex-column">
+                <div class="d-flex mb-1">
+                    <div class="pe-1">
+                        <select name="minMonth" [(ngModel)]="minMonth" class="form-select" (change)="setDate()">
+                            <option class="pe-2" *ngFor="let month of months" [ngValue]="month.monthNumValue">
+                                {{month.abbreviation}}</option>
+                        </select>
+                    </div>
+                    <div class="pe-1">
+                        <select name="minYear" [(ngModel)]="minYear" class="form-select" (change)="setDate()">
+                            <option class="pe-2" *ngFor="let year of years" [ngValue]="year">{{year}}</option>
+                        </select>
+                    </div>
+                    <div class="ps-1 pe-1">
+                        <span class="fa fa-arrow-right"></span>
+                    </div>
+                    <div class="pe-1">
+                        <select name="maxMonth" [(ngModel)]="maxMonth" class="form-select" (change)="setDate()">
+                            <option class="pe-2" *ngFor="let month of months" [ngValue]="month.monthNumValue">
+                                {{month.abbreviation}}</option>
+                        </select>
+                    </div>
+                    <div class="pe-1">
+                        <select name="maxYear" [(ngModel)]="maxYear" class="form-select" (change)="setDate()">
+                            <option class="pe-2" *ngFor="let year of years" [ngValue]="year">{{year}}</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="text-danger fw-bold" *ngIf="errorMessage">
+                    {{errorMessage}}
+                </div>
             </div>
             <div class="pe-1">
-                <select name="minYear" [(ngModel)]="minYear" class="form-select" (change)="setDate()">
-                    <option class="pe-2" *ngFor="let year of years" [ngValue]="year">{{year}}</option>
-                </select>
-            </div>
-            <div class="ps-1 pe-1">
-                <span class="fa fa-arrow-right"></span>
-            </div>
-            <div class="pe-1">
-                <select name="maxMonth" [(ngModel)]="maxMonth" class="form-select" (change)="setDate()">
-                    <option class="pe-2" *ngFor="let month of months" [ngValue]="month.monthNumValue">
-                        {{month.abbreviation}}</option>
-                </select>
-            </div>
-            <div class="pe-1">
-                <select name="maxYear" [(ngModel)]="maxYear" class="form-select" (change)="setDate()">
-                    <option class="pe-2" *ngFor="let year of years" [ngValue]="year">{{year}}</option>
-                </select>
-            </div>
-
-
-            <div class="pe-1">
-                <button class="btn action-btn btn-sm" (click)="createReport()"><span class="fa fa-file"></span> Create
+                <button class="btn action-btn btn-sm" (click)="createReport()" [disabled]="errorMessage"><span class="fa fa-file"></span> Create
                     Report</button>
             </div>
             <div class="pe-1" *ngIf="urlDisplay == 'energy'">

--- a/src/app/account/account-overview/account-overview-banner/account-overview-banner.component.ts
+++ b/src/app/account/account-overview/account-overview-banner/account-overview-banner.component.ts
@@ -36,7 +36,7 @@ export class AccountOverviewBannerComponent implements OnInit {
   maxYear: number;
   months: Array<Month> = Months;
   years: Array<number>;
-
+  errorMessage: string = '';
   dateRangeSub: Subscription;
   constructor(private sharedDataService: SharedDataService, private accountDbService: AccountdbService,
     private router: Router,
@@ -117,9 +117,20 @@ export class AccountOverviewBannerComponent implements OnInit {
     this.sharedDataService.openCreateReportModal.next(true);
   }
 
+  //date validation
   setDate() {
     let startDate: Date = new Date(this.minYear, this.minMonth, 1);
     let endDate: Date = new Date(this.maxYear, this.maxMonth, 1);
+ 
+    // compare start and end date
+    if (startDate.getTime() >= endDate.getTime()) {
+      this.errorMessage = 'Start date cannot be later than the end date';
+      return;
+    }
+
+    this.errorMessage = '';
+
+    // Proceed with valid date range
     this.accountOverviewService.dateRange.next({
       startDate: startDate,
       endDate: endDate

--- a/src/app/account/account-reports/account-report-setup/account-report-setup.component.html
+++ b/src/app/account/account-reports/account-report-setup/account-report-setup.component.html
@@ -69,6 +69,9 @@
                             </select>
                         </div>
                     </div>
+                    <span class="alert alert-danger" *ngIf="errorMessage">
+                        {{errorMessage}}
+                    </span>
                 </div>
                 <div class="col-12">
                     <hr>
@@ -79,12 +82,12 @@
             <app-better-plants-setup
                 *ngIf="setupForm.controls.reportType.value == 'betterPlants'"></app-better-plants-setup>
             <app-data-overview-setup
-                *ngIf="setupForm.controls.reportType.value == 'dataOverview'"></app-data-overview-setup>
+                *ngIf="setupForm.controls.reportType.value == 'dataOverview' && errorMessage.length <= 0"></app-data-overview-setup>
             <app-performance-setup *ngIf="setupForm.controls.reportType.value == 'performance'"></app-performance-setup>
             <app-better-climate-setup
                 *ngIf="setupForm.controls.reportType.value == 'betterClimate'"></app-better-climate-setup>
         </ng-container>
-        <ng-container *ngIf="setupForm.valid == false">
+        <ng-container *ngIf="setupForm.valid == false || errorMessage.length > 0">
             <div class="alert alert-warning text-center">
                 Additional report detail options will appear once report dates are selected.
             </div>

--- a/src/app/account/account-reports/account-report-setup/account-report-setup.component.ts
+++ b/src/app/account/account-reports/account-report-setup/account-report-setup.component.ts
@@ -5,16 +5,17 @@ import { AccountReportsService } from '../account-reports.service';
 import { DbChangesService } from 'src/app/indexedDB/db-changes.service';
 import { AccountdbService } from 'src/app/indexedDB/account-db.service';
 import { Month, Months } from 'src/app/shared/form-data/months';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, Subscription } from 'rxjs';
 import { CalanderizationService } from 'src/app/shared/helper-services/calanderization.service';
 import { IdbAccount } from 'src/app/models/idbModels/account';
 import { IdbAccountReport } from 'src/app/models/idbModels/accountReport';
 import { ReportType } from 'src/app/models/constantsAndTypes';
+import { AccountOverviewService } from '../../account-overview/account-overview.service';
 @Component({
-    selector: 'app-account-report-setup',
-    templateUrl: './account-report-setup.component.html',
-    styleUrls: ['./account-report-setup.component.css'],
-    standalone: false
+  selector: 'app-account-report-setup',
+  templateUrl: './account-report-setup.component.html',
+  styleUrls: ['./account-report-setup.component.css'],
+  standalone: false
 })
 export class AccountReportSetupComponent {
 
@@ -25,11 +26,18 @@ export class AccountReportSetupComponent {
   months: Array<Month> = Months;
   //TODO: Report years validation. Start < End (issue-1194)
   reportType: ReportType;
+  dateRangeSub: Subscription;
+  startMonth: number;
+  startYear: number;
+  endMonth: number;
+  endYear: number;
+  errorMessage: string = '';
   constructor(private accountReportDbService: AccountReportDbService,
     private accountReportsService: AccountReportsService,
     private dbChangesService: DbChangesService,
     private accountDbService: AccountdbService,
-    private calanderizationService: CalanderizationService) {
+    private calanderizationService: CalanderizationService,
+    private accountOverviewService: AccountOverviewService) {
 
   }
 
@@ -37,11 +45,59 @@ export class AccountReportSetupComponent {
     this.account = this.accountDbService.selectedAccount.getValue();
     let selectedReport: IdbAccountReport = this.accountReportDbService.selectedReport.getValue()
     this.reportType = selectedReport.reportType;
+    this.accountReportsService.setErrorMessage(this.errorMessage);
     this.setupForm = this.accountReportsService.getSetupFormFromReport(selectedReport);
     this.setYearOptions();
+
+    this.dateRangeSub = this.accountOverviewService.dateRange.subscribe(dateRange => {
+      if (dateRange) {
+        this.startMonth = this.setupForm.get('startMonth').value;
+        this.startYear = this.setupForm.get('startYear').value;
+        this.endMonth = this.setupForm.get('endMonth').value;
+        this.endYear = this.setupForm.get('endYear').value;
+      }
+    });
+
+    // on browser reload
+    if (this.setupForm.get('startYear').value !== null && this.setupForm.get('startMonth').value !== null && this.setupForm.get('endYear').value !== null
+      && this.setupForm.get('endMonth').value !== null) {
+      this.validateDate();
+    }
+  }
+
+  ngOnDestroy() {
+    this.dateRangeSub.unsubscribe();
+  }
+
+  validateDate() {
+
+    let startDate: Date = new Date(this.setupForm.get('startYear').value, this.setupForm.get('startMonth').value, 1);
+    let endDate: Date = new Date(this.setupForm.get('endYear').value, this.setupForm.get('endMonth').value, 1);
+
+    // compare start and end date
+    if (startDate.getTime() >= endDate.getTime()) {
+      this.errorMessage = 'Start date cannot be later than the end date';
+      this.accountReportsService.setErrorMessage(this.errorMessage); // setting the message in the local storage
+      return;
+    }
+
+    this.errorMessage = '';
+    this.accountReportsService.setErrorMessage(this.errorMessage); // setting the message in the local storage
+
+    // Proceed with valid date range
+    this.accountOverviewService.dateRange.next({
+      startDate: startDate,
+      endDate: endDate
+    });
   }
 
   async save() {
+
+    // if all the date fields are filled, validate the date
+    if (this.setupForm.get('startYear').value !== null && this.setupForm.get('startMonth').value !== null && this.setupForm.get('endYear').value !== null
+      && this.setupForm.get('endMonth').value !== null) {
+      this.validateDate();
+    }
     let selectedReport: IdbAccountReport = this.accountReportDbService.selectedReport.getValue();
     selectedReport = this.accountReportsService.updateReportFromSetupForm(selectedReport, this.setupForm);
     selectedReport = await firstValueFrom(this.accountReportDbService.updateWithObservable(selectedReport));

--- a/src/app/account/account-reports/account-report-setup/account-report-setup.component.ts
+++ b/src/app/account/account-reports/account-report-setup/account-report-setup.component.ts
@@ -52,35 +52,7 @@ export class AccountReportSetupComponent {
     this.errorMessageSub.unsubscribe();
   }
 
-  // validateDate() {
-
-  //   let startDate: Date = new Date(this.setupForm.get('startYear').value, this.setupForm.get('startMonth').value, 1);
-  //   let endDate: Date = new Date(this.setupForm.get('endYear').value, this.setupForm.get('endMonth').value, 1);
-
-  //   // compare start and end date
-  //   if (startDate.getTime() >= endDate.getTime()) {
-  //     this.errorMessage = 'Start date cannot be later than the end date';
-  //     this.accountReportsService.setErrorMessage(this.errorMessage); // setting the message in the local storage
-  //     return;
-  //   }
-
-  //   this.errorMessage = '';
-  //   this.accountReportsService.setErrorMessage(this.errorMessage); // setting the message in the local storage
-
-  //   // Proceed with valid date range
-  //   this.accountOverviewService.dateRange.next({
-  //     startDate: startDate,
-  //     endDate: endDate
-  //   });
-  // }
-
   async save() {
-
-    // // if all the date fields are filled, validate the date
-    // if (this.setupForm.get('startYear').value !== null && this.setupForm.get('startMonth').value !== null && this.setupForm.get('endYear').value !== null
-    //   && this.setupForm.get('endMonth').value !== null) {
-    //   this.validateDate();
-    // }
     let selectedReport: IdbAccountReport = this.accountReportDbService.selectedReport.getValue();
     selectedReport = this.accountReportsService.updateReportFromSetupForm(selectedReport, this.setupForm);
     selectedReport = await firstValueFrom(this.accountReportDbService.updateWithObservable(selectedReport));

--- a/src/app/account/account-reports/account-report-setup/account-report-setup.component.ts
+++ b/src/app/account/account-reports/account-report-setup/account-report-setup.component.ts
@@ -10,7 +10,7 @@ import { CalanderizationService } from 'src/app/shared/helper-services/calanderi
 import { IdbAccount } from 'src/app/models/idbModels/account';
 import { IdbAccountReport } from 'src/app/models/idbModels/accountReport';
 import { ReportType } from 'src/app/models/constantsAndTypes';
-import { AccountOverviewService } from '../../account-overview/account-overview.service';
+
 @Component({
   selector: 'app-account-report-setup',
   templateUrl: './account-report-setup.component.html',
@@ -24,7 +24,6 @@ export class AccountReportSetupComponent {
   reportYears: Array<number>;
   baselineYears: Array<number>;
   months: Array<Month> = Months;
-  //TODO: Report years validation. Start < End (issue-1194)
   reportType: ReportType;
   errorMessage: string = '';
   errorMessageSub: Subscription;

--- a/src/app/account/account-reports/account-report-setup/account-report-setup.component.ts
+++ b/src/app/account/account-reports/account-report-setup/account-report-setup.component.ts
@@ -26,18 +26,13 @@ export class AccountReportSetupComponent {
   months: Array<Month> = Months;
   //TODO: Report years validation. Start < End (issue-1194)
   reportType: ReportType;
-  dateRangeSub: Subscription;
-  startMonth: number;
-  startYear: number;
-  endMonth: number;
-  endYear: number;
   errorMessage: string = '';
+  errorMessageSub: Subscription;
   constructor(private accountReportDbService: AccountReportDbService,
     private accountReportsService: AccountReportsService,
     private dbChangesService: DbChangesService,
     private accountDbService: AccountdbService,
-    private calanderizationService: CalanderizationService,
-    private accountOverviewService: AccountOverviewService) {
+    private calanderizationService: CalanderizationService) {
 
   }
 
@@ -45,59 +40,47 @@ export class AccountReportSetupComponent {
     this.account = this.accountDbService.selectedAccount.getValue();
     let selectedReport: IdbAccountReport = this.accountReportDbService.selectedReport.getValue()
     this.reportType = selectedReport.reportType;
-    this.accountReportsService.setErrorMessage(this.errorMessage);
     this.setupForm = this.accountReportsService.getSetupFormFromReport(selectedReport);
     this.setYearOptions();
 
-    this.dateRangeSub = this.accountOverviewService.dateRange.subscribe(dateRange => {
-      if (dateRange) {
-        this.startMonth = this.setupForm.get('startMonth').value;
-        this.startYear = this.setupForm.get('startYear').value;
-        this.endMonth = this.setupForm.get('endMonth').value;
-        this.endYear = this.setupForm.get('endYear').value;
-      }
+    this.errorMessageSub = this.accountReportsService.errorMessage.subscribe(message => {
+      this.errorMessage = message;
     });
-
-    // on browser reload
-    if (this.setupForm.get('startYear').value !== null && this.setupForm.get('startMonth').value !== null && this.setupForm.get('endYear').value !== null
-      && this.setupForm.get('endMonth').value !== null) {
-      this.validateDate();
-    }
   }
 
   ngOnDestroy() {
-    this.dateRangeSub.unsubscribe();
+    this.errorMessageSub.unsubscribe();
   }
 
-  validateDate() {
+  // validateDate() {
 
-    let startDate: Date = new Date(this.setupForm.get('startYear').value, this.setupForm.get('startMonth').value, 1);
-    let endDate: Date = new Date(this.setupForm.get('endYear').value, this.setupForm.get('endMonth').value, 1);
+  //   let startDate: Date = new Date(this.setupForm.get('startYear').value, this.setupForm.get('startMonth').value, 1);
+  //   let endDate: Date = new Date(this.setupForm.get('endYear').value, this.setupForm.get('endMonth').value, 1);
 
-    // compare start and end date
-    if (startDate.getTime() >= endDate.getTime()) {
-      this.errorMessage = 'Start date cannot be later than the end date';
-      this.accountReportsService.setErrorMessage(this.errorMessage); // setting the message in the local storage
-      return;
-    }
+  //   // compare start and end date
+  //   if (startDate.getTime() >= endDate.getTime()) {
+  //     this.errorMessage = 'Start date cannot be later than the end date';
+  //     this.accountReportsService.setErrorMessage(this.errorMessage); // setting the message in the local storage
+  //     return;
+  //   }
 
-    this.errorMessage = '';
-    this.accountReportsService.setErrorMessage(this.errorMessage); // setting the message in the local storage
+  //   this.errorMessage = '';
+  //   this.accountReportsService.setErrorMessage(this.errorMessage); // setting the message in the local storage
 
-    // Proceed with valid date range
-    this.accountOverviewService.dateRange.next({
-      startDate: startDate,
-      endDate: endDate
-    });
-  }
+  //   // Proceed with valid date range
+  //   this.accountOverviewService.dateRange.next({
+  //     startDate: startDate,
+  //     endDate: endDate
+  //   });
+  // }
 
   async save() {
 
-    // if all the date fields are filled, validate the date
-    if (this.setupForm.get('startYear').value !== null && this.setupForm.get('startMonth').value !== null && this.setupForm.get('endYear').value !== null
-      && this.setupForm.get('endMonth').value !== null) {
-      this.validateDate();
-    }
+    // // if all the date fields are filled, validate the date
+    // if (this.setupForm.get('startYear').value !== null && this.setupForm.get('startMonth').value !== null && this.setupForm.get('endYear').value !== null
+    //   && this.setupForm.get('endMonth').value !== null) {
+    //   this.validateDate();
+    // }
     let selectedReport: IdbAccountReport = this.accountReportDbService.selectedReport.getValue();
     selectedReport = this.accountReportsService.updateReportFromSetupForm(selectedReport, this.setupForm);
     selectedReport = await firstValueFrom(this.accountReportDbService.updateWithObservable(selectedReport));

--- a/src/app/account/account-reports/account-reports-banner/account-reports-banner.component.ts
+++ b/src/app/account/account-reports/account-reports-banner/account-reports-banner.component.ts
@@ -7,10 +7,10 @@ import { AccountReportDbService } from 'src/app/indexedDB/account-report-db.serv
 import { IdbAccountReport } from 'src/app/models/idbModels/accountReport';
 
 @Component({
-    selector: 'app-account-reports-banner',
-    templateUrl: './account-reports-banner.component.html',
-    styleUrls: ['./account-reports-banner.component.css'],
-    standalone: false
+  selector: 'app-account-reports-banner',
+  templateUrl: './account-reports-banner.component.html',
+  styleUrls: ['./account-reports-banner.component.css'],
+  standalone: false
 })
 export class AccountReportsBannerComponent {
 
@@ -37,9 +37,11 @@ export class AccountReportsBannerComponent {
       this.modalOpen = val;
     });
 
-    this.errorSub = this.accountReportsService.errorMessage$.subscribe(errorMessage => {
+    this.errorSub = this.accountReportsService.errorMessage.subscribe(errorMessage => {
       this.errorMessage = errorMessage;
-      this.setValidation(this.selectedReport);  //setValidation() is called here to take care of the validation on browser reload.
+      if (this.selectedReport) {
+        this.setValidation(this.selectedReport);
+      }
     });
 
     this.selectedReportSub = this.accountReportDbService.selectedReport.subscribe(val => {

--- a/src/app/account/account-reports/account-reports.service.ts
+++ b/src/app/account/account-reports/account-reports.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { FormBuilder, FormGroup, ValidatorFn, Validators } from '@angular/forms';
 import { BetterClimateReportSetup, BetterPlantsReportSetup, DataOverviewReportSetup, PerformanceReportSetup } from 'src/app/models/overview-report';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, Subject } from 'rxjs';
 import { IdbAccountReport } from 'src/app/models/idbModels/accountReport';
 
 @Injectable({
@@ -11,9 +11,28 @@ export class AccountReportsService {
 
   print: BehaviorSubject<boolean>;
   generateExcel: BehaviorSubject<boolean>;
+  errorMessage = new Subject<string>();
+  errorMessage$ = this.errorMessage.asObservable();
+
   constructor(private formBuilder: FormBuilder) {
     this.print = new BehaviorSubject<boolean>(false);
     this.generateExcel = new BehaviorSubject<boolean>(false);
+
+    // store the error message in local storage to persist the value after browser reload
+    const message = localStorage.getItem('errorMessage');
+    if (message) {
+      this.errorMessage.next(message);
+    }
+  }
+
+  setErrorMessage(message: string) {
+    this.errorMessage.next(message);
+    localStorage.setItem('errorMessage', message);
+  }
+
+  clearMessage() {
+    this.errorMessage.next(null);
+    localStorage.removeItem('errorMessage');
   }
 
   getSetupFormFromReport(report: IdbAccountReport): FormGroup {

--- a/src/app/facility/facility-overview/facility-overview-banner/facility-overview-banner.component.html
+++ b/src/app/facility/facility-overview/facility-overview-banner/facility-overview-banner.component.html
@@ -29,33 +29,42 @@
         </ul>
 
         <div class="d-flex" *ngIf="minMonth != undefined">
-            <div class="pe-1">
-                <select name="minMonth" [(ngModel)]="minMonth" class="form-select" (change)="setDate()">
-                    <option class="pe-2" *ngFor="let month of months" [ngValue]="month.monthNumValue">
-                        {{month.abbreviation}}</option>
-                </select>
+            <div class="d-flex flex-column">
+                <div class="d-flex mb-1">
+                    <div class="pe-1">
+                        <select name="minMonth" [(ngModel)]="minMonth" class="form-select" (change)="setDate()">
+                            <option class="pe-2" *ngFor="let month of months" [ngValue]="month.monthNumValue">
+                                {{month.abbreviation}}</option>
+                        </select>
+                    </div>
+                    <div class="pe-1">
+                        <select name="minYear" [(ngModel)]="minYear" class="form-select" (change)="setDate()">
+                            <option class="pe-2" *ngFor="let year of years" [ngValue]="year">{{year}}</option>
+                        </select>
+                    </div>
+                    <div class="ps-1 pe-1">
+                        <span class="fa fa-arrow-right"></span>
+                    </div>
+                    <div class="pe-1">
+                        <select name="maxMonth" [(ngModel)]="maxMonth" class="form-select" (change)="setDate()">
+                            <option class="pe-2" *ngFor="let month of months" [ngValue]="month.monthNumValue">
+                                {{month.abbreviation}}</option>
+                        </select>
+                    </div>
+                    <div class="pe-1">
+                        <select name="maxYear" [(ngModel)]="maxYear" class="form-select" (change)="setDate()">
+                            <option class="pe-2" *ngFor="let year of years" [ngValue]="year">{{year}}</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="text-danger fw-bold" *ngIf="errorMessage">
+                    {{errorMessage}}
+                </div>
             </div>
+
             <div class="pe-1">
-                <select name="minYear" [(ngModel)]="minYear" class="form-select" (change)="setDate()">
-                    <option class="pe-2" *ngFor="let year of years" [ngValue]="year">{{year}}</option>
-                </select>
-            </div>
-            <div class="ps-1 pe-1">
-                <span class="fa fa-arrow-right"></span>
-            </div>
-            <div class="pe-1">
-                <select name="maxMonth" [(ngModel)]="maxMonth" class="form-select" (change)="setDate()">
-                    <option class="pe-2" *ngFor="let month of months" [ngValue]="month.monthNumValue">
-                        {{month.abbreviation}}</option>
-                </select>
-            </div>
-            <div class="pe-1">
-                <select name="maxYear" [(ngModel)]="maxYear" class="form-select" (change)="setDate()">
-                    <option class="pe-2" *ngFor="let year of years" [ngValue]="year">{{year}}</option>
-                </select>
-            </div>
-            <div class="pe-1">
-                <button class="btn action-btn btn-sm" (click)="openCreateReportModal()"><span class="fa fa-file"></span> Create
+                <button class="btn action-btn btn-sm" (click)="openCreateReportModal()" [disabled]="errorMessage"><span class="fa fa-file"></span>
+                    Create
                     Report</button>
             </div>
             <div class="pe-1" *ngIf="urlDisplay == 'energy'">

--- a/src/app/facility/facility-overview/facility-overview-banner/facility-overview-banner.component.ts
+++ b/src/app/facility/facility-overview/facility-overview-banner/facility-overview-banner.component.ts
@@ -43,11 +43,9 @@ export class FacilityOverviewBannerComponent implements OnInit {
   maxYear: number;
   months: Array<Month> = Months;
   years: Array<number>;
-
   dateRangeSub: Subscription;
-
   showReportModal: boolean = false;
-
+  errorMessage: string;
   facilityReport: IdbFacilityReport;
   constructor(private sharedDataService: SharedDataService, private facilityDbService: FacilitydbService,
     private router: Router,
@@ -155,9 +153,18 @@ export class FacilityOverviewBannerComponent implements OnInit {
     this.router.navigateByUrl('/facility/' + this.selectedFacility.id + '/reports/setup');
   }
 
+  // date validation
   setDate() {
     let startDate: Date = new Date(this.minYear, this.minMonth, 1);
     let endDate: Date = new Date(this.maxYear, this.maxMonth, 1);
+
+    //compare start date and end date
+    if (startDate.getTime() >= endDate.getTime()) {
+      this.errorMessage = 'Start date cannot be later than the end date';
+      return;
+    }
+
+    this.errorMessage = '';
     this.facilityOverviewService.dateRange.next({
       startDate: startDate,
       endDate: endDate

--- a/src/app/facility/facility-overview/facility-overview.service.ts
+++ b/src/app/facility/facility-overview/facility-overview.service.ts
@@ -21,7 +21,10 @@ export class FacilityOverviewService {
 
   constructor() {
     this.emissionsDisplay = new BehaviorSubject<"market" | "location">("market");
-    this.dateRange = new BehaviorSubject(undefined);
+    this.dateRange = new BehaviorSubject<{
+      startDate: Date,
+      endDate: Date
+    }>(undefined);
     this.utilityUseAndCost = new BehaviorSubject(undefined);
     this.facilityOverviewData = new BehaviorSubject(undefined);
     this.calculating = new BehaviorSubject(undefined);

--- a/src/app/facility/facility-reports/facility-report-setup/facility-overview-report-setup/facility-overview-report-setup.component.html
+++ b/src/app/facility/facility-reports/facility-report-setup/facility-overview-report-setup/facility-overview-report-setup.component.html
@@ -31,8 +31,8 @@
         </div>
     </div>
 
-    <div class="row justify-content-end">
-        <span class="col-6 alert alert-danger small mt-2" *ngIf="errorMessage">
+    <div class="row justify-content-end" *ngIf="errorMessage">
+        <span class="col-6 alert alert-danger small mt-2">
             {{errorMessage}}
         </span>
     </div>

--- a/src/app/facility/facility-reports/facility-report-setup/facility-overview-report-setup/facility-overview-report-setup.component.html
+++ b/src/app/facility/facility-reports/facility-report-setup/facility-overview-report-setup/facility-overview-report-setup.component.html
@@ -30,6 +30,13 @@
             </select>
         </div>
     </div>
+
+    <div class="row justify-content-end">
+        <span class="col-6 alert alert-danger small mt-2" *ngIf="errorMessage">
+            {{errorMessage}}
+        </span>
+    </div>
+    
     <hr>
     <div class="row mt-2">
         <div class="col-6">

--- a/src/app/facility/facility-reports/facility-report-setup/facility-overview-report-setup/facility-overview-report-setup.component.ts
+++ b/src/app/facility/facility-reports/facility-report-setup/facility-overview-report-setup/facility-overview-report-setup.component.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { firstValueFrom, Subscription } from 'rxjs';
+import { FacilityOverviewService } from 'src/app/facility/facility-overview/facility-overview.service';
 import { AccountdbService } from 'src/app/indexedDB/account-db.service';
 import { DbChangesService } from 'src/app/indexedDB/db-changes.service';
 import { FacilitydbService } from 'src/app/indexedDB/facility-db.service';
@@ -18,7 +19,6 @@ import { CalanderizationService } from 'src/app/shared/helper-services/calanderi
 })
 export class FacilityOverviewReportSetupComponent {
 
-
   facilityReport: IdbFacilityReport;
   reportSettings: DataOverviewFacilityReportSettings;
   facilityReportSub: Subscription;
@@ -26,16 +26,25 @@ export class FacilityOverviewReportSetupComponent {
   reportYears: Array<number>;
   baselineYears: Array<number>;
   months: Array<Month> = Months;
+  startMonth: number;
+  startYear: number;
+  endMonth: number;
+  endYear: number;
+  dateRangeSub: Subscription;
+  errorMessage: string = '';
+
   constructor(private facilityReportsDbService: FacilityReportsDbService,
     private accountDbService: AccountdbService,
     private facilityDbService: FacilitydbService,
     private dbChangesService: DbChangesService,
-    private calanderizationService: CalanderizationService
+    private calanderizationService: CalanderizationService,
+    private facilityOverviewService: FacilityOverviewService
   ) {
 
   }
 
   ngOnInit() {
+    this.facilityReportsDbService.setErrorMessage(this.errorMessage);
     this.facilityReportSub = this.facilityReportsDbService.selectedReport.subscribe(report => {
       if (this.isFormChange == false) {
         this.facilityReport = report;
@@ -45,12 +54,51 @@ export class FacilityOverviewReportSetupComponent {
       }
     });
     this.setYearOptions();
+
+    this.dateRangeSub = this.facilityOverviewService.dateRange.subscribe(dateRange => {
+      if (dateRange) {
+        this.startMonth = this.facilityReport.dataOverviewReportSettings.startMonth;
+        this.startYear = this.facilityReport.dataOverviewReportSettings.startYear;
+        this.endMonth = this.facilityReport.dataOverviewReportSettings.endMonth;
+        this.endYear = this.facilityReport.dataOverviewReportSettings.endYear;
+      }
+    });
+
+    // on browser reload
+    if (this.facilityReport.dataOverviewReportSettings.startMonth !== undefined 
+      && this.facilityReport.dataOverviewReportSettings.startYear !== undefined 
+      && this.facilityReport.dataOverviewReportSettings.endMonth !== undefined
+      && this.facilityReport.dataOverviewReportSettings.endYear !== undefined) {
+      this.validateDate();
+    }
   }
 
   ngOnDestroy() {
     this.facilityReportSub.unsubscribe();
+    this.dateRangeSub.unsubscribe();
   }
 
+  validateDate() {
+
+    let startDate: Date = new Date(this.facilityReport.dataOverviewReportSettings.startYear, this.facilityReport.dataOverviewReportSettings.startMonth, 1);
+    let endDate: Date = new Date(this.facilityReport.dataOverviewReportSettings.endYear, this.facilityReport.dataOverviewReportSettings.endMonth, 1);
+
+    // compare start and end date
+    if (startDate.getTime() >= endDate.getTime()) {
+      this.errorMessage = 'Start date cannot be later than the end date.';
+      this.facilityReportsDbService.setErrorMessage(this.errorMessage); // store error message in local storage
+      return;
+    }
+
+    this.errorMessage = '';
+    this.facilityReportsDbService.setErrorMessage(this.errorMessage);  // store error message in local storage
+
+    // Proceed with valid date range
+    this.facilityOverviewService.dateRange.next({
+      startDate: startDate,
+      endDate: endDate
+    });
+  }
 
   async save() {
     this.isFormChange = true;
@@ -61,6 +109,14 @@ export class FacilityOverviewReportSetupComponent {
     let selectedFacility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
     await this.dbChangesService.setAccountFacilityReports(selectedAccount, selectedFacility);
     this.facilityReportsDbService.selectedReport.next(facilityReport);
+
+    // proceed with date validation if all the date fields are filled
+    if (this.facilityReport.dataOverviewReportSettings.startMonth !== undefined 
+      && this.facilityReport.dataOverviewReportSettings.startYear !== undefined 
+      && this.facilityReport.dataOverviewReportSettings.endMonth !== undefined
+      && this.facilityReport.dataOverviewReportSettings.endYear !== undefined) {
+      this.validateDate();
+    }
   }
 
   setYearOptions() {

--- a/src/app/facility/facility-reports/facility-report-setup/facility-overview-report-setup/facility-overview-report-setup.component.ts
+++ b/src/app/facility/facility-reports/facility-report-setup/facility-overview-report-setup/facility-overview-report-setup.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { firstValueFrom, Subscription } from 'rxjs';
-import { FacilityOverviewService } from 'src/app/facility/facility-overview/facility-overview.service';
+// import { FacilityOverviewService } from 'src/app/facility/facility-overview/facility-overview.service';
 import { AccountdbService } from 'src/app/indexedDB/account-db.service';
 import { DbChangesService } from 'src/app/indexedDB/db-changes.service';
 import { FacilitydbService } from 'src/app/indexedDB/facility-db.service';
@@ -10,6 +10,7 @@ import { IdbFacility } from 'src/app/models/idbModels/facility';
 import { DataOverviewFacilityReportSettings, IdbFacilityReport } from 'src/app/models/idbModels/facilityReport';
 import { Month, Months } from 'src/app/shared/form-data/months';
 import { CalanderizationService } from 'src/app/shared/helper-services/calanderization.service';
+import { FacilityReportsService } from '../../facility-reports.service';
 
 @Component({
     selector: 'app-facility-overview-report-setup',
@@ -26,25 +27,27 @@ export class FacilityOverviewReportSetupComponent {
   reportYears: Array<number>;
   baselineYears: Array<number>;
   months: Array<Month> = Months;
-  startMonth: number;
-  startYear: number;
-  endMonth: number;
-  endYear: number;
-  dateRangeSub: Subscription;
-  errorMessage: string = '';
+  // startMonth: number;
+  // startYear: number;
+  // endMonth: number;
+  // endYear: number;
+  // dateRangeSub: Subscription;
+  errorMessage: string;
+  errorMessageSub: Subscription;
 
   constructor(private facilityReportsDbService: FacilityReportsDbService,
     private accountDbService: AccountdbService,
     private facilityDbService: FacilitydbService,
     private dbChangesService: DbChangesService,
     private calanderizationService: CalanderizationService,
-    private facilityOverviewService: FacilityOverviewService
+    // private facilityOverviewService: FacilityOverviewService,
+    private facilityReportsService: FacilityReportsService
   ) {
 
   }
 
   ngOnInit() {
-    this.facilityReportsDbService.setErrorMessage(this.errorMessage);
+    // this.facilityReportsDbService.setErrorMessage(this.errorMessage);
     this.facilityReportSub = this.facilityReportsDbService.selectedReport.subscribe(report => {
       if (this.isFormChange == false) {
         this.facilityReport = report;
@@ -55,50 +58,38 @@ export class FacilityOverviewReportSetupComponent {
     });
     this.setYearOptions();
 
-    this.dateRangeSub = this.facilityOverviewService.dateRange.subscribe(dateRange => {
-      if (dateRange) {
-        this.startMonth = this.facilityReport.dataOverviewReportSettings.startMonth;
-        this.startYear = this.facilityReport.dataOverviewReportSettings.startYear;
-        this.endMonth = this.facilityReport.dataOverviewReportSettings.endMonth;
-        this.endYear = this.facilityReport.dataOverviewReportSettings.endYear;
-      }
+    this.errorMessageSub = this.facilityReportsService.errorMessage.subscribe(message => {
+      this.errorMessage = message;
     });
-
-    // on browser reload
-    if (this.facilityReport.dataOverviewReportSettings.startMonth !== undefined 
-      && this.facilityReport.dataOverviewReportSettings.startYear !== undefined 
-      && this.facilityReport.dataOverviewReportSettings.endMonth !== undefined
-      && this.facilityReport.dataOverviewReportSettings.endYear !== undefined) {
-      this.validateDate();
-    }
   }
 
   ngOnDestroy() {
     this.facilityReportSub.unsubscribe();
-    this.dateRangeSub.unsubscribe();
+    // this.dateRangeSub.unsubscribe();
+    this.errorMessageSub.unsubscribe();
   }
 
-  validateDate() {
+  // validateDate() {
 
-    let startDate: Date = new Date(this.facilityReport.dataOverviewReportSettings.startYear, this.facilityReport.dataOverviewReportSettings.startMonth, 1);
-    let endDate: Date = new Date(this.facilityReport.dataOverviewReportSettings.endYear, this.facilityReport.dataOverviewReportSettings.endMonth, 1);
+  //   let startDate: Date = new Date(this.facilityReport.dataOverviewReportSettings.startYear, this.facilityReport.dataOverviewReportSettings.startMonth, 1);
+  //   let endDate: Date = new Date(this.facilityReport.dataOverviewReportSettings.endYear, this.facilityReport.dataOverviewReportSettings.endMonth, 1);
 
-    // compare start and end date
-    if (startDate.getTime() >= endDate.getTime()) {
-      this.errorMessage = 'Start date cannot be later than the end date.';
-      this.facilityReportsDbService.setErrorMessage(this.errorMessage); // store error message in local storage
-      return;
-    }
+  //   // compare start and end date
+  //   if (startDate.getTime() >= endDate.getTime()) {
+  //     this.errorMessage = 'Start date cannot be later than the end date.';
+  //     this.facilityReportsDbService.setErrorMessage(this.errorMessage); // store error message in local storage
+  //     return;
+  //   }
 
-    this.errorMessage = '';
-    this.facilityReportsDbService.setErrorMessage(this.errorMessage);  // store error message in local storage
+  //   this.errorMessage = '';
+  //   this.facilityReportsDbService.setErrorMessage(this.errorMessage);  // store error message in local storage
 
-    // Proceed with valid date range
-    this.facilityOverviewService.dateRange.next({
-      startDate: startDate,
-      endDate: endDate
-    });
-  }
+  //   // Proceed with valid date range
+  //   this.facilityOverviewService.dateRange.next({
+  //     startDate: startDate,
+  //     endDate: endDate
+  //   });
+  // }
 
   async save() {
     this.isFormChange = true;
@@ -111,12 +102,12 @@ export class FacilityOverviewReportSetupComponent {
     this.facilityReportsDbService.selectedReport.next(facilityReport);
 
     // proceed with date validation if all the date fields are filled
-    if (this.facilityReport.dataOverviewReportSettings.startMonth !== undefined 
-      && this.facilityReport.dataOverviewReportSettings.startYear !== undefined 
-      && this.facilityReport.dataOverviewReportSettings.endMonth !== undefined
-      && this.facilityReport.dataOverviewReportSettings.endYear !== undefined) {
-      this.validateDate();
-    }
+    // if (this.facilityReport.dataOverviewReportSettings.startMonth !== undefined 
+    //   && this.facilityReport.dataOverviewReportSettings.startYear !== undefined 
+    //   && this.facilityReport.dataOverviewReportSettings.endMonth !== undefined
+    //   && this.facilityReport.dataOverviewReportSettings.endYear !== undefined) {
+    //   this.validateDate();
+    // }
   }
 
   setYearOptions() {

--- a/src/app/facility/facility-reports/facility-report-setup/facility-overview-report-setup/facility-overview-report-setup.component.ts
+++ b/src/app/facility/facility-reports/facility-report-setup/facility-overview-report-setup/facility-overview-report-setup.component.ts
@@ -27,11 +27,6 @@ export class FacilityOverviewReportSetupComponent {
   reportYears: Array<number>;
   baselineYears: Array<number>;
   months: Array<Month> = Months;
-  // startMonth: number;
-  // startYear: number;
-  // endMonth: number;
-  // endYear: number;
-  // dateRangeSub: Subscription;
   errorMessage: string;
   errorMessageSub: Subscription;
 
@@ -40,14 +35,12 @@ export class FacilityOverviewReportSetupComponent {
     private facilityDbService: FacilitydbService,
     private dbChangesService: DbChangesService,
     private calanderizationService: CalanderizationService,
-    // private facilityOverviewService: FacilityOverviewService,
     private facilityReportsService: FacilityReportsService
   ) {
 
   }
 
   ngOnInit() {
-    // this.facilityReportsDbService.setErrorMessage(this.errorMessage);
     this.facilityReportSub = this.facilityReportsDbService.selectedReport.subscribe(report => {
       if (this.isFormChange == false) {
         this.facilityReport = report;
@@ -65,31 +58,8 @@ export class FacilityOverviewReportSetupComponent {
 
   ngOnDestroy() {
     this.facilityReportSub.unsubscribe();
-    // this.dateRangeSub.unsubscribe();
     this.errorMessageSub.unsubscribe();
   }
-
-  // validateDate() {
-
-  //   let startDate: Date = new Date(this.facilityReport.dataOverviewReportSettings.startYear, this.facilityReport.dataOverviewReportSettings.startMonth, 1);
-  //   let endDate: Date = new Date(this.facilityReport.dataOverviewReportSettings.endYear, this.facilityReport.dataOverviewReportSettings.endMonth, 1);
-
-  //   // compare start and end date
-  //   if (startDate.getTime() >= endDate.getTime()) {
-  //     this.errorMessage = 'Start date cannot be later than the end date.';
-  //     this.facilityReportsDbService.setErrorMessage(this.errorMessage); // store error message in local storage
-  //     return;
-  //   }
-
-  //   this.errorMessage = '';
-  //   this.facilityReportsDbService.setErrorMessage(this.errorMessage);  // store error message in local storage
-
-  //   // Proceed with valid date range
-  //   this.facilityOverviewService.dateRange.next({
-  //     startDate: startDate,
-  //     endDate: endDate
-  //   });
-  // }
 
   async save() {
     this.isFormChange = true;
@@ -100,14 +70,6 @@ export class FacilityOverviewReportSetupComponent {
     let selectedFacility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
     await this.dbChangesService.setAccountFacilityReports(selectedAccount, selectedFacility);
     this.facilityReportsDbService.selectedReport.next(facilityReport);
-
-    // proceed with date validation if all the date fields are filled
-    // if (this.facilityReport.dataOverviewReportSettings.startMonth !== undefined 
-    //   && this.facilityReport.dataOverviewReportSettings.startYear !== undefined 
-    //   && this.facilityReport.dataOverviewReportSettings.endMonth !== undefined
-    //   && this.facilityReport.dataOverviewReportSettings.endYear !== undefined) {
-    //   this.validateDate();
-    // }
   }
 
   setYearOptions() {

--- a/src/app/facility/facility-reports/facility-report-setup/facility-overview-report-setup/facility-overview-report-setup.component.ts
+++ b/src/app/facility/facility-reports/facility-report-setup/facility-overview-report-setup/facility-overview-report-setup.component.ts
@@ -1,6 +1,5 @@
 import { Component } from '@angular/core';
 import { firstValueFrom, Subscription } from 'rxjs';
-// import { FacilityOverviewService } from 'src/app/facility/facility-overview/facility-overview.service';
 import { AccountdbService } from 'src/app/indexedDB/account-db.service';
 import { DbChangesService } from 'src/app/indexedDB/db-changes.service';
 import { FacilitydbService } from 'src/app/indexedDB/facility-db.service';

--- a/src/app/facility/facility-reports/facility-reports-tabs/facility-reports-tabs.component.ts
+++ b/src/app/facility/facility-reports/facility-reports-tabs/facility-reports-tabs.component.ts
@@ -8,10 +8,10 @@ import { IdbFacilityReport } from 'src/app/models/idbModels/facilityReport';
 import { SharedDataService } from 'src/app/shared/helper-services/shared-data.service';
 
 @Component({
-    selector: 'app-facility-reports-tabs',
-    templateUrl: './facility-reports-tabs.component.html',
-    styleUrl: './facility-reports-tabs.component.css',
-    standalone: false
+  selector: 'app-facility-reports-tabs',
+  templateUrl: './facility-reports-tabs.component.html',
+  styleUrl: './facility-reports-tabs.component.css',
+  standalone: false
 })
 export class FacilityReportsTabsComponent {
 
@@ -22,7 +22,8 @@ export class FacilityReportsTabsComponent {
   setupValid: boolean = true;
   selectedReportSub: Subscription;
   selectedReport: IdbFacilityReport;
-
+  errorSub: Subscription;
+  errorMessage: string = '';
   facility: IdbFacility;
   facilitySub: Subscription;
   constructor(private router: Router,
@@ -42,6 +43,12 @@ export class FacilityReportsTabsComponent {
     this.modalOpenSub = this.sharedDataService.modalOpen.subscribe(val => {
       this.modalOpen = val;
     });
+
+    this.errorSub = this.facilityReportsDbService.errorMessage$.subscribe(errorMessage => {
+      this.errorMessage = errorMessage;
+      this.setSetupValid();  //setValidation() is called here to take care of the validation on browser reload.
+    });
+
     this.selectedReportSub = this.facilityReportsDbService.selectedReport.subscribe(val => {
       this.selectedReport = val;
       if (this.selectedReport) {
@@ -74,7 +81,8 @@ export class FacilityReportsTabsComponent {
         this.selectedReport.dataOverviewReportSettings.endMonth != undefined &&
         this.selectedReport.dataOverviewReportSettings.endYear != undefined &&
         this.selectedReport.dataOverviewReportSettings.startMonth != undefined &&
-        this.selectedReport.dataOverviewReportSettings.startYear != undefined)
+        this.selectedReport.dataOverviewReportSettings.startYear != undefined &&
+        this.errorMessage.length <= 0)
     } else {
       this.setupValid = false;
     }

--- a/src/app/facility/facility-reports/facility-reports-tabs/facility-reports-tabs.component.ts
+++ b/src/app/facility/facility-reports/facility-reports-tabs/facility-reports-tabs.component.ts
@@ -64,6 +64,7 @@ export class FacilityReportsTabsComponent {
     this.routerSub.unsubscribe();
     this.selectedReportSub.unsubscribe();
     this.facilitySub.unsubscribe();
+    this.errorSub.unsubscribe();
   }
 
 

--- a/src/app/facility/facility-reports/facility-reports-tabs/facility-reports-tabs.component.ts
+++ b/src/app/facility/facility-reports/facility-reports-tabs/facility-reports-tabs.component.ts
@@ -6,6 +6,7 @@ import { FacilityReportsDbService } from 'src/app/indexedDB/facility-reports-db.
 import { IdbFacility } from 'src/app/models/idbModels/facility';
 import { IdbFacilityReport } from 'src/app/models/idbModels/facilityReport';
 import { SharedDataService } from 'src/app/shared/helper-services/shared-data.service';
+import { FacilityReportsService } from '../facility-reports.service';
 
 @Component({
   selector: 'app-facility-reports-tabs',
@@ -23,13 +24,14 @@ export class FacilityReportsTabsComponent {
   selectedReportSub: Subscription;
   selectedReport: IdbFacilityReport;
   errorSub: Subscription;
-  errorMessage: string = '';
+  errorMessage: string;
   facility: IdbFacility;
   facilitySub: Subscription;
   constructor(private router: Router,
     private sharedDataService: SharedDataService,
     private facilityReportsDbService: FacilityReportsDbService,
-    private facilityDbService: FacilitydbService) { }
+    private facilityDbService: FacilitydbService,
+    private facilityReportsService: FacilityReportsService) { }
   ngOnInit() {
     this.routerSub = this.router.events.subscribe(event => {
       this.setInDashboard();
@@ -44,9 +46,9 @@ export class FacilityReportsTabsComponent {
       this.modalOpen = val;
     });
 
-    this.errorSub = this.facilityReportsDbService.errorMessage$.subscribe(errorMessage => {
+    this.errorSub = this.facilityReportsService.errorMessage.subscribe(errorMessage => {
       this.errorMessage = errorMessage;
-      this.setSetupValid();  //setValidation() is called here to take care of the validation on browser reload.
+      this.setSetupValid();
     });
 
     this.selectedReportSub = this.facilityReportsDbService.selectedReport.subscribe(val => {
@@ -82,7 +84,7 @@ export class FacilityReportsTabsComponent {
         this.selectedReport.dataOverviewReportSettings.endYear != undefined &&
         this.selectedReport.dataOverviewReportSettings.startMonth != undefined &&
         this.selectedReport.dataOverviewReportSettings.startYear != undefined &&
-        this.errorMessage.length <= 0)
+        this.errorMessage == undefined)
     } else {
       this.setupValid = false;
     }

--- a/src/app/facility/facility-reports/facility-reports.service.ts
+++ b/src/app/facility/facility-reports/facility-reports.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
+import { FacilityReportsDbService } from 'src/app/indexedDB/facility-reports-db.service';
+import { IdbFacilityReport } from 'src/app/models/idbModels/facilityReport';
 
 @Injectable({
   providedIn: 'root'
@@ -7,7 +9,28 @@ import { BehaviorSubject } from 'rxjs';
 export class FacilityReportsService {
 
   print: BehaviorSubject<boolean>;
-  constructor() {
+
+  errorMessage: BehaviorSubject<string>;
+  constructor(private facilityReportDbService: FacilityReportsDbService) {
     this.print = new BehaviorSubject<boolean>(false);
+    this.errorMessage = new BehaviorSubject<string>(undefined);
+
+    this.facilityReportDbService.selectedReport.subscribe(report => {
+      this.validateReport(report);
+    });
+  }
+
+  validateReport(report: IdbFacilityReport) {
+    let errorMessage: string = undefined;
+    if (report) {
+      //write validation for report
+      let startDate: Date = new Date(report.dataOverviewReportSettings.startYear, report.dataOverviewReportSettings.startMonth, 1);
+      let endDate: Date = new Date(report.dataOverviewReportSettings.endYear, report.dataOverviewReportSettings.endMonth, 1);
+      // compare start and end date
+      if (startDate.getTime() >= endDate.getTime()) {
+        errorMessage = 'Start date cannot be later than the end date.';
+      }
+    }
+    this.errorMessage.next(errorMessage)
   }
 }

--- a/src/app/indexedDB/facility-reports-db.service.ts
+++ b/src/app/indexedDB/facility-reports-db.service.ts
@@ -13,9 +13,6 @@ export class FacilityReportsDbService {
   accountFacilityReports: BehaviorSubject<Array<IdbFacilityReport>>;
   facilityReports: BehaviorSubject<Array<IdbFacilityReport>>;
   selectedReport: BehaviorSubject<IdbFacilityReport>;
-  
-  // errorMessage = new Subject<string>();
-  // errorMessage$ = this.errorMessage.asObservable();
 
   constructor(private dbService: NgxIndexedDBService, private localStorageService: LocalStorageService,
     private loadingService: LoadingService) {
@@ -28,23 +25,7 @@ export class FacilityReportsDbService {
         this.localStorageService.store('facilityReportId', analysisItem.id);
       }
     });
-
-    // store error message in local storage for browser reload case
-    // const message = localStorage.getItem('errorMessage');
-    // if (message) {
-    //   this.errorMessage.next(message);
-    // }
   }
-
-  // setErrorMessage(message: string) {
-  //   this.errorMessage.next(message);
-  //   localStorage.setItem('errorMessage', message);
-  // }
-
-  // clearMessage() {
-  //   this.errorMessage.next(null);
-  //   localStorage.removeItem('errorMessage');
-  // }
 
   getInitialReport(): number {
     let reportId: number = this.localStorageService.retrieve("facilityReportId");

--- a/src/app/indexedDB/facility-reports-db.service.ts
+++ b/src/app/indexedDB/facility-reports-db.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { NgxIndexedDBService } from 'ngx-indexed-db';
 import { LocalStorageService } from 'ngx-webstorage';
-import { BehaviorSubject, firstValueFrom, Observable } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, Observable, Subject } from 'rxjs';
 import { IdbFacilityReport } from '../models/idbModels/facilityReport';
 import { LoadingService } from '../core-components/loading/loading.service';
 
@@ -13,6 +13,9 @@ export class FacilityReportsDbService {
   accountFacilityReports: BehaviorSubject<Array<IdbFacilityReport>>;
   facilityReports: BehaviorSubject<Array<IdbFacilityReport>>;
   selectedReport: BehaviorSubject<IdbFacilityReport>;
+  errorMessage = new Subject<string>();
+  errorMessage$ = this.errorMessage.asObservable();
+
   constructor(private dbService: NgxIndexedDBService, private localStorageService: LocalStorageService,
     private loadingService: LoadingService) {
     this.accountFacilityReports = new BehaviorSubject<Array<IdbFacilityReport>>([]);
@@ -24,6 +27,22 @@ export class FacilityReportsDbService {
         this.localStorageService.store('facilityReportId', analysisItem.id);
       }
     });
+
+    // store error message in local storage for browser reload case
+    const message = localStorage.getItem('errorMessage');
+    if (message) {
+      this.errorMessage.next(message);
+    }
+  }
+
+  setErrorMessage(message: string) {
+    this.errorMessage.next(message);
+    localStorage.setItem('errorMessage', message);
+  }
+
+  clearMessage() {
+    this.errorMessage.next(null);
+    localStorage.removeItem('errorMessage');
   }
 
   getInitialReport(): number {

--- a/src/app/indexedDB/facility-reports-db.service.ts
+++ b/src/app/indexedDB/facility-reports-db.service.ts
@@ -13,8 +13,9 @@ export class FacilityReportsDbService {
   accountFacilityReports: BehaviorSubject<Array<IdbFacilityReport>>;
   facilityReports: BehaviorSubject<Array<IdbFacilityReport>>;
   selectedReport: BehaviorSubject<IdbFacilityReport>;
-  errorMessage = new Subject<string>();
-  errorMessage$ = this.errorMessage.asObservable();
+  
+  // errorMessage = new Subject<string>();
+  // errorMessage$ = this.errorMessage.asObservable();
 
   constructor(private dbService: NgxIndexedDBService, private localStorageService: LocalStorageService,
     private loadingService: LoadingService) {
@@ -29,21 +30,21 @@ export class FacilityReportsDbService {
     });
 
     // store error message in local storage for browser reload case
-    const message = localStorage.getItem('errorMessage');
-    if (message) {
-      this.errorMessage.next(message);
-    }
+    // const message = localStorage.getItem('errorMessage');
+    // if (message) {
+    //   this.errorMessage.next(message);
+    // }
   }
 
-  setErrorMessage(message: string) {
-    this.errorMessage.next(message);
-    localStorage.setItem('errorMessage', message);
-  }
+  // setErrorMessage(message: string) {
+  //   this.errorMessage.next(message);
+  //   localStorage.setItem('errorMessage', message);
+  // }
 
-  clearMessage() {
-    this.errorMessage.next(null);
-    localStorage.removeItem('errorMessage');
-  }
+  // clearMessage() {
+  //   this.errorMessage.next(null);
+  //   localStorage.removeItem('errorMessage');
+  // }
 
   getInitialReport(): number {
     let reportId: number = this.localStorageService.retrieve("facilityReportId");


### PR DESCRIPTION
Added date validation in the overview tab and the data overview reports. The validation works such that the start date cannot be later than the end date. This has been done both for the account and the facility.
![analysis_account](https://github.com/user-attachments/assets/6aaa9035-ba6d-49d3-bdcb-deccbc36cf61)
![analysis_facility](https://github.com/user-attachments/assets/fce08387-170f-432d-9633-8d5e31f33b2e)
![data_overview_report_account](https://github.com/user-attachments/assets/6c13aba4-07e2-4672-afb1-ba56fb9baa4d)
![data_overview_report_facility](https://github.com/user-attachments/assets/6357fd43-769c-4931-93d8-12ec7ae67e25)
