### PR TITLE
Issue 2051: add validation for read date max and min in meter readings

### DIFF
--- a/src/app/shared/customFormValidators.ts
+++ b/src/app/shared/customFormValidators.ts
@@ -1,0 +1,20 @@
+import { AbstractControl, ValidatorFn } from '@angular/forms';
+
+export function maxDateValidator(): ValidatorFn {
+    let maxDate: Date = new Date();
+    maxDate.setFullYear(maxDate.getFullYear() + 10);
+    return (control: AbstractControl) => {
+        if (!control.value) return null;
+        const inputDate = new Date(control.value);
+        return inputDate > maxDate ? { maxDate: true } : null;
+    };
+}
+export function minDateValidator(): ValidatorFn {
+    let minDate: Date = new Date();
+    minDate.setFullYear(minDate.getFullYear() - 30);
+    return (control: AbstractControl) => {
+        if (!control.value) return null;
+        const inputDate = new Date(control.value);
+        return inputDate < minDate ? { minDate: true } : null;
+    };
+}

--- a/src/app/shared/shared-meter-content/edit-bill/edit-electricity-bill/edit-electricity-bill.component.html
+++ b/src/app/shared/shared-meter-content/edit-bill/edit-electricity-bill/edit-electricity-bill.component.html
@@ -13,6 +13,12 @@
           </div>
           <div class="alert alert-danger" *ngIf="meterDataForm.get('readDate').hasError('required')">Meter read date is
             required</div>
+          <div class="alert alert-danger" *ngIf="meterDataForm.get('readDate').hasError('maxDate')">Meter read date
+            exceeds
+            maximum read date.</div>
+          <div class="alert alert-danger" *ngIf="meterDataForm.get('readDate').hasError('minDate')">Meter read date is
+            before
+            minimum read date.</div>
           <div class="alert alert-danger" *ngIf="invalidDate">Meter already has data entered for selected date</div>
         </div>
         <div class="col-6">

--- a/src/app/shared/shared-meter-content/edit-bill/edit-electricity-bill/edit-electricity-bill.component.ts
+++ b/src/app/shared/shared-meter-content/edit-bill/edit-electricity-bill/edit-electricity-bill.component.ts
@@ -65,6 +65,7 @@ export class EditElectricityBillComponent implements OnInit {
         this.invalidDate = checkMeterReadingExistForDate(this.meterDataForm.controls.readDate.value, this.editMeter, accountMeterData) != undefined;
       }
     }
