### PR TITLE
Issue 1214 - label change for year dropdown in case of Fiscal Year

### DIFF
--- a/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-menu/regression-model-menu.component.html
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-menu/regression-model-menu.component.html
@@ -166,8 +166,7 @@
             <div class="col-6">
                 <select required class="form-select" id="regressionModelYear" id="regressionModelYear"
                     [(ngModel)]="group.regressionModelYear" (change)="saveItem()" [disabled]="group.userDefinedModel">
-                    <option *ngFor="let year of yearOptions" [ngValue]="year">{{year |
-                        yearDisplay:selectedFacility.fiscalYear}}</option>
+                    <option *ngFor="let year of yearOptions" [ngValue]="year">{{year}}</option>
                 </select>
             </div>
         </div>


### PR DESCRIPTION
connects #1214 

This pull request makes a small update to the regression model selection menu in the UI. The change simplifies the year dropdown by removing the use of the `yearDisplay` pipe, so years are now shown as plain numbers instead of custom-formatted strings.