### PR TITLE
Issue 2065: updated home chart to filter 0 energy use and 0 predictor usage

### DIFF
--- a/src/app/data-evaluation/account/account-home/account-home.component.ts
+++ b/src/app/data-evaluation/account/account-home/account-home.component.ts
@@ -165,7 +165,7 @@ export class AccountHomeComponent implements OnInit {
       return isNaN(summary.adjusted) == false;
     })
     monthlyAnalysisSummaryData = monthlyAnalysisSummaryData.filter(summary => {
-      return isNaN(summary.adjusted) == false;
+      return isNaN(summary.adjusted) == false && summary.energyUse != 0;
     })
     this.accountHomeService.annualEnergyAnalysisSummary.next(annualAnalysisSummaries);
     this.accountHomeService.monthlyEnergyAnalysisData.next(monthlyAnalysisSummaryData);
@@ -219,7 +219,7 @@ export class AccountHomeComponent implements OnInit {
       return isNaN(summary.adjusted) == false;
     })
     monthlyAnalysisSummaryData = monthlyAnalysisSummaryData.filter(summary => {
-      return isNaN(summary.adjusted) == false;
+      return isNaN(summary.adjusted) == false && summary.energyUse != 0;
     })
     this.accountHomeService.annualWaterAnalysisSummary.next(annualAnalysisSummaries);
     this.accountHomeService.monthlyWaterAnalysisData.next(monthlyAnalysisSummaryData);

--- a/src/app/data-evaluation/facility/facility-home/facility-home.component.ts
+++ b/src/app/data-evaluation/facility/facility-home/facility-home.component.ts
@@ -150,10 +150,14 @@ export class FacilityHomeComponent implements OnInit {
   setEnergyBehaviorSubjects(annualAnalysisSummaries: Array<AnnualAnalysisSummary>, monthlyAnalysisSummaryData: Array<MonthlyAnalysisSummaryData>) {
     annualAnalysisSummaries = annualAnalysisSummaries.filter(summary => {
       return isNaN(summary.adjusted) == false;
-    })
+    });
     monthlyAnalysisSummaryData = monthlyAnalysisSummaryData.filter(summary => {
-      return isNaN(summary.adjusted) == false;
-    })
+      let predictorUsage: number = 0;
+      summary.predictorUsage?.forEach(predictor => {
+        predictorUsage += predictor.usage;
+      });
+      return isNaN(summary.adjusted) == false && summary.energyUse != 0 && predictorUsage != 0;
+    });
     this.facilityHomeService.annualEnergyAnalysisSummary.next(annualAnalysisSummaries);
     this.facilityHomeService.monthlyFacilityEnergyAnalysisData.next(monthlyAnalysisSummaryData);
   }
@@ -207,7 +211,11 @@ export class FacilityHomeComponent implements OnInit {
       return isNaN(summary.adjusted) == false;
     })
     monthlyAnalysisSummaryData = monthlyAnalysisSummaryData.filter(summary => {
-      return isNaN(summary.adjusted) == false;
+      let predictorUsage: number = 0;
+      summary.predictorUsage?.forEach(predictor => {
+        predictorUsage += predictor.usage;
+      });
+      return isNaN(summary.adjusted) == false && summary.energyUse != 0 && predictorUsage != 0;
     })
     this.facilityHomeService.annualWaterAnalysisSummary.next(annualAnalysisSummaries);
     this.facilityHomeService.monthlyFacilityWaterAnalysisData.next(monthlyAnalysisSummaryData);


### PR DESCRIPTION
connects #2065 

This pull request refines the filtering logic for analysis summary data in both the account and facility home components. The changes ensure that only valid summaries with meaningful energy and predictor usage values are included in the results, improving the accuracy and relevance of the displayed data.

**Filtering improvements for summary data:**

* In `account-home.component.ts`, monthly energy and water analysis summaries now exclude entries where `energyUse` is zero, in addition to checking for valid `adjusted` values. [[1]](diffhunk://#diff-349536d993aaf6ab47359a16b0ddde63d286fabceac53d72dbe7ba06e09497d7L168-R168) [[2]](diffhunk://#diff-349536d993aaf6ab47359a16b0ddde63d286fabceac53d72dbe7ba06e09497d7L222-R222)

* In `facility-home.component.ts`, monthly energy and water analysis summaries are further filtered to exclude entries where either `energyUse` or the total `predictorUsage` is zero, alongside the existing `adjusted` value check. This is achieved by summing up all predictor usages and ensuring the total is not zero. [[1]](diffhunk://#diff-6b67c88c492ae3f9e8ff3a4f6f3b8e57001ad0dcde1d2fec8147c796c1aaa69cL153-R160) [[2]](diffhunk://#diff-6b67c88c492ae3f9e8ff3a4f6f3b8e57001ad0dcde1d2fec8147c796c1aaa69cL210-R218)