### PR TITLE
Issue 2019: Use guids instead of int IDs for routing

### DIFF
--- a/src/app/analytics/analytics.service.ts
+++ b/src/app/analytics/analytics.service.ts
@@ -133,10 +133,15 @@ export class AnalyticsService {
   }
 
   getPageWithoutId(pagePath: string) {
-    let pathWithoutId: string = pagePath.replace(/[0-9]/g, '');
-    pathWithoutId = pathWithoutId.replace(/\/$/, "");
-    pathWithoutId = pathWithoutId.replace("//", "/:id/");
-    return pathWithoutId;
+    // let pathWithoutId: string = pagePath.replace(/[0-9]/g, '');
+    // pathWithoutId = pathWithoutId.replace(/\/$/, "");
+    // pathWithoutId = pathWithoutId.replace("//", "/:id/");
+    // return pathWithoutId;
+    // Replace segments that match the custom ID pattern: 9 chars, lowercase letters and digits, with ':id'
+    return pagePath
+      .split('/')
+      .map(segment => /^[a-z0-9]{9}$/.test(segment) ? ':id' : segment)
+      .join('/') || '/';
   }
 
   sendEvent(eventName: AnalyticsEventString, path?: string) {

--- a/src/app/core-components/header/header.component.ts
+++ b/src/app/core-components/header/header.component.ts
@@ -229,7 +229,7 @@ export class HeaderComponent implements OnInit {
       if (url.includes('facilities')) {
         let selectedFacility: IdbFacility = this.facilitydbService.selectedFacility.getValue();
         if (selectedFacility) {
-          this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.id);
+          this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid);
         } else {
           this.router.navigateByUrl('/data-evaluation/account')
         }

--- a/src/app/core-components/header/search-bar/search-bar.component.ts
+++ b/src/app/core-components/header/search-bar/search-bar.component.ts
@@ -125,9 +125,9 @@ export class SearchBarComponent implements OnInit {
 
   selectValue(item: DropdownOption) {
     if (item.type == 'facility') {
-      this.router.navigateByUrl('facility/' + item.facilityId)
+      this.router.navigateByUrl('facility/' + item.facilityGuid)
     } else if (item.type == 'meter') {
-      this.router.navigateByUrl('facility/' + item.facilityId + '/utility/energy-consumption/utility-meter/' + item.meterId);
+      this.router.navigateByUrl('facility/' + item.facilityGuid + '/utility/energy-consumption/utility-meter/' + item.meterId);
     } else if (item.type == 'accountAnalysis') {
       this.accountAnalysisDbService.selectedAnalysisItem.next(item.accountAnalysisItem);
       if (item.accountAnalysisItem.setupErrors.hasError || item.accountAnalysisItem.setupErrors.facilitiesSelectionsInvalid) {
@@ -138,9 +138,9 @@ export class SearchBarComponent implements OnInit {
     } else if (item.type == 'facilityAnalysis') {
       this.analysisDbService.selectedAnalysisItem.next(item.facilityAnalysisItem);
       if (item.facilityAnalysisItem.setupErrors.hasError || item.facilityAnalysisItem.setupErrors.groupsHaveErrors) {
-        this.router.navigateByUrl('facility/' + item.facilityId + '/analysis/run-analysis');
+        this.router.navigateByUrl('facility/' + item.facilityGuid + '/analysis/run-analysis');
       } else {
-        this.router.navigateByUrl('facility/' + item.facilityId + '/analysis/run-analysis/facility-analysis');
+        this.router.navigateByUrl('facility/' + item.facilityGuid + '/analysis/run-analysis/facility-analysis');
       }
     } else if (item.type == 'report') {
       this.accountReportsDbService.selectedReport.next(item.idbAccountReport);

--- a/src/app/core-components/header/search-bar/search-bar.component.ts
+++ b/src/app/core-components/header/search-bar/search-bar.component.ts
@@ -48,7 +48,7 @@ export class SearchBarComponent implements OnInit {
         type: 'facility',
         facilityId: item.id,
         facilityGuid: item.guid,
-        meterId: undefined,
+        meterGuid: undefined,
         idbAccountReport: undefined,
         facilityAnalysisItem: undefined,
         accountAnalysisItem: undefined,
@@ -62,7 +62,7 @@ export class SearchBarComponent implements OnInit {
         type: 'meter',
         facilityId: facility.id,
         facilityGuid: item.facilityId,
-        meterId: item.id,
+        meterGuid: item.guid,
         idbAccountReport: undefined,
         facilityAnalysisItem: undefined,
         accountAnalysisItem: undefined,
@@ -75,7 +75,7 @@ export class SearchBarComponent implements OnInit {
         type: 'accountAnalysis',
         facilityId: undefined,
         facilityGuid: undefined,
-        meterId: undefined,
+        meterGuid: undefined,
         idbAccountReport: undefined,
         facilityAnalysisItem: undefined,
         accountAnalysisItem: item,
@@ -89,7 +89,7 @@ export class SearchBarComponent implements OnInit {
         type: 'facilityAnalysis',
         facilityId: facility.id,
         facilityGuid: item.facilityId,
-        meterId: undefined,
+        meterGuid: undefined,
         idbAccountReport: undefined,
         facilityAnalysisItem: item,
         accountAnalysisItem: undefined,
@@ -102,7 +102,7 @@ export class SearchBarComponent implements OnInit {
         type: 'report',
         facilityId: undefined,
         facilityGuid: undefined,
-        meterId: undefined,
+        meterGuid: undefined,
         idbAccountReport: reportOptions,
         facilityAnalysisItem: undefined,
         accountAnalysisItem: undefined,
@@ -127,7 +127,7 @@ export class SearchBarComponent implements OnInit {
     if (item.type == 'facility') {
       this.router.navigateByUrl('facility/' + item.facilityGuid)
     } else if (item.type == 'meter') {
-      this.router.navigateByUrl('facility/' + item.facilityGuid + '/utility/energy-consumption/utility-meter/' + item.meterId);
+      this.router.navigateByUrl('facility/' + item.facilityGuid + '/utility/energy-consumption/utility-meter/' + item.meterGuid);
     } else if (item.type == 'accountAnalysis') {
       this.accountAnalysisDbService.selectedAnalysisItem.next(item.accountAnalysisItem);
       if (item.accountAnalysisItem.setupErrors.hasError || item.accountAnalysisItem.setupErrors.facilitiesSelectionsInvalid) {
@@ -167,7 +167,7 @@ export interface DropdownOption {
   facilityId: number,
   facilityGuid: string,
   // accountId: number,
-  meterId: number,
+  meterGuid: string,
   idbAccountReport: IdbAccountReport,
   facilityAnalysisItem: IdbAnalysisItem,
   accountAnalysisItem: IdbAccountAnalysisItem,

--- a/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-item-table/select-item-table.component.ts
+++ b/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-item-table/select-item-table.component.ts
@@ -87,7 +87,7 @@ export class SelectItemTableComponent implements OnInit {
     this.sharedDataService.modalOpen.next(false);
     this.analysisService.accountAnalysisItem = this.selectedAnalysisItem;
     this.analysisDbService.selectedAnalysisItem.next(this.itemToEdit);
-    this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.id + '/analysis/run-analysis');
+    this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.guid + '/analysis/run-analysis');
   }
 
   createNewItem() {
@@ -124,7 +124,7 @@ export class SelectItemTableComponent implements OnInit {
     this.analysisDbService.selectedAnalysisItem.next(newIdbItem);
     this.loadingService.setLoadingStatus(false);
     this.analysisService.accountAnalysisItem = this.selectedAnalysisItem;
-    this.router.navigateByUrl("/data-evaluation/facility/" + this.facility.id + "/analysis/run-analysis/analysis-setup");
+    this.router.navigateByUrl("/data-evaluation/facility/" + this.facility.guid + "/analysis/run-analysis/analysis-setup");
   }
 
   setSelectedFacilityItem() {

--- a/src/app/data-evaluation/account/account-overview/account-overview.component.ts
+++ b/src/app/data-evaluation/account/account-overview/account-overview.component.ts
@@ -147,7 +147,7 @@ export class AccountOverviewComponent implements OnInit {
     //TODO: Update select facility call
     let facilities: Array<IdbFacility> = this.facilityDbService.accountFacilities.getValue();
     if (facilities.length > 0) {
-      this.router.navigateByUrl('/data-evaluation/facility/' + facilities[0].id + '/utility');
+      this.router.navigateByUrl('/data-evaluation/facility/' + facilities[0].guid + '/utility');
     }
   }
 }

--- a/src/app/data-evaluation/account/account-settings/account-settings.component.ts
+++ b/src/app/data-evaluation/account/account-settings/account-settings.component.ts
@@ -97,7 +97,7 @@ export class AccountSettingsComponent implements OnInit {
 
   switchFacility(facility: IdbFacility) {
     this.facilityDbService.selectedFacility.next(facility);
-    this.router.navigateByUrl('/data-evaluation/facility/' + facility.id + '/settings');
+    this.router.navigateByUrl('/data-evaluation/facility/' + facility.guid + '/settings');
   }
 
   async addNewFacility() {
@@ -110,7 +110,7 @@ export class AccountSettingsComponent implements OnInit {
     await this.dbChangesService.selectAccount(this.selectedAccount, false);
     this.loadingService.setLoadingStatus(false);
     this.toastNotificationService.showToast('New Facility Added!', undefined, undefined, false, 'alert-success');
-    this.router.navigateByUrl('/data-evaluation/facility/' + newFacility.id + '/settings');
+    this.router.navigateByUrl('/data-evaluation/facility/' + newFacility.guid + '/settings');
   }
 
 

--- a/src/app/data-evaluation/facility/analysis/analysis-banner/analysis-banner.component.ts
+++ b/src/app/data-evaluation/facility/analysis/analysis-banner/analysis-banner.component.ts
@@ -72,7 +72,7 @@ export class AnalysisBannerComponent implements OnInit {
   selectItem(item: IdbAnalysisItem) {
     this.analysisDbService.selectedAnalysisItem.next(item);
     let facility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-    this.router.navigateByUrl('/data-evaluation/facility/' + facility.id + '/analysis/run-analysis/analysis-setup');
+    this.router.navigateByUrl('/data-evaluation/facility/' + facility.guid + '/analysis/run-analysis/analysis-setup');
     this.showDropdown = false;
   }
 }

--- a/src/app/data-evaluation/facility/analysis/analysis-dashboard/analysis-dashboard.component.ts
+++ b/src/app/data-evaluation/facility/analysis/analysis-dashboard/analysis-dashboard.component.ts
@@ -85,7 +85,7 @@ export class AnalysisDashboardComponent implements OnInit {
     this.analyticsService.sendEvent('create_facility_analysis', undefined)
     this.analysisDbService.selectedAnalysisItem.next(addedItem);
     this.toastNotificationService.showToast('New Analysis Created', undefined, undefined, false, "alert-success");
-    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/analysis/run-analysis');
+    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/analysis/run-analysis');
   }
 
   saveShowDetails() {
@@ -133,10 +133,10 @@ export class AnalysisDashboardComponent implements OnInit {
     this.hasEnergy = hasEnergy;
     //check nav
     if (this.analysisType == 'Energy' && !this.hasEnergy) {
-      this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/analysis/analysis-dashboard/water');
+      this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/analysis/analysis-dashboard/water');
     }
     if (this.analysisType == 'Water' && !this.hasWater) {
-      this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/analysis/analysis-dashboard/energy');
+      this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/analysis/analysis-dashboard/energy');
     }
   }
 

--- a/src/app/data-evaluation/facility/analysis/analysis-dashboard/analysis-item-card/analysis-item-card.component.ts
+++ b/src/app/data-evaluation/facility/analysis/analysis-dashboard/analysis-item-card/analysis-item-card.component.ts
@@ -78,9 +78,9 @@ export class AnalysisItemCardComponent implements OnInit {
   selectAnalysisItem() {
     this.analysisDbService.selectedAnalysisItem.next(this.analysisItem);
     if (this.analysisItem.setupErrors.hasError || this.analysisItem.setupErrors.groupsHaveErrors) {
-      this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/analysis/run-analysis');
+      this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/analysis/run-analysis');
     } else {
-      this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/analysis/run-analysis/facility-analysis');
+      this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/analysis/run-analysis/facility-analysis');
     }
   }
 
@@ -103,7 +103,7 @@ export class AnalysisItemCardComponent implements OnInit {
     await this.dbChangesService.setAnalysisItems(selectedAccount, false, this.selectedFacility);
     this.analysisDbService.selectedAnalysisItem.next(addedItem);
     this.toastNotificationService.showToast('Analysis Copy Created', undefined, undefined, false, "alert-success");
-    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/analysis/run-analysis');
+    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/analysis/run-analysis');
   }
 
   deleteItem() {
@@ -272,7 +272,7 @@ export class AnalysisItemCardComponent implements OnInit {
   goToReport(reportGuid: string) {
     let facilityReport: IdbFacilityReport = this.facilityReportsDbService.getByGuid(reportGuid);
     this.facilityReportsDbService.selectedReport.next(facilityReport);
-    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/reports/setup')
+    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/reports/setup')
   }
 
   goToAccountAnalysis(analysisGuid: string) {
@@ -289,9 +289,9 @@ export class AnalysisItemCardComponent implements OnInit {
     let bankedAnalysisItem: IdbAnalysisItem = this.analysisDbService.getByGuid(analysisGuid);
     this.analysisDbService.selectedAnalysisItem.next(bankedAnalysisItem);
     if (bankedAnalysisItem.setupErrors.hasError || bankedAnalysisItem.setupErrors.groupsHaveErrors) {
-      this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/analysis/run-analysis');
+      this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/analysis/run-analysis');
     } else {
-      this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/analysis/run-analysis/facility-analysis');
+      this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/analysis/run-analysis/facility-analysis');
     }
   }
 }

--- a/src/app/data-evaluation/facility/analysis/analysis-dashboard/energy-dashboard/energy-dashboard.component.ts
+++ b/src/app/data-evaluation/facility/analysis/analysis-dashboard/energy-dashboard/energy-dashboard.component.ts
@@ -80,10 +80,10 @@ export class EnergyDashboardComponent {
   }
   
   goToSettings() {
-    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/settings');
+    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/settings');
   }
 
   goToUtilityData() {
-    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/utility');
+    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/utility');
   }
 }

--- a/src/app/data-evaluation/facility/analysis/analysis-dashboard/water-dashboard/water-dashboard.component.ts
+++ b/src/app/data-evaluation/facility/analysis/analysis-dashboard/water-dashboard/water-dashboard.component.ts
@@ -80,10 +80,10 @@ export class WaterDashboardComponent {
   }
   
   goToSettings() {
-    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/settings');
+    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/settings');
   }
 
   goToUtilityData() {
-    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/utility');
+    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/utility');
   }
 }

--- a/src/app/data-evaluation/facility/analysis/analysis-footer/analysis-footer.component.ts
+++ b/src/app/data-evaluation/facility/analysis/analysis-footer/analysis-footer.component.ts
@@ -72,7 +72,7 @@ export class AnalysisFooterComponent implements OnInit {
 
   goBack() {
     let facility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-    let facilityUrlStr: string = '/data-evaluation/facility/' + facility.id + '/analysis/run-analysis/';
+    let facilityUrlStr: string = '/data-evaluation/facility/' + facility.guid + '/analysis/run-analysis/';
     if (this.router.url.includes('account-analysis')) {
       this.router.navigateByUrl(facilityUrlStr + 'facility-analysis/monthly-analysis');
     } else if (this.router.url.includes('facility-analysis')) {
@@ -101,13 +101,13 @@ export class AnalysisFooterComponent implements OnInit {
         }
       }
     } else {
-      this.router.navigateByUrl('/facility/' + facility.id + '/analysis/analysis-dashboard');
+      this.router.navigateByUrl('/facility/' + facility.guid + '/analysis/analysis-dashboard');
     }
   }
 
   continue() {
     let facility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-    let facilityUrlStr: string = '/facility/' + facility.id + '/analysis/run-analysis/';
+    let facilityUrlStr: string = '/facility/' + facility.guid + '/analysis/run-analysis/';
     if (this.router.url.includes('analysis-setup')) {
       this.router.navigateByUrl(facilityUrlStr + 'group-analysis/' + this.analysisItem.groups[0].idbGroupId + '/options');
     } else if (this.router.url.includes('group-analysis')) {
@@ -191,7 +191,7 @@ export class AnalysisFooterComponent implements OnInit {
 
   returnToDashboard() {
     let facility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-    this.router.navigateByUrl('/data-evaluation/facility/' + facility.id + '/analysis/analysis-dashboard');
+    this.router.navigateByUrl('/data-evaluation/facility/' + facility.guid + '/analysis/analysis-dashboard');
   }
 
 }

--- a/src/app/data-evaluation/facility/analysis/analysis.component.ts
+++ b/src/app/data-evaluation/facility/analysis/analysis.component.ts
@@ -57,12 +57,12 @@ export class AnalysisComponent implements OnInit {
 
   goToMeterGroups() {
     let selectedFacility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-    this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.id + '/utility/meter-groups')
+    this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility/meter-groups')
   }
 
   goToUtilityData() {
     let selectedFacility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-    this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.id + '/utility')
+    this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility')
   }
 
   async updateAccountValidation(allAnalysisItems: Array<IdbAnalysisItem>) {

--- a/src/app/data-evaluation/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.ts
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.ts
@@ -109,7 +109,7 @@ export class AnalysisSetupComponent implements OnInit {
   }
 
   continue() {
-    this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.id + '/analysis/run-analysis/group-analysis/' + this.analysisItem.groups[0].idbGroupId + '/options');
+    this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.guid + '/analysis/run-analysis/group-analysis/' + this.analysisItem.groups[0].idbGroupId + '/options');
   }
 
   setBaselineYearWarning() {

--- a/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/group-analysis-options/group-analysis-options.component.ts
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/group-analysis-options/group-analysis-options.component.ts
@@ -93,12 +93,12 @@ export class GroupAnalysisOptionsComponent implements OnInit {
 
   goToPredictors() {
     let facility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-    this.router.navigateByUrl('/data-evaluation/facility/' + facility.id + '/utility/predictors');
+    this.router.navigateByUrl('/data-evaluation/facility/' + facility.guid + '/utility/predictors');
   }
 
   goToMeterGroups() {
     let facility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-    this.router.navigateByUrl('/data-evaluation/facility/' + facility.id + '/utility/meter-groups');
+    this.router.navigateByUrl('/data-evaluation/facility/' + facility.guid + '/utility/meter-groups');
   }
 
   setShowInUseMessage() {

--- a/src/app/data-evaluation/facility/facility-home/facility-home-summary/facility-home-summary.component.html
+++ b/src/app/data-evaluation/facility/facility-home/facility-home-summary/facility-home-summary.component.html
@@ -90,7 +90,7 @@
                     <ul class="list-group list-group-flush">
                         <!--meters-->
                         <li class="list-group-item" *ngIf="meterReadingsNeeded">
-                            <a class="nav-link" routerLink="/facility/{{facility.id}}/utility">
+                            <a class="nav-link" routerLink="/facility/{{facility.guid}}/utility">
                                 <span class="badge rounded-pill bg-danger">
                                     <span class="fa fa-exclamation white"></span>
                                 </span>
@@ -100,7 +100,7 @@
                         </li>
                         <li class="list-group-item" *ngIf="energyAnalysisNeeded && lastBill">
                             <a class="nav-link"
-                                routerLink="/facility/{{facility.id}}/analysis/analysis-dashboard/energy">
+                                routerLink="/facility/{{facility.guid}}/analysis/analysis-dashboard/energy">
                                 <span class="badge rounded-pill bg-danger">
                                     <span class="fa fa-exclamation white"></span>
                                 </span>
@@ -112,7 +112,7 @@
                         </li>
                         <li class="list-group-item" *ngIf="waterAnalysisNeeded && lastBill">
                             <a class="nav-link"
-                                routerLink="/facility/{{facility.id}}/analysis/analysis-dashboard/water">
+                                routerLink="/facility/{{facility.guid}}/analysis/analysis-dashboard/water">
                                 <span class="badge rounded-pill bg-danger">
                                     <span class="fa fa-exclamation white"></span>
                                 </span>

--- a/src/app/data-evaluation/facility/facility-home/facility-home-summary/facility-home-summary.component.ts
+++ b/src/app/data-evaluation/facility/facility-home/facility-home-summary/facility-home-summary.component.ts
@@ -52,7 +52,7 @@ export class FacilityHomeSummaryComponent implements OnInit {
 
   navigateTo(urlStr: string) {
     if (urlStr != 'upload') {
-      this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.id + '/' + urlStr);
+      this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.guid + '/' + urlStr);
     } else {
       this.router.navigateByUrl('/data-management/' + this.facility.accountId + '/import-data');
     }

--- a/src/app/data-evaluation/facility/facility-home/facility-home.component.ts
+++ b/src/app/data-evaluation/facility/facility-home/facility-home.component.ts
@@ -99,7 +99,7 @@ export class FacilityHomeComponent implements OnInit {
 
 
   navigateToMeters() {
-    this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.id + '/utility');
+    this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.guid + '/utility');
   }
 
   setAnnualEnergyAnalysisSummary() {

--- a/src/app/data-evaluation/facility/facility-overview/facility-overview-banner/facility-overview-banner.component.ts
+++ b/src/app/data-evaluation/facility/facility-overview/facility-overview-banner/facility-overview-banner.component.ts
@@ -150,7 +150,7 @@ export class FacilityOverviewBannerComponent implements OnInit {
     let account: IdbAccount = this.accountDbService.selectedAccount.getValue();
     await this.dbChangesService.setAccountFacilityReports(account, this.selectedFacility);
     this.facilityReportDbService.selectedReport.next(this.facilityReport);
-    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/reports/setup');
+    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/reports/setup');
   }
 
   // date validation

--- a/src/app/data-evaluation/facility/facility-overview/facility-overview.component.ts
+++ b/src/app/data-evaluation/facility/facility-overview/facility-overview.component.ts
@@ -149,6 +149,6 @@ export class FacilityOverviewComponent implements OnInit {
 
   addUtilityData() {
     let selectedFacility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-    this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.id + '/utility');
+    this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility');
   }
 }

--- a/src/app/data-evaluation/facility/facility-reports/facility-reports-dashboard/facility-report-item-card/facility-report-item-card.component.ts
+++ b/src/app/data-evaluation/facility/facility-reports/facility-reports-dashboard/facility-report-item-card/facility-report-item-card.component.ts
@@ -52,7 +52,7 @@ export class FacilityReportItemCardComponent {
 
   selectReport() {
     this.facilityDbReportsService.selectedReport.next(this.report);
-    this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.id + '/reports/setup');
+    this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.guid + '/reports/setup');
   }
 
   async createCopy() {
@@ -67,7 +67,7 @@ export class FacilityReportItemCardComponent {
     this.facilityDbReportsService.selectedReport.next(addedReport);
     this.toastNotificationService.showToast('New Report Created', undefined, undefined, false, "alert-success");
     this.facilityDbReportsService.selectedReport.next(addedReport);
-    this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.id + '/reports/setup');
+    this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.guid + '/reports/setup');
   }
 
   deleteItem() {

--- a/src/app/data-evaluation/facility/facility-reports/facility-reports-dashboard/facility-reports-dashboard.component.ts
+++ b/src/app/data-evaluation/facility/facility-reports/facility-reports-dashboard/facility-reports-dashboard.component.ts
@@ -84,7 +84,7 @@ export class FacilityReportsDashboardComponent {
     this.facilityReportsDbService.selectedReport.next(addedReport);
     this.toastNotificationService.showToast('New Report Created', undefined, undefined, false, "alert-success");
     this.facilityReportsDbService.selectedReport.next(addedReport);
-    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/reports/setup');
+    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/reports/setup');
   }
 
 

--- a/src/app/data-evaluation/facility/facility-reports/facility-reports-tabs/facility-reports-tabs.component.ts
+++ b/src/app/data-evaluation/facility/facility-reports/facility-reports-tabs/facility-reports-tabs.component.ts
@@ -83,13 +83,13 @@ export class FacilityReportsTabsComponent {
 
   goToDashboard() {
     if (this.selectedReport.facilityReportType == 'analysis') {
-      this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.id + '/reports/dashboard/analysis');
+      this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.guid + '/reports/dashboard/analysis');
     }
     else if (this.selectedReport.facilityReportType == 'overview') {
-      this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.id + '/reports/dashboard/overview');
+      this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.guid + '/reports/dashboard/overview');
     }
     else if (this.selectedReport.facilityReportType == 'emissionFactors') {
-      this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.id + '/reports/dashboard/emission-factors');
+      this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.guid + '/reports/dashboard/emission-factors');
     }
   }
 
@@ -122,7 +122,7 @@ export class FacilityReportsTabsComponent {
   selectItem(item: IdbFacilityReport) {
     this.facilityReportsDbService.selectedReport.next(item);
     let facility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-    this.router.navigateByUrl('/data-evaluation/facility/' + facility.id + '/reports/setup');
+    this.router.navigateByUrl('/data-evaluation/facility/' + facility.guid + '/reports/setup');
     this.showDropdown = false;
   }
 

--- a/src/app/data-evaluation/facility/facility-reports/facility-reports.component.ts
+++ b/src/app/data-evaluation/facility/facility-reports/facility-reports.component.ts
@@ -34,6 +34,6 @@ export class FacilityReportsComponent {
 
   goToUtilityData() {
     let selectedFacility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-    this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.id + '/utility')
+    this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility')
   }
 }

--- a/src/app/data-evaluation/facility/facility.component.ts
+++ b/src/app/data-evaluation/facility/facility.component.ts
@@ -28,9 +28,9 @@ export class FacilityComponent implements OnInit {
       this.selectedFacility = val;
     });
     this.activatedRoute.params.subscribe(params => {
-      let facilityId: number = parseInt(params['id']);
+      let facilityId: string = params['id'];
       let facilities: Array<IdbFacility> = this.facilityDbService.accountFacilities.getValue();
-      let selectedFacility: IdbFacility = facilities.find(facility => { return facility.id == facilityId });
+      let selectedFacility: IdbFacility = facilities.find(facility => { return facility.guid == facilityId });
       if (selectedFacility) {
         this.dbChangesService.selectFacility(selectedFacility);
       } else {

--- a/src/app/data-evaluation/facility/utility-data/calanderization/calanderization.component.ts
+++ b/src/app/data-evaluation/facility/utility-data/calanderization/calanderization.component.ts
@@ -59,6 +59,6 @@ export class CalanderizationComponent implements OnInit {
 
   addMeter() {
     let selectedFacility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-    this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.id + '/utility/energy-consumption/energy-source/new-meter');
+    this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility/energy-consumption/energy-source/new-meter');
   }
 }

--- a/src/app/data-evaluation/facility/utility-data/energy-consumption/energy-consumption.component.html
+++ b/src/app/data-evaluation/facility/utility-data/energy-consumption/energy-consumption.component.html
@@ -5,7 +5,7 @@
                     <i class="fa fa-gauge-high"></i>
                     Meters</a></li>
             <li class="nav-item" *ngFor="let meter of utilityMeters">
-                <a class="nav-link" routerLink="utility-meter/{{meter.id}}" [routerLinkActive]="['active']">
+                <a class="nav-link" routerLink="utility-meter/{{meter.guid}}" [routerLinkActive]="['active']">
                     <i class="fa fa-file-invoice"></i>
                     {{meter.name}}
                     <i class="fa fa-exclamation-circle" *ngIf="meter.guid | invalidMeter: meterData"></i>

--- a/src/app/data-evaluation/facility/utility-data/energy-consumption/utility-meter-data/utility-meter-data.component.ts
+++ b/src/app/data-evaluation/facility/utility-data/energy-consumption/utility-meter-data/utility-meter-data.component.ts
@@ -24,9 +24,9 @@ export class UtilityMeterDataComponent implements OnInit {
 
   ngOnInit() {
     this.activatedRoute.params.subscribe(params => {
-      let meterId: number = parseInt(params['id']);
+      let meterId: string = params['id'];
       let facilityMeters: Array<IdbUtilityMeter> = this.utilityMeterDbService.facilityMeters.getValue();
-      this.selectedMeter = facilityMeters.find(meter => { return meter.id == meterId });
+      this.selectedMeter = facilityMeters.find(meter => { return meter.guid == meterId });
     });
     this.routerSub = this.router.events.subscribe(event => {
       if (event instanceof NavigationEnd) {

--- a/src/app/data-evaluation/facility/utility-data/predictors/edit-predictor/edit-predictor.component.ts
+++ b/src/app/data-evaluation/facility/utility-data/predictors/edit-predictor/edit-predictor.component.ts
@@ -94,7 +94,7 @@ export class EditPredictorComponent {
   }
 
   cancel() {
-    this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.id + '/utility/predictors/manage/predictor-table')
+    this.router.navigateByUrl('/data-evaluation/facility/' + this.facility.guid + '/utility/predictors/manage/predictor-table')
   }
 
   async saveChanges() {

--- a/src/app/data-evaluation/facility/utility-data/predictors/predictors-data/calculated-predictor-data-update/calculated-predictor-data-update.component.ts
+++ b/src/app/data-evaluation/facility/utility-data/predictors/predictors-data/calculated-predictor-data-update/calculated-predictor-data-update.component.ts
@@ -296,7 +296,7 @@ export class CalculatedPredictorDataUpdateComponent {
 
   cancel() {
     let selectedFacility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-    this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.id + '/utility/predictors/predictor/' + this.predictor.guid)
+    this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility/predictors/predictor/' + this.predictor.guid)
   }
 
   async updateEntries() {

--- a/src/app/data-evaluation/facility/utility-data/predictors/predictors-data/predictors-data-form/predictors-data-form.component.ts
+++ b/src/app/data-evaluation/facility/utility-data/predictors/predictors-data/predictors-data-form/predictors-data-form.component.ts
@@ -60,7 +60,7 @@ export class PredictorsDataFormComponent {
 
   cancel() {
     let selectedFacility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-    this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.id + '/utility/predictors/predictor/' + this.predictor.guid)
+    this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility/predictors/predictor/' + this.predictor.guid)
   }
 
   async saveChanges() {

--- a/src/app/data-evaluation/sidebar/sidebar.component.html
+++ b/src/app/data-evaluation/sidebar/sidebar.component.html
@@ -47,7 +47,7 @@
         <div *ngFor="let facility of facilityList | facilityList:(showAllFacilities && sidebarOpen); let index = index;"
             [ngClass]="{'open': sidebarOpen, 'not-open': !sidebarOpen}" (mouseenter)="setHoverIndex(index)"
             (mouseleave)="setHoverIndex(undefined)">
-            <a title="Facility Home" class="nav-link" routerLink="/data-evaluation/facility/{{facility.id}}"
+            <a title="Facility Home" class="nav-link" routerLink="/data-evaluation/facility/{{facility.guid}}"
                 [routerLinkActive]="['active-head']"><i class="fa fa-industry" [ngStyle]="{color: facility.color}"></i>
                 <span [hidden]="!sidebarOpen" class="ps-2 nav-label">
                     {{facility.guid | facilityName}}
@@ -55,31 +55,31 @@
             </a>
             <div class="d-flex icon-row"
                 [ngClass]="{'flex-column not-open': !sidebarOpen, 'icon-row': sidebarOpen, 'hidden': url|hideFacilityLinks:index:sidebarOpen:showAllFacilities:hoverIndex:selectedFacility:facility.guid}">
-                <a title="Facility Home" class="nav-link" routerLink="/data-evaluation/facility/{{facility.id}}/home"
+                <a title="Facility Home" class="nav-link" routerLink="/data-evaluation/facility/{{facility.guid}}/home"
                     [routerLinkActive]="['active']"><i class="fa fa-home"></i>
                 </a>
                 <a title="Facility Utility Data" class="nav-link"
-                    routerLink="/data-evaluation/facility/{{facility.id}}/utility" [routerLinkActive]="['active']"><i
+                    routerLink="/data-evaluation/facility/{{facility.guid}}/utility" [routerLinkActive]="['active']"><i
                         class="fa fa-book"></i>
                 </a>
                 <a title="Facility Overview" class="nav-link"
-                    routerLink="/data-evaluation/facility/{{facility.id}}/overview" [routerLinkActive]="['active']"><i
+                    routerLink="/data-evaluation/facility/{{facility.guid}}/overview" [routerLinkActive]="['active']"><i
                         class="fa fa-chart-column"></i>
                 </a>
                 <a title="Facility Data Visualization" class="nav-link"
-                    routerLink="/data-evaluation/facility/{{facility.id}}/visualization"
+                    routerLink="/data-evaluation/facility/{{facility.guid}}/visualization"
                     [routerLinkActive]="['active']"><i class="fa fa-chart-line"></i>
                 </a>
                 <a title="Facility Analysis" class="nav-link"
-                    routerLink="/data-evaluation/facility/{{facility.id}}/analysis" [routerLinkActive]="['active']"><i
+                    routerLink="/data-evaluation/facility/{{facility.guid}}/analysis" [routerLinkActive]="['active']"><i
                         class="fa fa-microscope"></i>
                 </a>
                 <a title="Facility Analysis" class="nav-link"
-                    routerLink="/data-evaluation/facility/{{facility.id}}/reports" [routerLinkActive]="['active']"><i
+                    routerLink="/data-evaluation/facility/{{facility.guid}}/reports" [routerLinkActive]="['active']"><i
                         class="fa fa-folder"></i>
                 </a>
                 <a title="Facility Settings" class="nav-link"
-                    routerLink="/data-evaluation/facility/{{facility.id}}/settings" [routerLinkActive]="['active']"><i
+                    routerLink="/data-evaluation/facility/{{facility.guid}}/settings" [routerLinkActive]="['active']"><i
                         class="fa fa-cog"></i>
                 </a>
             </div>

--- a/src/app/shared/data-overview/facilities-usage-table/facilities-usage-table.component.ts
+++ b/src/app/shared/data-overview/facilities-usage-table/facilities-usage-table.component.ts
@@ -51,7 +51,7 @@ export class FacilitiesUsageTableComponent {
   }
 
   selectFacility(facility: IdbFacility) {
-    this.router.navigateByUrl('/data-evaluation/facility/' + facility.id);
+    this.router.navigateByUrl('/data-evaluation/facility/' + facility.guid);
   }
 
   setOrderBy() {

--- a/src/app/shared/shared-meter-content/edit-bill/edit-bill.component.ts
+++ b/src/app/shared/shared-meter-content/edit-bill/edit-bill.component.ts
@@ -50,41 +50,21 @@ export class EditBillComponent implements OnInit {
     this.isElectron = this.electronService.isElectron;
     this.paramsSub = this.activatedRoute.parent.params.subscribe(parentParams => {
       let accountMeters: Array<IdbUtilityMeter> = this.utilityMeterDbService.accountMeters.getValue();
-      if (this.inDataManagement) {
-        let meterId: string = parentParams['id'];
-        this.editMeter = accountMeters.find(meter => { return meter.guid == meterId });
-      } else {
-        let meterId: number = parseInt(parentParams['id']);
-        this.editMeter = accountMeters.find(meter => { return meter.id == meterId });
-      }
+      let meterId: string = parentParams['id'];
+      this.editMeter = accountMeters.find(meter => { return meter.guid == meterId });
       this.setDisplayHeatCapacity();
       this.activatedRoute.params.subscribe(params => {
-        if (this.inDataManagement) {
-          let meterReadingId: string = params['id'];
-          if (meterReadingId) {
-            //existing reading
-            this.addOrEdit = 'edit';
-            let accountMeterData: Array<IdbUtilityMeterData> = this.utilityMeterDataDbService.accountMeterData.getValue();
-            this.editMeterData = accountMeterData.find(data => { return data.guid == meterReadingId });
-          } else {
-            //new Reading
-            let accountMeterData: Array<IdbUtilityMeterData> = this.utilityMeterDataDbService.accountMeterData.getValue();
-            this.editMeterData = getNewIdbUtilityMeterData(this.editMeter, accountMeterData);
-            this.addOrEdit = 'add';
-          }
+        let meterReadingId: string = params['id'];
+        if (meterReadingId) {
+          //existing reading
+          this.addOrEdit = 'edit';
+          let accountMeterData: Array<IdbUtilityMeterData> = this.utilityMeterDataDbService.accountMeterData.getValue();
+          this.editMeterData = accountMeterData.find(data => { return data.guid == meterReadingId });
         } else {
-          let meterReadingId: number = parseInt(params['id']);
-          if (meterReadingId) {
-            //existing reading
-            this.addOrEdit = 'edit';
-            let accountMeterData: Array<IdbUtilityMeterData> = this.utilityMeterDataDbService.accountMeterData.getValue();
-            this.editMeterData = accountMeterData.find(data => { return data.id == meterReadingId });
-          } else {
-            //new Reading
-            let accountMeterData: Array<IdbUtilityMeterData> = this.utilityMeterDataDbService.accountMeterData.getValue();
-            this.editMeterData = getNewIdbUtilityMeterData(this.editMeter, accountMeterData);
-            this.addOrEdit = 'add';
-          }
+          //new Reading
+          let accountMeterData: Array<IdbUtilityMeterData> = this.utilityMeterDataDbService.accountMeterData.getValue();
+          this.editMeterData = getNewIdbUtilityMeterData(this.editMeter, accountMeterData);
+          this.addOrEdit = 'add';
         }
         if (this.editMeterData) {
           this.setMeterDataForm();
@@ -106,7 +86,7 @@ export class EditBillComponent implements OnInit {
     if (this.inDataManagement) {
       this.router.navigateByUrl('/data-management/' + this.editMeter.accountId + '/facilities/' + this.editMeter.facilityId + '/meters/' + this.editMeter.guid + '/meter-data');
     } else {
-      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility/energy-consumption/utility-meter/' + this.editMeter.id + '/data-table');
+      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility/energy-consumption/utility-meter/' + this.editMeter.guid + '/data-table');
     }
   }
 

--- a/src/app/shared/shared-meter-content/edit-bill/edit-bill.component.ts
+++ b/src/app/shared/shared-meter-content/edit-bill/edit-bill.component.ts
@@ -106,7 +106,7 @@ export class EditBillComponent implements OnInit {
     if (this.inDataManagement) {
       this.router.navigateByUrl('/data-management/' + this.editMeter.accountId + '/facilities/' + this.editMeter.facilityId + '/meters/' + this.editMeter.guid + '/meter-data');
     } else {
-      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.id + '/utility/energy-consumption/utility-meter/' + this.editMeter.id + '/data-table');
+      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility/energy-consumption/utility-meter/' + this.editMeter.id + '/data-table');
     }
   }
 

--- a/src/app/shared/shared-meter-content/edit-meter/edit-meter.component.ts
+++ b/src/app/shared/shared-meter-content/edit-meter/edit-meter.component.ts
@@ -100,7 +100,7 @@ export class EditMeterComponent implements OnInit {
 
   cancel() {
     let selectedFacility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-    this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.id + '/utility/energy-consumption/energy-source/meters')
+    this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility/energy-consumption/energy-source/meters')
   }
 
   async updateMeterData(meter: IdbUtilityMeter) {

--- a/src/app/shared/shared-meter-content/meter-data/meter-data-table/meter-data-table.component.ts
+++ b/src/app/shared/shared-meter-content/meter-data/meter-data-table/meter-data-table.component.ts
@@ -171,7 +171,7 @@ export class MeterDataTableComponent {
     if (this.inDataManagement) {
       this.router.navigateByUrl('/data-management/' + this.selectedMeter.accountId + '/facilities/' + this.selectedMeter.facilityId + '/meters/' + this.selectedMeter.guid + '/meter-data/new-bill');
     } else {
-      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.id + '/utility/energy-consumption/utility-meter/' + this.selectedMeter.id + '/new-bill');
+      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility/energy-consumption/utility-meter/' + this.selectedMeter.id + '/new-bill');
     }
   }
 
@@ -181,7 +181,7 @@ export class MeterDataTableComponent {
     if (this.inDataManagement) {
       this.router.navigateByUrl('/data-management/' + this.selectedMeter.accountId + '/facilities/' + this.selectedMeter.facilityId + '/meters/' + this.selectedMeter.guid + '/meter-data/edit-bill/' + meterData.guid);
     } else {
-      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.id + '/utility/energy-consumption/utility-meter/' + this.selectedMeter.id + '/edit-bill/' + meterData.id);
+      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility/energy-consumption/utility-meter/' + this.selectedMeter.id + '/edit-bill/' + meterData.id);
     }
   }
 

--- a/src/app/shared/shared-meter-content/meter-data/meter-data-table/meter-data-table.component.ts
+++ b/src/app/shared/shared-meter-content/meter-data/meter-data-table/meter-data-table.component.ts
@@ -57,16 +57,10 @@ export class MeterDataTableComponent {
   ngOnInit(): void {
     this.setInDataManagement();
     this.paramsSub = this.activatedRoute.parent.params.subscribe(params => {
-      //TODO: update for int
       this.showFilterDropdown = false;
       this.facilityMeters = this.utilityMeterDbService.facilityMeters.getValue();
-      if (this.inDataManagement) {
-        let meterId: string = params['id'];
-        this.selectedMeter = this.facilityMeters.find(meter => { return meter.guid == meterId });
-      } else {
-        let meterId: number = parseInt(params['id']);
-        this.selectedMeter = this.facilityMeters.find(meter => { return meter.id == meterId });
-      }
+      let meterId: string = params['id'];
+      this.selectedMeter = this.facilityMeters.find(meter => { return meter.guid == meterId });
       this.setData();
     });
 
@@ -171,7 +165,7 @@ export class MeterDataTableComponent {
     if (this.inDataManagement) {
       this.router.navigateByUrl('/data-management/' + this.selectedMeter.accountId + '/facilities/' + this.selectedMeter.facilityId + '/meters/' + this.selectedMeter.guid + '/meter-data/new-bill');
     } else {
-      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility/energy-consumption/utility-meter/' + this.selectedMeter.id + '/new-bill');
+      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility/energy-consumption/utility-meter/' + this.selectedMeter.guid + '/new-bill');
     }
   }
 
@@ -181,7 +175,7 @@ export class MeterDataTableComponent {
     if (this.inDataManagement) {
       this.router.navigateByUrl('/data-management/' + this.selectedMeter.accountId + '/facilities/' + this.selectedMeter.facilityId + '/meters/' + this.selectedMeter.guid + '/meter-data/edit-bill/' + meterData.guid);
     } else {
-      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility/energy-consumption/utility-meter/' + this.selectedMeter.id + '/edit-bill/' + meterData.id);
+      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility/energy-consumption/utility-meter/' + this.selectedMeter.guid + '/edit-bill/' + meterData.guid);
     }
   }
 
@@ -189,8 +183,8 @@ export class MeterDataTableComponent {
     this.showFilterDropdown = !this.showFilterDropdown;
   }
 
-  goToDataQualityReport(){
-          this.router.navigateByUrl('/data-management/' + this.selectedMeter.accountId + '/facilities/' + this.selectedMeter.facilityId + '/meters/' + this.selectedMeter.guid + '/data-quality-report');
+  goToDataQualityReport() {
+    this.router.navigateByUrl('/data-management/' + this.selectedMeter.accountId + '/facilities/' + this.selectedMeter.facilityId + '/meters/' + this.selectedMeter.guid + '/data-quality-report');
 
   }
 }

--- a/src/app/shared/shared-meter-content/shared-meter-calendarization/shared-meter-calendarization.component.ts
+++ b/src/app/shared/shared-meter-content/shared-meter-calendarization/shared-meter-calendarization.component.ts
@@ -277,7 +277,7 @@ export class SharedMeterCalendarizationComponent {
       this.router.navigateByUrl('/data-management/' + this.selectedMeter.accountId + '/facilities/' + this.selectedMeter.facilityId + '/meters/' + this.selectedMeter.guid + '/meter-data/new-bill');
     } else {
       let facility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-      this.router.navigateByUrl('/data-evaluation/facility/' + facility.id + '/utility/energy-consumption/utility-meter/' + this.selectedMeter.id + '/new-bill');
+      this.router.navigateByUrl('/data-evaluation/facility/' + facility.guid + '/utility/energy-consumption/utility-meter/' + this.selectedMeter.id + '/new-bill');
     }
   }
 }

--- a/src/app/shared/shared-meter-content/shared-meter-calendarization/shared-meter-calendarization.component.ts
+++ b/src/app/shared/shared-meter-content/shared-meter-calendarization/shared-meter-calendarization.component.ts
@@ -277,7 +277,7 @@ export class SharedMeterCalendarizationComponent {
       this.router.navigateByUrl('/data-management/' + this.selectedMeter.accountId + '/facilities/' + this.selectedMeter.facilityId + '/meters/' + this.selectedMeter.guid + '/meter-data/new-bill');
     } else {
       let facility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-      this.router.navigateByUrl('/data-evaluation/facility/' + facility.guid + '/utility/energy-consumption/utility-meter/' + this.selectedMeter.id + '/new-bill');
+      this.router.navigateByUrl('/data-evaluation/facility/' + facility.guid + '/utility/energy-consumption/utility-meter/' + this.selectedMeter.guid + '/new-bill');
     }
   }
 }

--- a/src/app/shared/shared-meter-content/utility-meters-table/utility-meters-table.component.ts
+++ b/src/app/shared/shared-meter-content/utility-meters-table/utility-meters-table.component.ts
@@ -78,7 +78,7 @@ export class UtilityMetersTableComponent implements OnInit {
   }
 
   addMeter() {
-    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/utility/energy-consumption/energy-source/new-meter');
+    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/utility/energy-consumption/energy-source/new-meter');
   }
 
 
@@ -161,7 +161,7 @@ export class UtilityMetersTableComponent implements OnInit {
   }
 
   selectEditMeter(meter: IdbUtilityMeter) {
-    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/utility/energy-consumption/energy-source/edit-meter/' + meter.guid);
+    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/utility/energy-consumption/energy-source/edit-meter/' + meter.guid);
   }
 
   async createCopy(meter: IdbUtilityMeter) {

--- a/src/app/shared/shared-predictors-content/calculated-predictor-data-update/calculated-predictor-data-update.component.ts
+++ b/src/app/shared/shared-predictors-content/calculated-predictor-data-update/calculated-predictor-data-update.component.ts
@@ -296,7 +296,7 @@ export class CalculatedPredictorDataUpdateComponent {
       this.router.navigateByUrl('/data-management/' + this.predictor.accountId + '/facilities/' + this.predictor.facilityId + '/predictors/' + this.predictor.guid + '/predictor-data')
     } else {
       let selectedFacility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.id + '/utility/predictors/predictor/' + this.predictor.guid)
+      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility/predictors/predictor/' + this.predictor.guid)
     }
   }
 

--- a/src/app/shared/shared-predictors-content/predictor-table/predictor-table.component.ts
+++ b/src/app/shared/shared-predictors-content/predictor-table/predictor-table.component.ts
@@ -147,7 +147,7 @@ export class PredictorTableComponent {
       await this.dbChangesService.setPredictorsV2(account, facility);
       this.router.navigateByUrl('/data-management/' + predictor.accountId + '/facilities/' + predictor.facilityId + '/predictors/' + predictor.guid);
     } else {
-      this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/utility/predictors/manage/edit-predictor/' + predictor.guid);
+      this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/utility/predictors/manage/edit-predictor/' + predictor.guid);
     }
   }
 
@@ -165,7 +165,7 @@ export class PredictorTableComponent {
       this.toastNotificationService.showToast('New Predictor Added!', undefined, undefined, false, 'alert-success');
       this.selectEditPredictor(newPredictor);
     } else {
-      this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/utility/predictors/manage/add-predictor');
+      this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/utility/predictors/manage/add-predictor');
     }
   }
 
@@ -277,7 +277,7 @@ export class PredictorTableComponent {
     await this.dbChangesService.setPredictorsV2(account);
     await this.dbChangesService.setPredictorDataV2(account)
     await this.dbChangesService.selectFacility(facility);
-    this.router.navigateByUrl('/data-evaluation/facility/' + facility.id + '/utility/predictors/manage/predictor-table');
+    this.router.navigateByUrl('/data-evaluation/facility/' + facility.guid + '/utility/predictors/manage/predictor-table');
   }
 
   setPredictors(facilityPredictors: Array<IdbPredictor>) {

--- a/src/app/shared/shared-predictors-content/predictors-data-table/predictors-data-table.component.ts
+++ b/src/app/shared/shared-predictors-content/predictors-data-table/predictors-data-table.component.ts
@@ -137,7 +137,7 @@ export class PredictorsDataTableComponent {
       this.toastNotificationService.showToast('Predictor Added!', undefined, undefined, false, 'alert-success');
       this.setEditPredictorData(newEntry);
     } else {
-      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.id + '/utility/predictors/predictor/' + this.predictor.guid + '/add-entry');
+      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility/predictors/predictor/' + this.predictor.guid + '/add-entry');
     }
   }
 
@@ -162,7 +162,7 @@ export class PredictorsDataTableComponent {
       this.router.navigateByUrl('data-management/' + predictorEntry.accountId + '/facilities/' + predictorEntry.facilityId + '/predictors/' + predictorEntry.predictorId + '/predictor-data/edit-entry/' + predictorEntry.guid);
     } else {
       let selectedFacility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.id + '/utility/predictors/predictor/' + this.predictor.guid + '/edit-entry/' + predictorEntry.guid);
+      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility/predictors/predictor/' + this.predictor.guid + '/edit-entry/' + predictorEntry.guid);
     }
   }
 
@@ -321,7 +321,7 @@ export class PredictorsDataTableComponent {
       this.router.navigateByUrl('data-management/' + this.predictor.accountId + '/facilities/' + this.predictor.facilityId + '/predictors/' + this.predictor.guid + '/predictor-data/update-calculated-entries');
     } else {
       let selectedFacility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.id + '/utility/predictors/predictor/' + this.predictor.guid + '/update-calculated-entries');
+      this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility/predictors/predictor/' + this.predictor.guid + '/update-calculated-entries');
     }
 
   }

--- a/src/app/weather-data/weather-data.component.ts
+++ b/src/app/weather-data/weather-data.component.ts
@@ -218,7 +218,7 @@ export class WeatherDataComponent {
       if (this.router.url.includes('data-management')) {
         this.router.navigateByUrl('data-management/' + this.selectedFacility.accountId + '/facilities/' + this.selectedFacility.guid + '/predictors');
       } else {
-        this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.id + '/utility/predictors/manage/predictor-table');
+        this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/utility/predictors/manage/predictor-table');
       }
     } else {
       this.toastNotificationService.weatherDataErrorToast();


### PR DESCRIPTION
connects #2019 

updates analytics events to strip guid and cleanup rollup of analytics page views

all navigation uses guid instead of int IDs