### PR TITLE
Issue 2056 - added pagination to monthly tables. added copy table button to tables

### DIFF
--- a/src/app/data-evaluation/account/account-reports/account-savings-report/account-savings-report.component.html
+++ b/src/app/data-evaluation/account/account-reports/account-savings-report/account-savings-report.component.html
@@ -19,8 +19,7 @@
                     <app-annual-analysis-summary-table
                         *ngIf="annualAnalysisSummaries && annualAnalysisSummaries.length > 0 && accountSavingsReportSetup.includeAnnualResultsTable"
                         [latestMonthSummary]="latestMonthSummary" [annualAnalysisSummary]="annualAnalysisSummaries"
-                        [inReport]="true" [analysisItem]="selectedAnalysisItem" [accountOrFacility]="account"
-                        [printBlock]="'all'">
+                        [analysisItem]="selectedAnalysisItem" [accountOrFacility]="account" [printBlock]="'all'">
                     </app-annual-analysis-summary-table>
                     <app-annual-analysis-summary-graph
                         *ngIf="annualAnalysisSummaries && annualAnalysisSummaries.length > 0 && accountSavingsReportSetup.includeAnnualResultsGraph"
@@ -33,9 +32,12 @@
                     <h4>
                         Monthly Company Analysis
                     </h4>
+                    <div class="d-flex w-100 justify-content-end mb-2">
+                        <app-table-items-dropdown></app-table-items-dropdown>
+                    </div>
                     <div class="w-100 scroll-x">
                         <app-monthly-analysis-summary-table [monthlyAnalysisSummaryData]="monthlyAnalysisSummaryData"
-                            [analysisItem]="selectedAnalysisItem" [facilityOrAccount]="account" [inReport]="true"
+                            [analysisItem]="selectedAnalysisItem" [facilityOrAccount]="account"
                             [itemsPerPage]="itemsPerPage" [printBlock]="'all'">
                         </app-monthly-analysis-summary-table>
                     </div>
@@ -77,7 +79,7 @@
                         <div class="w-100 scroll-x">
                             <app-annual-analysis-summary-table
                                 *ngIf="summary.annualAnalysisSummaries && summary.annualAnalysisSummaries.length > 0 && accountSavingsReportSetup.includeFacilityResultsTable"
-                                [annualAnalysisSummary]="summary.annualAnalysisSummaries" [inReport]="true"
+                                [annualAnalysisSummary]="summary.annualAnalysisSummaries"
                                 [latestMonthSummary]="summary.latestMonthSummary" [analysisItem]="summary.analysisItem"
                                 [accountOrFacility]="summary.facility" [printBlock]="'all'">
                             </app-annual-analysis-summary-table>

--- a/src/app/data-evaluation/facility/facility-reports/report-results/facility-savings-report-results/facility-savings-report-results.component.html
+++ b/src/app/data-evaluation/facility/facility-reports/report-results/facility-savings-report-results/facility-savings-report-results.component.html
@@ -18,8 +18,7 @@
             <div class="scroll-x">
                 <app-annual-analysis-summary-table *ngIf="annualAnalysisSummaries"
                     [annualAnalysisSummary]="annualAnalysisSummaries" [analysisItem]="analysisItem"
-                    [latestMonthSummary]="latestMonthSummary" [accountOrFacility]="facility" [printBlock]="'all'"
-                    [inReport]="true">
+                    [latestMonthSummary]="latestMonthSummary" [accountOrFacility]="facility" [printBlock]="'all'">
                 </app-annual-analysis-summary-table>
             </div>
         </ng-container>
@@ -31,10 +30,13 @@
                     Monthly Facility Analysis
                 </h4>
             </div>
+            <div class="d-flex w-100 justify-content-end mb-2">
+                <app-table-items-dropdown></app-table-items-dropdown>
+            </div>
             <div class="scroll-x">
                 <app-monthly-analysis-summary-table [monthlyAnalysisSummaryData]="monthlyAnalysisSummaryData"
                     [analysisItem]="analysisItem" [facilityOrAccount]="facility" [itemsPerPage]="itemsPerPage"
-                    [printBlock]="'all'" [inReport]="true">
+                    [printBlock]="'all'">
                 </app-monthly-analysis-summary-table>
             </div>
         </ng-container>
