### PR TITLE
Issue 2109: fix exporting to template predictor name bug

### DIFF
--- a/src/app/shared/helper-services/export-to-excel-template-v3.service.ts
+++ b/src/app/shared/helper-services/export-to-excel-template-v3.service.ts
@@ -796,7 +796,6 @@ export class ExportToExcelTemplateV3Service {
         worksheet.getCell('B' + rowIndex).value = this.getFormatedDate(date);
         let alpha: string = 'C';
         facilityPredictors.forEach(predictor => {
-          worksheet.getCell(alpha + rowIndex).value = predictor.name;
           alpha = this.getNextAlpha(alpha);
           let reading: IdbPredictorData = facilityPredictorData.find(pData => {
             return checkSameMonth(new Date(pData.date), new Date(pDate.year, pDate.month, 1)) && pData.predictorId == predictor.guid;


### PR DESCRIPTION
connects #2109

Manually setting the value of the cell was overriding the formula in the cell. Removed the manual entry and referenced cell is now working.