### PR TITLE
Issue 2111 - check for multiple entries for same month and year in data validity 

### DIFF
--- a/src/app/shared/shared-data-quality-report-meters/meter-data-quality-report/meter-data-quality-report.component.html
+++ b/src/app/shared/shared-data-quality-report-meters/meter-data-quality-report/meter-data-quality-report.component.html
@@ -45,6 +45,14 @@
                     cost reading<ng-container *ngIf="costOutlierCount > 1">s</ng-container>
                     <br>
                 </span>
+                <span class="alert-message" *ngIf="datesList.length > 0">
+                    There <ng-container *ngIf="datesList.length == 1">is </ng-container>
+                    <ng-container *ngIf="datesList.length > 1">are </ng-container>
+                    <span class="fw-bold text-danger">{{ datesList.length}}</span>
+                    month<ng-container *ngIf="datesList.length > 1">s</ng-container>
+                    with multiple readings.
+                    <br>
+                </span>
             </div>
         </div>
     </ng-container>
@@ -113,8 +121,8 @@
                     <i class="fa fa-line-chart me-2"></i>
                     Total Consumption
                 </h5>
-                <app-meter-energy-timeseries-graph [meterData]="meterData"
-                    [selectedMeter]="selectedMeter" [energyStats]="energyStats"></app-meter-energy-timeseries-graph>
+                <app-meter-energy-timeseries-graph [meterData]="meterData" [selectedMeter]="selectedMeter"
+                    [energyStats]="energyStats"></app-meter-energy-timeseries-graph>
             </div>
             <ng-container *ngIf="includeConsumption">
                 <div class="col-md-6 col-sm-12">
@@ -128,4 +136,14 @@
             </ng-container>
         </div>
     </ng-template>
+    <div *ngIf="datesList.length > 0">
+        <hr>
+        <h5 class="mt-5">
+            <i class="fa fa-table me-2 mb-3"></i>
+            Months with multiple readings
+        </h5>
+        <span *ngFor="let date of datesList" class="badge bg-warning text-dark px-2 py-2 fs-5 me-2 mb-2 ms-3">
+            {{ date.monthYear }}
+        </span>
+    </div>
 </ng-template>