+    console.log(this.meterDataForm.controls.readDate)
   }
 
   setTotalEmissions() {

--- a/src/app/shared/shared-meter-content/edit-bill/edit-other-emissions-bill/edit-other-emissions-bill.component.html
+++ b/src/app/shared/shared-meter-content/edit-bill/edit-other-emissions-bill/edit-other-emissions-bill.component.html
@@ -11,6 +11,12 @@
             <div class="alert alert-danger" *ngIf="meterDataForm.get('readDate').hasError('required')">Meter read date
                 is
                 required</div>
+            <div class="alert alert-danger" *ngIf="meterDataForm.get('readDate').hasError('maxDate')">Meter read date
+                exceeds
+                maximum read date.</div>
+            <div class="alert alert-danger" *ngIf="meterDataForm.get('readDate').hasError('minDate')">Meter read date is
+                before
+                minimum read date.</div>
             <div class="alert alert-danger" *ngIf="invalidDate">Meter already has data entered for selected date</div>
         </div>
         <div class="col-6">

--- a/src/app/shared/shared-meter-content/edit-bill/edit-utility-bill/edit-utility-bill.component.html
+++ b/src/app/shared/shared-meter-content/edit-bill/edit-utility-bill/edit-utility-bill.component.html
@@ -10,6 +10,10 @@
       </div>
       <div class="alert alert-danger" *ngIf="meterDataForm.get('readDate').hasError('required')">Meter read date is
         required</div>
+      <div class="alert alert-danger" *ngIf="meterDataForm.get('readDate').hasError('maxDate')">Meter read date exceeds
+        maximum read date.</div>
+      <div class="alert alert-danger" *ngIf="meterDataForm.get('readDate').hasError('minDate')">Meter read date is before
+        minimum read date.</div>
       <div class="alert alert-danger" *ngIf="invalidDate">Meter already has data entered for selected date</div>
     </div>
     <div class="col-6">
@@ -86,40 +90,40 @@
         <div class="col-md-6 col-sm-12">
           <table class="table table-sm table-bordered">
             <tbody>
-                <tr *ngIf="!isBiofuel">
-                    <th>
-                        Carbon Emissions
-                    </th>
-                    <td>
-                        {{emissionsResults.stationaryCarbonEmissions| number:'1.0-2'}} tonne CO<sub>2</sub>e
-                    </td>
-                </tr>
-                <tr *ngIf="isBiofuel">
-                    <th>
-                        Biogenic Emissions
-                    </th>
-                    <td>
-                        {{emissionsResults.stationaryBiogenicEmmissions| number:'1.0-2'}} tonne CO<sub>2</sub>e
-                    </td>
-                </tr>
-                <tr>
-                    <th>
-                        Other Emissions
-                    </th>
-                    <td>
-                        {{emissionsResults.stationaryOtherEmissions| number:'1.0-2'}} tonne CO<sub>2</sub>e
-                    </td>
-                </tr>
-                <tr>
-                    <th>
-                        Total Emissions
-                    </th>
-                    <td>
-                        {{emissionsResults.stationaryEmissions| number:'1.0-2'}} tonne CO<sub>2</sub>e
-                    </td>
-                </tr>
+              <tr *ngIf="!isBiofuel">
+                <th>
+                  Carbon Emissions
+                </th>
+                <td>
+                  {{emissionsResults.stationaryCarbonEmissions| number:'1.0-2'}} tonne CO<sub>2</sub>e
+                </td>
+              </tr>
+              <tr *ngIf="isBiofuel">
+                <th>
+                  Biogenic Emissions
+                </th>
+                <td>
+                  {{emissionsResults.stationaryBiogenicEmmissions| number:'1.0-2'}} tonne CO<sub>2</sub>e
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  Other Emissions
+                </th>
+                <td>
+                  {{emissionsResults.stationaryOtherEmissions| number:'1.0-2'}} tonne CO<sub>2</sub>e
+                </td>
+              </tr>
+              <tr>
+                <th>
+                  Total Emissions
+                </th>
+                <td>
+                  {{emissionsResults.stationaryEmissions| number:'1.0-2'}} tonne CO<sub>2</sub>e
+                </td>
+              </tr>
             </tbody>
-        </table>
+          </table>
         </div>
       </ng-container>
       <ng-container *ngIf="showScope2OtherEmissions">

--- a/src/app/shared/shared-meter-content/edit-bill/edit-vehicle-meter-bill/edit-vehicle-meter-bill.component.html
+++ b/src/app/shared/shared-meter-content/edit-bill/edit-vehicle-meter-bill/edit-vehicle-meter-bill.component.html
@@ -11,6 +11,12 @@
             <div class="alert alert-danger" *ngIf="meterDataForm.get('readDate').hasError('required')">Meter read date
                 is
                 required</div>
+            <div class="alert alert-danger" *ngIf="meterDataForm.get('readDate').hasError('maxDate')">Meter read date
+                exceeds
+                maximum read date.</div>
+            <div class="alert alert-danger" *ngIf="meterDataForm.get('readDate').hasError('minDate')">Meter read date is
+                before
+                minimum read date.</div>
             <div class="alert alert-danger" *ngIf="invalidDate">Meter already has data entered for selected date</div>
         </div>
         <div class="col-6">

--- a/src/app/shared/shared-meter-content/utility-meter-data.service.ts
+++ b/src/app/shared/shared-meter-content/utility-meter-data.service.ts
@@ -7,6 +7,7 @@ import { ElectricityDataFilters, EmissionsFilters, GeneralInformationFilters, Ge
 import * as _ from 'lodash';
 import { IdbUtilityMeterData } from 'src/app/models/idbModels/utilityMeterData';
 import { MeterSource } from 'src/app/models/constantsAndTypes';
+import { maxDateValidator, minDateValidator } from '../customFormValidators';
 
 @Injectable({
   providedIn: 'root'
@@ -129,7 +130,7 @@ export class UtilityMeterDataService {
     }) : []);
 
     return this.formBuilder.group({
-      readDate: [dateString, Validators.required],
+      readDate: [dateString, [Validators.required, maxDateValidator(), minDateValidator()]],
       //ISSUE 1176: Validators.min(0) removed
       totalEnergyUse: [meterData.totalEnergyUse, [Validators.required]],
       totalCost: [meterData.totalCost, [Validators.min(0)]],
@@ -217,7 +218,7 @@ export class UtilityMeterDataService {
     }) : []);
 
     let form: FormGroup = this.formBuilder.group({
-      readDate: [dateString, Validators.required],
+      readDate: [dateString, [Validators.required, maxDateValidator(), minDateValidator()]],
       totalVolume: [meterData.totalVolume, totalVolumeValidators],
       totalEnergyUse: [meterData.totalEnergyUse, totalEnergyUseValidators],
       totalCost: [meterData.totalCost],

--- a/src/app/shared/shared-predictors-content/edit-predictor-form.service.ts
+++ b/src/app/shared/shared-predictors-content/edit-predictor-form.service.ts
@@ -11,7 +11,7 @@ export class EditPredictorFormService {
 
   getFormFromPredictor(predictor: IdbPredictor): FormGroup {
     let predictorForm: FormGroup = this.formBuilder.group({
-      'name': [predictor.name, [Validators.required]],
+      'name': [predictor.name, [Validators.required ]],
       'unit': [predictor.unit],
       'description': [predictor.description],
       'production': [predictor.production || false],


### PR DESCRIPTION
connects #2051 
This pull request introduces custom date validation for meter reading forms, ensuring that users cannot enter a meter read date that is either too far in the past or future. The changes add both backend form validation and corresponding user-facing error messages across various meter bill editing components.

**Form validation improvements:**

* Added new custom validators, `maxDateValidator` and `minDateValidator`, in `customFormValidators.ts` to restrict meter read dates to within the last 30 years and the next 10 years.
* Integrated these validators into the `readDate` field of meter data forms in `utility-meter-data.service.ts`, applying them to both electricity and other meter types. [[1]](diffhunk://#diff-8bbbcc724590bdc4bca999f93b19dd6fdb142bb9b9eba2f29da3a5a0e7ead848R10) [[2]](diffhunk://#diff-8bbbcc724590bdc4bca999f93b19dd6fdb142bb9b9eba2f29da3a5a0e7ead848L132-R133) [[3]](diffhunk://#diff-8bbbcc724590bdc4bca999f93b19dd6fdb142bb9b9eba2f29da3a5a0e7ead848L220-R221)

**User interface enhancements:**

* Updated all meter bill editing components to display specific error messages when the entered meter read date is before the minimum or after the maximum allowed date. [[1]](diffhunk://#diff-5686a33695d2f1c36b5d3fb5302102aea7041b47a1ef931e3bf0f708ae005c50R16-R21) [[2]](diffhunk://#diff-baf18d54899deff92aefa32e199542954aed88e826f9a3fc86b101aa130299d6R13-R16) [[3]](diffhunk://#diff-b58db322f13fbf440339b4aef45913c4bf55d81dfa039b07404e9643eb602227R14-R19) [[4]](diffhunk://#diff-2c95b93f7ddd2bfd087f16cfa7eb9ab126ced92efe82f69707a85df19483b57eR14-R19)
