### PR TITLE
Issue 878 - phone number formatted for US in settings form

### DIFF
--- a/src/app/shared/settings-forms/general-information-form/general-information-form.component.html
+++ b/src/app/shared/settings-forms/general-information-form/general-information-form.component.html
@@ -118,8 +118,8 @@
         </div>
         <div class="mb-3 col-md-6 col-sm-12">
             <label for="phone">Contact Phone</label>
-            <input type="text" class="form-control" formControlName="contactPhone" (input)="saveChanges()"
-                onfocus="this.select();" minlength="1" maxlength="10">
+            <input type="text" class="form-control" formControlName="contactPhone" (input)="formatPhone($event)"
+                onfocus="this.select();" minlength="1" maxlength="12">
         </div>
         <div class="mb-3 col-md-6 col-sm-12">
             <label for="email">Contact Email</label>

--- a/src/app/shared/settings-forms/general-information-form/general-information-form.component.ts
+++ b/src/app/shared/settings-forms/general-information-form/general-information-form.component.ts
@@ -178,4 +178,23 @@ export class GeneralInformationFormComponent implements OnInit {
     }
     this.saveChanges();
   }
+
+  formatPhone(event: Event) {
+    let country = this.form.get('country')?.value;
+    if (country == 'US') {
+      let input = (event.target as HTMLInputElement).value;
+
+      input = input.replace(/\D/g, '');
+      if (input.length > 3 && input.length <= 6) {
+        input = input.replace(/(\d{3})(\d+)/, '$1-$2');
+      }
+      else if (input.length > 6) {
+        input = input.replace(/(\d{3})(\d{3})(\d+)/, '$1-$2-$3');
+      }
+
+      input = input.substring(0, 12);
+      this.form.get('contactPhone')?.setValue(input, { emitEvent: false });
+    }
+    this.saveChanges();
+  }
 }


### PR DESCRIPTION
connects #878 

This pull request updates the phone number input handling in the `GeneralInformationFormComponent` to improve user experience and data consistency, especially for US phone numbers. The main changes include adding phone number formatting logic and adjusting input constraints.

**Phone input improvements:**

* Added a new `formatPhone` method in `general-information-form.component.ts` to automatically format US phone numbers as the user types, inserting dashes after the third and sixth digits and restricting the length to 12 characters.
* Updated the phone number input field in `general-information-form.component.html` to use the new `formatPhone` method on input events, and increased the maximum allowed length from 10 to 12 characters.