### PR TITLE
Issue 1794 - Removed baseline year dropdown in Better Plants Reports

### DIFF
--- a/src/app/account/account-reports/account-report-setup/account-report-setup.component.html
+++ b/src/app/account/account-reports/account-report-setup/account-report-setup.component.html
@@ -13,7 +13,7 @@
                     </div>
                 </div>
                 <div class="col-6" *ngIf="setupForm.controls.reportType.value != 'dataOverview'">
-                    <div class="row form-group">
+                    <div class="row form-group" *ngIf="setupForm.controls.reportType.value != 'betterPlants'">
                         <label class="col-5 col-form-label semibold" for="baselineYear">Baseline Year</label>
 
                         <div class="col-7">

--- a/src/app/account/account-reports/account-report-setup/better-plants-setup/better-plants-setup.component.html
+++ b/src/app/account/account-reports/account-report-setup/better-plants-setup/better-plants-setup.component.html
@@ -21,6 +21,9 @@
                                 Facilities Included
                             </td>
                             <td>
+                                Baseline Year
+                            </td>
+                            <td>
                             </td>
                         </tr>
                     </thead>
@@ -48,6 +51,9 @@
                                     </span>
                                 </span>
                             </td>
+                            <td>
+                                {{analysisItem.baselineYear}}
+                            </td>
                             <td class="text-center">
                                 <a class="click-link" (click)="viewAnalysis(analysisItem)">View Analysis</a>
                             </td>
@@ -60,6 +66,10 @@
                     </tbody>
                 </table>
             </div>
+            <div class="alert alert-warning text-center p-1" *ngIf="baselineYearWarning">
+                {{baselineYearWarning}}
+            </div>
+
             <!-- <div class="alert alert-danger" *ngIf="!reportOptions.analysisItemId">
             Analysis Item Required
         </div> -->

--- a/src/app/account/account-reports/account-report-setup/better-plants-setup/better-plants-setup.component.ts
+++ b/src/app/account/account-reports/account-report-setup/better-plants-setup/better-plants-setup.component.ts
@@ -29,6 +29,7 @@ export class BetterPlantsSetupComponent {
   isFormChange: boolean = false;
   itemToEdit: IdbAccountAnalysisItem;
   selectedAnalysisItem: IdbAccountAnalysisItem;
+  baselineYearWarning: string;
   constructor(private accountReportDbService: AccountReportDbService,
     private accountReportsService: AccountReportsService,
     private dbChangesService: DbChangesService,
@@ -92,9 +93,30 @@ export class BetterPlantsSetupComponent {
     if (this.selectedAnalysisItem && this.selectedAnalysisItem.analysisCategory == 'water') {
       this.methodsUndertakenLabel = 'If a baseline adjustment was made, please indicate the reason for making the adjustment';
       this.modificationNotesLabel = 'Please briefly describe major technologies, strategies, and practices employed during the previous year to decrease water intensity. Please identify: systems/processes impacted, approximate water savings from projects, and implementation cost';
-    } else {
+    } else if (this.selectedAnalysisItem && this.selectedAnalysisItem.analysisCategory == 'energy'){
       this.methodsUndertakenLabel = 'Please describe any methods undertaken to normalize energy intensity data or adjust baseline data to account for economic and other factors that affect energy use:';
       this.modificationNotesLabel = 'Please describe the energy efficient technologies, strategies, and practices employed during the previous year to decrease intensity. Please identify systems impacted and approximate savings from projects. (Ex: Furnace insulation project-12,000 MMBtu/yr savings, compressor controls upgrade-6,000 MMBtu/yr, energy awareness campaign, etc):';
     }
+    this.setBaselineYearWarning();
   }
+
+  setBaselineYearWarning() {
+    this.baselineYearWarning = undefined;
+    if (this.selectedAnalysisItem && this.selectedAnalysisItem.analysisCategory == 'water') {
+      if (this.selectedAnalysisItem.baselineYear && this.account.sustainabilityQuestions.waterReductionGoal && this.account.sustainabilityQuestions.waterReductionBaselineYear != this.selectedAnalysisItem.baselineYear) {
+        this.baselineYearWarning = "This baseline year does not match your corporate baseline year."
+      } else {
+        this.baselineYearWarning = undefined;
+      }
+    } else if (this.selectedAnalysisItem && this.selectedAnalysisItem.analysisCategory == 'energy') {
+      if (this.selectedAnalysisItem.baselineYear && this.account.sustainabilityQuestions.energyReductionGoal && this.account.sustainabilityQuestions.energyReductionBaselineYear != this.selectedAnalysisItem.baselineYear) {
+        this.baselineYearWarning = "This baseline year does not match your corporate baseline year."
+      } else {
+        this.baselineYearWarning = undefined;
+      }
+    } else {
+      this.baselineYearWarning = undefined;
+    }
+  }
+
 }

--- a/src/app/account/account-reports/account-reports.service.ts
+++ b/src/app/account/account-reports/account-reports.service.ts
@@ -25,18 +25,32 @@ export class AccountReportsService {
       dateValidators = [Validators.required];
     }
 
-
-    let form: FormGroup = this.formBuilder.group({
-      reportName: [report.name, Validators.required],
-      reportType: [report.reportType, Validators.required],
-      reportYear: [report.reportYear, yearValidators],
-      baselineYear: [report.baselineYear, yearValidators],
-      startMonth: [report.startMonth, dateValidators],
-      startYear: [report.startYear, dateValidators],
-      endMonth: [report.endMonth, dateValidators],
-      endYear: [report.endYear, dateValidators]
-    });
-    return form;
+    if (report.reportType == 'performance' || report.reportType == 'betterClimate' || report.reportType == 'dataOverview') {
+      let form: FormGroup = this.formBuilder.group({
+        reportName: [report.name, Validators.required],
+        reportType: [report.reportType, Validators.required],
+        reportYear: [report.reportYear, yearValidators],
+        baselineYear: [report.baselineYear, yearValidators],
+        startMonth: [report.startMonth, dateValidators],
+        startYear: [report.startYear, dateValidators],
+        endMonth: [report.endMonth, dateValidators],
+        endYear: [report.endYear, dateValidators]
+      });
+      return form;
+    }
+    else if (report.reportType == 'betterPlants') {
+      let form: FormGroup = this.formBuilder.group({
+        reportName: [report.name, Validators.required],
+        reportType: [report.reportType, Validators.required],
+        reportYear: [report.reportYear, yearValidators],
+        baselineYear: [report.baselineYear, ''],
+        startMonth: [report.startMonth, dateValidators],
+        startYear: [report.startYear, dateValidators],
+        endMonth: [report.endMonth, dateValidators],
+        endYear: [report.endYear, dateValidators]
+      });
+      return form;
+    }
   }
 
   updateReportFromSetupForm(report: IdbAccountReport, form: FormGroup): IdbAccountReport {


### PR DESCRIPTION
#1794 

Removed baseline year dropdown from BP reports and put an alert message in case the selected analysis item does not match the company level baseline year.