@@ -102,7 +104,7 @@
                     <app-annual-analysis-summary-table *ngIf="annualAnalysisSummaries"
                         [annualAnalysisSummary]="groupSummary.annualAnalysisSummaryData" [analysisItem]="analysisItem"
                         [latestMonthSummary]="groupSummary.latestMonthGroupSummary" [accountOrFacility]="facility"
-                        [printBlock]="'all'" [inReport]="true" [group]="groupSummary.group">
+                        [printBlock]="'all'" [group]="groupSummary.group">
                     </app-annual-analysis-summary-table>
                 </div>
                 <hr>
@@ -118,11 +120,14 @@
                 </ng-container>
                 <ng-container
                     *ngIf="facilityReport.savingsReportSettings.groupMonthlyResults && facilityReport.savingsReportSettings.groupMonthlyResultsTable">
+                    <div class="d-flex w-100 justify-content-end mb-2">
+                        <app-table-items-dropdown></app-table-items-dropdown>
+                    </div>
                     <div class="scroll-x">
                         <app-monthly-analysis-summary-table
                             [monthlyAnalysisSummaryData]="groupSummary.monthlyAnalysisSummaryData"
                             [analysisItem]="analysisItem" [facilityOrAccount]="facility" [itemsPerPage]="itemsPerPage"
-                            [inReport]="true" [printBlock]="'all'">
+                            [printBlock]="'all'">
                         </app-monthly-analysis-summary-table>
                         <hr>
                     </div>

--- a/src/app/data-evaluation/facility/facility-reports/report-results/facility-savings-report-results/facility-savings-report-results.component.ts
+++ b/src/app/data-evaluation/facility/facility-reports/report-results/facility-savings-report-results/facility-savings-report-results.component.ts
@@ -17,7 +17,7 @@ import { CalanderizedMeter } from 'src/app/models/calanderization';
 import { IdbAccount } from 'src/app/models/idbModels/account';
 import { IdbAnalysisItem } from 'src/app/models/idbModels/analysisItem';
 import { IdbFacility } from 'src/app/models/idbModels/facility';
-import { IdbFacilityReport, SavingsFacilityReportSettings } from 'src/app/models/idbModels/facilityReport';
+import { IdbFacilityReport } from 'src/app/models/idbModels/facilityReport';
 import { IdbPredictor } from 'src/app/models/idbModels/predictor';
 import { IdbPredictorData } from 'src/app/models/idbModels/predictorData';
 import { IdbUtilityMeter } from 'src/app/models/idbModels/utilityMeter';

--- a/src/app/shared/table-items-dropdown/table-items-dropdown.component.ts
+++ b/src/app/shared/table-items-dropdown/table-items-dropdown.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { SharedDataService } from '../helper-services/shared-data.service';
+import { Subscription } from 'rxjs';
 
 @Component({
     selector: 'app-table-items-dropdown',
@@ -10,13 +11,20 @@ import { SharedDataService } from '../helper-services/shared-data.service';
 export class TableItemsDropdownComponent implements OnInit {
 
   itemsPerPage: number;
+  itemsPerPageSub: Subscription;
   constructor(private sharedDataService: SharedDataService) { }
 
   ngOnInit(): void {
-    this.itemsPerPage = this.sharedDataService.itemsPerPage.getValue();
+    this.itemsPerPageSub = this.sharedDataService.itemsPerPage.subscribe(val => {
+      this.itemsPerPage = val;
+    });
   }
 
   save(){
     this.sharedDataService.itemsPerPage.next(this.itemsPerPage);
+  }
+
+  ngOnDestroy() {
+    this.itemsPerPageSub.unsubscribe();
   }
 }


### PR DESCRIPTION
connects #2056 

This pull request updates the account and facility savings report components to improve table pagination controls and streamline input properties for summary tables. The most significant changes are the removal of the unnecessary `inReport` input from summary table components and the addition of a new dropdown component for selecting items per page, with improved subscription management.

**Pagination and UI improvements:**

* Added the new `app-table-items-dropdown` component to the monthly analysis summary sections in both `account-savings-report.component.html` and `facility-savings-report-results.component.html`, allowing users to select the number of items per page. 
