### PR TITLE
Issue 2103: fix bug when creating new facility from old accounts

### DIFF
--- a/src/app/indexedDB/db-changes.service.ts
+++ b/src/app/indexedDB/db-changes.service.ts
@@ -381,25 +381,31 @@ export class DbChangesService {
     this.loadingService.setLoadingMessage('Updating Reports...');
     let accountReports: Array<IdbAccountReport> = this.accountReportDbService.accountReports.getValue();
     for (let index = 0; index < accountReports.length; index++) {
-      accountReports[index].dataOverviewReportSetup.includedFacilities.push({
-        facilityId: newFacility.guid,
-        included: false,
-        includedGroups: []
-      });
-      accountReports[index].betterClimateReportSetup.includedFacilityGroups.push({
-        facilityId: newFacility.guid,
-        include: false,
-        groups: []
-      });
+      if (accountReports[index].dataOverviewReportSetup) {
+        accountReports[index].dataOverviewReportSetup.includedFacilities.push({
+          facilityId: newFacility.guid,
+          included: false,
+          includedGroups: []
+        });
+      }
+      if (accountReports[index].betterClimateReportSetup) {
+        accountReports[index].betterClimateReportSetup.includedFacilityGroups.push({
+          facilityId: newFacility.guid,
+          include: false,
+          groups: []
+        });
+      }
       await firstValueFrom(this.accountReportDbService.updateWithObservable(accountReports[index]));
     }
     this.loadingService.setLoadingMessage('Updating Analysis Items...');
     let accountAnalysisItems: Array<IdbAccountAnalysisItem> = this.accountAnalysisDbService.accountAnalysisItems.getValue();
     for (let index = 0; index < accountAnalysisItems.length; index++) {
-      accountAnalysisItems[index].facilityAnalysisItems.push({
-        facilityId: newFacility.guid,
-        analysisItemId: undefined
-      });
+      if (accountAnalysisItems[index].facilityAnalysisItems) {
+        accountAnalysisItems[index].facilityAnalysisItems.push({
+          facilityId: newFacility.guid,
+          analysisItemId: undefined
+        });
+      }
       await firstValueFrom(this.accountAnalysisDbService.updateWithObservable(accountAnalysisItems[index]));
     }
   }


### PR DESCRIPTION
connects #2103 

This pull request improves the robustness of the facility addition logic in the `DbChangesService` by adding checks to ensure that properties exist before attempting to update them. This prevents potential runtime errors when certain report setups or analysis items are missing.

Improvements to facility addition logic:

* Added checks to ensure `dataOverviewReportSetup` and `betterClimateReportSetup` exist before pushing new facility data to their respective arrays in `accountReports`.
* Added a check to ensure `facilityAnalysisItems` exists before adding a new facility analysis item in `accountAnalysisItems`.