### PR TITLE
Issue 2055: Add warning for report year selection in facility analysis setup

### DIFF
--- a/src/app/data-evaluation/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.html
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.html
@@ -134,6 +134,12 @@
                         </select>
                     </div>
                 </div>
+                <div class="alert alert-warning text-center p-1" *ngIf="showReportYearWarning">
+                    This facility does not have 12 months of data for the selected report year
+                    ({{analysisItem.reportYear}}). An analysis is intended to be run with complete years only. To see
+                    mid-year progress, please run a <a class="click-link" (click)="goToSavingsReport()">"Savings
+                        Report"</a> for an analysis conducted with a different report year.
+                </div>
                 <div class="form-group row">
                     <label class="col-5 col-form-label">
                         Reporting Year
@@ -180,7 +186,8 @@
         </div>
     </form>
     <app-select-banked-analysis *ngIf="analysisItem.hasBanking" [facilityAnalysisItems]="facilityAnalysisItems"
-        [analysisItem]="analysisItem" [facility]="facility" (emitSave)="saveItem()" [disabled]="disableForm"></app-select-banked-analysis>
+        [analysisItem]="analysisItem" [facility]="facility" (emitSave)="saveItem()"
+        [disabled]="disableForm"></app-select-banked-analysis>
 
 
     <div class="row">

--- a/src/app/data-evaluation/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.ts
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.ts
@@ -5,7 +5,7 @@ import { FacilitydbService } from 'src/app/indexedDB/facility-db.service';
 import { EnergyUnitOptions, UnitOption } from 'src/app/shared/unitOptions';
 import * as _ from 'lodash';
 import { AnalysisService } from '../../analysis.service';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { DbChangesService } from 'src/app/indexedDB/db-changes.service';
 import { AccountdbService } from 'src/app/indexedDB/account-db.service';
 import { firstValueFrom, Subscription } from 'rxjs';
@@ -19,10 +19,10 @@ import { IdbAccount } from 'src/app/models/idbModels/account';
 import { IdbFacility } from 'src/app/models/idbModels/facility';
 import { IdbAnalysisItem } from 'src/app/models/idbModels/analysisItem';
 @Component({
-    selector: 'app-analysis-setup',
-    templateUrl: './analysis-setup.component.html',
-    styleUrls: ['./analysis-setup.component.css'],
-    standalone: false
+  selector: 'app-analysis-setup',
+  templateUrl: './analysis-setup.component.html',
+  styleUrls: ['./analysis-setup.component.css'],
+  standalone: false
 })
 export class AnalysisSetupComponent implements OnInit {
 
@@ -46,6 +46,7 @@ export class AnalysisSetupComponent implements OnInit {
 
   analysisItemSub: Subscription;
   isFormChange: boolean = false;
+  showReportYearWarning: boolean = false;
   constructor(private facilityDbService: FacilitydbService, private analysisDbService: AnalysisDbService,
     private analysisService: AnalysisService, private router: Router,
     private analysisValidationService: AnalysisValidationService,
@@ -53,24 +54,26 @@ export class AnalysisSetupComponent implements OnInit {
     private accountDbService: AccountdbService,
     private calanderizationService: CalanderizationService,
     private accountAnalysisDbService: AccountAnalysisDbService,
-    private regressionModelsService: RegressionModelsService) { }
+    private regressionModelsService: RegressionModelsService,
+    private activatedRoute: ActivatedRoute) { }
 
   ngOnInit(): void {
     this.analysisItemSub = this.analysisDbService.selectedAnalysisItem.subscribe(item => {
-      if(!this.isFormChange){
+      if (!this.isFormChange) {
         this.analysisItem = item;
         this.facility = this.facilityDbService.selectedFacility.getValue();
         this.yearOptions = this.calanderizationService.getYearOptionsFacility(this.facility.guid, this.analysisItem.analysisCategory);
         this.setReportYears();
         this.setBaselineYearWarning();
+        this.setReportYearWarning();
         this.setComponentBools();
-      }else{
+      } else {
         this.isFormChange = false;
       }
     })
   }
 
-  ngOnDestroy(){
+  ngOnDestroy() {
     this.analysisItemSub.unsubscribe();
   }
 
@@ -87,6 +90,7 @@ export class AnalysisSetupComponent implements OnInit {
   async changeReportYear() {
     this.analysisItem = this.analysisService.setDataAdjustments(this.analysisItem);
     this.setBaselineYearWarning();
+    this.setReportYearWarning();
     if (!this.baselineYearWarning) {
       let allFacilityAnalysisItems: Array<IdbAnalysisItem> = this.analysisDbService.facilityAnalysisItems.getValue();
       let selectYearAnalysis: boolean = true;
@@ -238,5 +242,18 @@ export class AnalysisSetupComponent implements OnInit {
       this.analysisItem.bankedAnalysisItemId = undefined;
     }
     await this.saveItem();
+  }
+
+
+  setReportYearWarning() {
+    if (this.analysisItem.reportYear != undefined) {
+      this.showReportYearWarning = this.calanderizationService.checkReportYearSelection('all', this.analysisItem.reportYear, this.facility);
+    } else {
+      this.showReportYearWarning = false;
+    }
+  }
+
+  goToSavingsReport(){
+    this.router.navigate(['../../../reports'], { relativeTo: this.activatedRoute });
   }
 }


### PR DESCRIPTION
connects #2055 

This pull request adds a warning and supporting logic to notify users when a facility lacks a full year of data for the selected report year in the analysis setup. The goal is to guide users to use the "Savings Report" feature for mid-year progress instead of running an analysis with incomplete data.

**User interface improvements:**
* Added a warning message to `analysis-setup.component.html` that displays when the selected report year does not have 12 months of data, including a link to the "Savings Report" for mid-year progress.

**Component logic and behavior:**
* Introduced the `showReportYearWarning` property and implemented the `setReportYearWarning` method in `analysis-setup.component.ts` to determine when to show the warning based on data completeness for the selected report year. [[1]](diffhunk://#diff-829254308019ae0e1b433726efd8d5c66944924fe3d40e15f2b966b26401e368R49-R58) [[2]](diffhunk://#diff-829254308019ae0e1b433726efd8d5c66944924fe3d40e15f2b966b26401e368R68) [[3]](diffhunk://#diff-829254308019ae0e1b433726efd8d5c66944924fe3d40e15f2b966b26401e368R246-R258)
* Updated the `changeReportYear` method to invoke `setReportYearWarning` whenever the report year changes, ensuring the warning is shown or hidden appropriately.
* Added the `goToSavingsReport` method to navigate users to the "Savings Report" page when the link in the warning is clicked.

**Code maintenance:**
* Updated imports in `analysis-setup.component.ts` to include `ActivatedRoute` for improved navigation handling.
* Minor formatting fix in the template for better readability.