### PR TITLE
Issue 974 - added validation for comparing report year and baseline year in report

### DIFF
--- a/src/app/data-evaluation/account/account-reports/account-report-setup/account-report-setup.component.html
+++ b/src/app/data-evaluation/account/account-reports/account-report-setup/account-report-setup.component.html
@@ -41,6 +41,12 @@
                             </div>
                         </div>
                     </div>
+
+                    <div *ngIf="showYearErrorMsg">
+                        <span class="alert alert-danger">
+                            Report Year cannot be earlier than Baseline Year.
+                        </span>
+                    </div>
                 </div>
                 <div class="col-6"
                     *ngIf="setupForm.controls.reportType.value == 'dataOverview' || setupForm.controls.reportType.value == 'accountSavings' || setupForm.controls.reportType.value == 'accountEmissionFactors'">

--- a/src/app/data-evaluation/account/account-reports/account-report-setup/account-report-setup.component.ts
+++ b/src/app/data-evaluation/account/account-reports/account-report-setup/account-report-setup.component.ts
@@ -30,6 +30,8 @@ export class AccountReportSetupComponent {
   selectedReportSub: Subscription;
   isFormChange: boolean = false;
   showReportYearWarning: boolean = false;
+  showYearErrorMsg: boolean = false;
+  showYearErrorMsgSub: Subscription;
   constructor(private accountReportDbService: AccountReportDbService,
     private accountReportsService: AccountReportsService,
     private dbChangesService: DbChangesService,
@@ -49,6 +51,10 @@ export class AccountReportSetupComponent {
       this.errorMessage = message;
     });
 
+    this.showYearErrorMsgSub = this.accountReportsService.compareBaselineYearToReportYearError.subscribe(showError => {
+      this.showYearErrorMsg = showError;
+    });
+
     this.selectedReportSub = this.accountReportDbService.selectedReport.subscribe(val => {
       selectedReport = val;
       if (!this.isFormChange) {
@@ -64,6 +70,7 @@ export class AccountReportSetupComponent {
   ngOnDestroy() {
     this.errorMessageSub.unsubscribe();
     this.selectedReportSub.unsubscribe();
+    this.showYearErrorMsgSub.unsubscribe();
   }
 
   async save() {
@@ -90,5 +97,4 @@ export class AccountReportSetupComponent {
       this.showReportYearWarning = this.calanderizationService.checkReportYearSelection('all', this.setupForm.controls.reportYear.value, this.account);
     }
   }
-
 }

--- a/src/app/data-evaluation/account/account-reports/account-reports-banner/account-reports-banner.component.ts
+++ b/src/app/data-evaluation/account/account-reports/account-reports-banner/account-reports-banner.component.ts
@@ -26,6 +26,8 @@ export class AccountReportsBannerComponent {
   showDropdown: boolean = false;
   reportList: Array<IdbAccountReport>;
   reportListSub: Subscription;
+  compareBaselineYearToReportYearError: boolean;
+  compareBaselineYearToReportYearErrorSub: Subscription;
 
   constructor(private router: Router,
     private sharedDataService: SharedDataService,
@@ -43,6 +45,13 @@ export class AccountReportsBannerComponent {
 
     this.errorSub = this.accountReportsService.errorMessage.subscribe(errorMessage => {
       this.errorMessage = errorMessage;
+      if (this.selectedReport) {
+        this.setValidation(this.selectedReport);
+      }
+    });
+
+    this.compareBaselineYearToReportYearErrorSub = this.accountReportsService.compareBaselineYearToReportYearError.subscribe(showError => {
+      this.compareBaselineYearToReportYearError = showError;
       if (this.selectedReport) {
         this.setValidation(this.selectedReport);
       }
@@ -79,8 +88,10 @@ export class AccountReportsBannerComponent {
     let betterPlantsValid: boolean = true;
     let dataOverviewValid: boolean = true;
     let performanceValid: boolean = true;
+    let betterClimateValid: boolean = true;
     let analysisValid: boolean = true;
     let accountSavingsValid: boolean = true;
+    let emissionFactorsValid: boolean = true;
     if (report.reportType == 'dataOverview') {
       if (this.errorMessage.length > 0) {
         dataOverviewValid = false;
@@ -90,17 +101,42 @@ export class AccountReportsBannerComponent {
       }
       this.setupValid = (setupValid && dataOverviewValid);
     }
+    else if (report.reportType == 'performance') {
+      if (this.compareBaselineYearToReportYearError) {
+        performanceValid = false;
+      }
+      else {
+        performanceValid = this.accountReportsService.getPerformanceFormFromReport(report.performanceReportSetup).valid;
+      }
+      this.setupValid = (setupValid && performanceValid);
+    }
+    else if (report.reportType == 'betterClimate') {
+      if (this.compareBaselineYearToReportYearError) {
+        betterClimateValid = false;
+      }
+      else {
+        betterClimateValid = this.accountReportsService.getBetterCimateFormFromReport(report.betterClimateReportSetup).valid;
+      }
+      this.setupValid = (setupValid && betterClimateValid);
+    }
+    else if (report.reportType == 'accountEmissionFactors') {
+      if (this.errorMessage.length > 0) {
+        emissionFactorsValid = false;
+      }
+      else {
+        emissionFactorsValid = true;
+      }
+      this.setupValid = (setupValid && emissionFactorsValid);
+    }
     else {
       if (report.reportType == 'betterPlants') {
         betterPlantsValid = this.accountReportsService.getBetterPlantsFormFromReport(report.betterPlantsReportSetup).valid;
-      } else if (report.reportType == 'performance') {
-        performanceValid = this.accountReportsService.getPerformanceFormFromReport(report.performanceReportSetup).valid;
       } else if (report.reportType == 'analysis') {
         analysisValid = this.accountReportsService.getAnalysisFormFromReport(report.analysisReportSetup).valid;
       } else if (report.reportType == 'accountSavings') {
         accountSavingsValid = this.accountReportsService.getAccountSavingsFormFromReport(report.accountSavingsReportSetup).valid;
       }
-      this.setupValid = (setupValid && betterPlantsValid && performanceValid && analysisValid && accountSavingsValid);
+      this.setupValid = (setupValid && betterPlantsValid && analysisValid && accountSavingsValid);
     }
   }
 

--- a/src/app/data-evaluation/account/account-reports/account-reports.service.ts
+++ b/src/app/data-evaluation/account/account-reports/account-reports.service.ts
@@ -13,15 +13,18 @@ export class AccountReportsService {
   generateExcel: BehaviorSubject<boolean>;
 
   errorMessage: BehaviorSubject<string>;
+  compareBaselineYearToReportYearError: BehaviorSubject<boolean>;
 
   constructor(private accountReportDbService: AccountReportDbService,
     private formBuilder: FormBuilder
   ) {
     this.generateExcel = new BehaviorSubject<boolean>(false);
     this.errorMessage = new BehaviorSubject<string>(undefined);
+    this.compareBaselineYearToReportYearError = new BehaviorSubject<boolean>(false);
 
     this.accountReportDbService.selectedReport.subscribe(report => {
       this.validateReport(report);
+      this.compareBaselineYearToReportYear(report);
     });
   }
 
@@ -40,6 +43,17 @@ export class AccountReportsService {
       }
     }
     this.errorMessage.next(errorMessage)
+  }
+
+  compareBaselineYearToReportYear(report: IdbAccountReport) {
+    if (report.reportType == 'performance' || report.reportType == 'betterClimate') {
+      if (report.baselineYear != undefined && report.reportYear != undefined && report.reportYear < report.baselineYear) {
+        this.compareBaselineYearToReportYearError.next(true);
+      }
+      else {
+        this.compareBaselineYearToReportYearError.next(false);
+      }
+    }
   }
 
   getSetupFormFromReport(report: IdbAccountReport): FormGroup {

--- a/src/app/data-evaluation/facility/facility-reports/facility-reports.service.ts
+++ b/src/app/data-evaluation/facility/facility-reports/facility-reports.service.ts
@@ -21,12 +21,20 @@ export class FacilityReportsService {
   validateReport(report: IdbFacilityReport) {
     let errorMessage: string = undefined;
     if (report) {
-      //write validation for report
-      let startDate: Date = new Date(report.dataOverviewReportSettings.startYear, report.dataOverviewReportSettings.startMonth, 1);
-      let endDate: Date = new Date(report.dataOverviewReportSettings.endYear, report.dataOverviewReportSettings.endMonth, 1);
-      // compare start and end date
-      if (startDate.getTime() >= endDate.getTime()) {
-        errorMessage = 'Start date cannot be later than the end date.';
+      if (report.facilityReportType == 'overview') {
+        //write validation for report
+        let startDate: Date = new Date(report.dataOverviewReportSettings.startYear, report.dataOverviewReportSettings.startMonth, 1);
+        let endDate: Date = new Date(report.dataOverviewReportSettings.endYear, report.dataOverviewReportSettings.endMonth, 1);
+        // compare start and end date
+        if (startDate.getTime() >= endDate.getTime()) {
+          errorMessage = 'Start date cannot be later than the end date.';
+        }
+      }
+      else if (report.facilityReportType == 'emissionFactors') {
+        console.log(report);
+        if (report.emissionFactorsReportSettings.startYear != undefined && report.emissionFactorsReportSettings.endYear != undefined && report.emissionFactorsReportSettings.endYear < report.emissionFactorsReportSettings.startYear) {
+          errorMessage = 'Start year cannot be later than the end year.';
+        }
       }
     }
     this.errorMessage.next(errorMessage)


### PR DESCRIPTION
connects #974 

This pull request introduces improved validation logic for report year selection in both account and facility report components, ensuring that users cannot select a report year earlier than the baseline year for certain report types. It also adds new error messaging to guide users and updates the validation flow for report setup forms.

**Account Report Year Validation and Error Messaging:**

* Added a new error message display in `account-report-setup.component.html` to inform users when the report year is earlier than the baseline year.
* Introduced a `compareBaselineYearToReportYearError` observable in `AccountReportsService` and integrated its subscription into both `AccountReportSetupComponent` and `AccountReportsBannerComponent` to trigger error messages and validation updates. 
* Implemented the `compareBaselineYearToReportYear` method in `AccountReportsService` to set the error state when the report year is less than the baseline year for 'performance' and 'betterClimate' report types.

**Account Report Setup Validation Logic:**

* Updated the report setup validation in `AccountReportsBannerComponent` to consider the new year comparison error for 'performance' and 'betterClimate' reports, preventing form submission when the error is present. 

**Facility Report Year Validation:**

* Enhanced `FacilityReportsService` validation to handle 'emissionFactors' reports, ensuring the start year is not later than the end year and providing appropriate error messaging. 