--- a/src/app/shared/shared-data-quality-report-meters/meter-data-quality-report/meter-data-quality-report.component.ts
+++ b/src/app/shared/shared-data-quality-report-meters/meter-data-quality-report/meter-data-quality-report.component.ts
@@ -23,8 +23,9 @@ export class MeterDataQualityReportComponent {
   costStats: Statistics;
 
   includeCosts: boolean = true;
-
   hasData: boolean;
+
+  datesList: Array<{ monthYear: string }> = [];
 
   constructor(private router: Router) { }
 
@@ -43,7 +44,8 @@ export class MeterDataQualityReportComponent {
       this.includeCosts = isNaN(this.costStats.average) == false && this.costStats.average != 0;
       this.energyOutlierCount = energyStats.outliers;
       this.costOutlierCount = costStats.outliers;
-      if (this.energyOutlierCount > 0 || this.costOutlierCount > 0) {
+      this.checkMultipleReadings();
+      if (this.energyOutlierCount > 0 || this.costOutlierCount > 0 || this.datesList.length > 0) {
         this.showAlert = true;
       } else {
         this.showAlert = false;
@@ -51,6 +53,24 @@ export class MeterDataQualityReportComponent {
     }
   }
 
+  checkMultipleReadings() {
+    let dateCount: { [key: string]: number } = {};
+    this.meterData.forEach(data => {
+      let date = new Date(data.readDate);
+      let month = date.toLocaleString('default', { month: 'short' });
+      let year = date.getFullYear();
+      let monthYear = `${month}, ${year}`;
+      if (dateCount[monthYear]) {
+        dateCount[monthYear]++;
+      } else {
+        dateCount[monthYear] = 1;
+      }
+    });
+    this.datesList = Object.keys(dateCount).filter(key => dateCount[key] > 1)
+      .map(key => {
+        return { monthYear: key };
+      });
+  }
 
   meterDataAdd() {
     this.router.navigateByUrl('/data-management/' + this.selectedMeter.accountId + '/facilities/' + this.selectedMeter.facilityId + '/meters/' + this.selectedMeter.guid + '/meter-data/new-bill');

--- a/src/app/shared/shared-data-quality-report-predictor/predictor-data-quality-report/predictor-data-quality-report.component.html
+++ b/src/app/shared/shared-data-quality-report-predictor/predictor-data-quality-report/predictor-data-quality-report.component.html
@@ -18,7 +18,7 @@
     </div>
 </ng-template>
 <ng-template #hasDataTemplate>
-    <ng-container *ngIf="outlierCount > 0">
+    <ng-container *ngIf="showAlert">
         <div
             class="alert alert-warning d-flex flex-column align-items-center justify-content-center gap-3 mb-3 text-center">
             <i class="fa fa-exclamation-triangle me-3" aria-hidden="true"></i>
@@ -29,10 +29,17 @@
                     reading<span *ngIf="outlierCount > 1">s</span>
                     <br>
                 </span>
+                <span class="alert-message" *ngIf="datesList.length > 0">
+                    There <ng-container *ngIf="datesList.length == 1">is </ng-container>
+                    <ng-container *ngIf="datesList.length > 1">are </ng-container>
+                    <span class="fw-bold text-danger">{{ datesList.length}}</span>
+                    month<ng-container *ngIf="datesList.length > 1">s</ng-container>
+                    with multiple readings.
+                    <br>
+                </span>
             </div>
         </div>
     </ng-container>
-
     <h5>
         <i class="fa fa-table me-2"></i>
         Total Consumption Statistics
@@ -57,5 +64,16 @@
             <app-predictor-histogram-graph [predictorData]="predictorData"
                 [selectedPredictor]="selectedPredictor"></app-predictor-histogram-graph>
         </div>
+    </div>
+
+    <div *ngIf="datesList.length > 0">
+        <hr>
+        <h5 class="mt-5">
+            <i class="fa fa-table me-2 mb-3"></i>
+            Months with multiple readings
+        </h5>
+        <span *ngFor="let date of datesList" class="badge bg-warning text-dark px-2 py-2 fs-5 me-2 mb-2 ms-3">
+            {{ date.monthYear }}
+        </span>
     </div>
 </ng-template>

--- a/src/app/shared/shared-data-quality-report-predictor/predictor-data-quality-report/predictor-data-quality-report.component.ts
+++ b/src/app/shared/shared-data-quality-report-predictor/predictor-data-quality-report/predictor-data-quality-report.component.ts
@@ -20,6 +20,8 @@ export class PredictorDataQualityReportComponent {
   outlierCount: number;
 
   hasData: boolean;
+  datesList: Array<{ monthYear: string }> = [];
+  showAlert: boolean = false;
 
   constructor(private router: Router) { }
 
@@ -29,7 +31,32 @@ export class PredictorDataQualityReportComponent {
       const data = this.predictorData?.map(d => d.amount);
       this.stats = getPredictorStatistics(data);
       this.outlierCount = this.stats.outliers;
+      this.checkMultipleReadings();
+      if (this.outlierCount > 0 || this.datesList.length > 0) {
+        this.showAlert = true;
+      } else {
+        this.showAlert = false;
+      }
     }
+  }
+
+  checkMultipleReadings() {
+    let dateCount: { [key: string]: number } = {};
+    this.predictorData.forEach(data => {
+      let date = new Date(data.date);
+      let month = date.toLocaleString('default', { month: 'short' });
+      let year = date.getFullYear();
+      let monthYear = `${month}, ${year}`;
+      if (dateCount[monthYear]) {
+        dateCount[monthYear]++;
+      } else {
+        dateCount[monthYear] = 1;
+      }
+    });
+    this.datesList = Object.keys(dateCount).filter(key => dateCount[key] > 1)
+      .map(key => {
+        return { monthYear: key };
+      });
   }
 
   predictorDataAdd() {


### PR DESCRIPTION
connects #2111 

This pull request enhances the data quality report components for both meters and predictors by adding visibility into months with multiple readings, improving user alerts, and refactoring related logic. The main improvements center around highlighting potential data issues so users can quickly identify and address them.

**Meter Data Quality Report Enhancements:**

* Added logic to identify months with multiple meter readings and expose this as a new `datesList` property in `MeterDataQualityReportComponent`. 
* Updated the alert section in `meter-data-quality-report.component.html` to notify users when there are months with multiple readings, including a count and dynamic messaging.
* Introduced a new UI section listing all months with multiple readings using badges for easy visualization.

**Predictor Data Quality Report Enhancements:**

* Added similar logic and properties in `PredictorDataQualityReportComponent` to track months with multiple predictor readings, along with a `showAlert` flag to control alert visibility. 
* Updated the predictor report alert and summary UI to include messaging and a badge list for months with multiple readings. 