### PR TITLE
Issue 2098: Fix bulk update not updating predictors

### DIFF
--- a/src/app/shared/shared-predictors-content/calculated-predictor-data-update/calculated-predictor-data-update.component.ts
+++ b/src/app/shared/shared-predictors-content/calculated-predictor-data-update/calculated-predictor-data-update.component.ts
@@ -159,7 +159,6 @@ export class CalculatedPredictorDataUpdateComponent {
       }
       let predictorIndex: number = existingPredictorIndex[i];
       if (!this.predictorData[predictorIndex].weatherOverride && !this.predictorData[predictorIndex].updatedAmount) {
-        let stationId: string = this.predictor.weatherStationId;
         let entryDate: Date = new Date(this.predictorData[predictorIndex].date);
         let degreeDays: Array<DetailDegreeDay> | 'error' = await this.weatherDataService.getDegreeDaysForMonth(entryDate, this.predictor.weatherStationId, this.predictor.weatherStationName, this.predictor.heatingBaseTemperature, this.predictor.coolingBaseTemperature);
         // let degreeDays: 'error' | Array<DetailDegreeDay> = await this.degreeDaysService.getDailyDataFromMonth(entryDate.getMonth(), entryDate.getFullYear(), this.predictor.heatingBaseTemperature, this.predictor.coolingBaseTemperature, stationId);
@@ -306,6 +305,7 @@ export class CalculatedPredictorDataUpdateComponent {
     for (let i = 0; i < this.predictorData.length; i++) {
       let pData: CalculatedPredictorTableItem = this.predictorData[i];
       if (pData.changeAmount && !pData.added && !pData.deleted) {
+        pData.amount = pData.updatedAmount;
         delete pData.changeAmount;
         delete pData.updatedAmount;
         await firstValueFrom(this.predictorDataDbService.updateWithObservable(pData));


### PR DESCRIPTION
connects #2098 

This pull request introduces a minor update to how predictor data is handled in the `CalculatedPredictorDataUpdateComponent`. The main change ensures that when a predictor data item has a `changeAmount`, its `amount` is updated from `updatedAmount` before saving.

Data update logic improvements:

* When saving predictor data, the `amount` field is now set from `updatedAmount` if a change is detected, ensuring the correct value is persisted. (`src/app/shared/shared-predictors-content/calculated-predictor-data-update/calculated-predictor-data-update.component.ts`)