### PR TITLE
Issue 2074 - logic for displaying the eye icon changed

### DIFF
--- a/src/app/data-management/data-management-import/shared-process-file/process-meter-readings/meter-data-summary-table/meter-data-summary-table.component.html
+++ b/src/app/data-management/data-management-import/shared-process-file/process-meter-readings/meter-data-summary-table/meter-data-summary-table.component.html
@@ -60,7 +60,7 @@
                         ({{summary.existingStart | date}} - {{summary.existingEnd | date}})
                     </span>
 
-                    <span class="float-end" *ngIf="summary.newEntries > 0">
+                    <span class="float-end" *ngIf="readingDifferencesMap[summary.meterId]?.length > 0">
                         <i class="fa-solid fa-eye icon-style" (click)="openModal(summary)"></i>
                     </span>
                 </td>
@@ -141,14 +141,6 @@
                         </tr>
                     </tbody>
                 </table>
-            </div>
-        </div>
-        <div *ngIf="comparisonSummaryWithDifferences.length === 0" class="text-center my-5">
-            <div
-                class="alert alert-info d-flex flex-column align-items-center justify-content-center py-4 rounded shadow-sm">
-                <i class="fa fa-info-circle fa-2x mb-2 text-primary"></i>
-                <div class="fw-bold fs-5 mb-1">No differences found between the existing and imported meter readings
-                </div>
             </div>
         </div>
     </div>

--- a/src/app/data-management/data-management-import/shared-process-file/process-meter-readings/meter-data-summary-table/meter-data-summary-table.component.ts
+++ b/src/app/data-management/data-management-import/shared-process-file/process-meter-readings/meter-data-summary-table/meter-data-summary-table.component.ts
@@ -29,6 +29,8 @@ export class MeterDataSummaryTableComponent {
   orderDataField: string = 'readDate';
   orderByDirection: 'asc' | 'desc' = 'desc';
 
+  readingDifferencesMap: { [meterId: string]: MeterReadingComparison[] } = {};
+
   constructor(
     private utilityMeterDataDbService: UtilityMeterDatadbService,
     private facilityDbService: FacilitydbService,
@@ -41,11 +43,13 @@ export class MeterDataSummaryTableComponent {
   ngOnInit() {
     this.facilities = this.facilityDbService.accountFacilities.getValue();
     this.meters = this.utilityMeterDbService.accountMeters.getValue();
+    this.computeReadingChanges();
   }
 
   openModal(summary: MeterDataSummary) {
     this.showModal = true;
-    this.compareMeterData(summary);
+    this.selectedMeterName = summary.meter.name;
+    this.comparisonSummaryWithDifferences = this.readingDifferencesMap[summary.meterId];
   }
 
   hideModal() {
@@ -64,8 +68,14 @@ export class MeterDataSummaryTableComponent {
     }
   }
 
+  computeReadingChanges() {
+    this.readingDifferencesMap = {};
+    this.meterDataSummaries.forEach(summary => {
+      this.readingDifferencesMap[summary.meterId] = this.compareMeterData(summary);
+    });
+  }
+
   compareMeterData(summary: MeterDataSummary) {
-    this.selectedMeterName = summary.meter.name;
     const inspectedFacility = summary.meter.facilityId;
     const inspectedMeterId = summary.meterId;
 
@@ -73,7 +83,7 @@ export class MeterDataSummaryTableComponent {
     const meter = this.meters.find(meter => meter.guid === inspectedMeterId);
     const existingMeterReadings = this.utilityMeterDataDbService.accountMeterData.getValue().filter(data => (data.meterId === meter?.guid && data.facilityId === facility?.guid));
 
-    this.comparisonSummaryWithDifferences = this.checkDifferences(existingMeterReadings, summary);
+    return this.checkDifferences(existingMeterReadings, summary);
   }
 
   checkDifferences(meterData: Array<IdbUtilityMeterData>, newMeterDataSummary: MeterDataSummary): Array<MeterReadingComparison> {


### PR DESCRIPTION
connects #2074 
This pull request refactors the `MeterDataSummaryTableComponent` to optimize how meter reading differences are managed and displayed. The main improvement is the introduction of a `readingDifferencesMap` for efficient access to comparison results, which streamlines modal interactions and UI conditionals. Additionally, some unused UI elements were removed for clarity.

### Data handling and performance improvements:
* Introduced a `readingDifferencesMap` object to cache meter reading differences for each meter, computed once during initialization with the new `computeReadingChanges()` method. This avoids redundant calculations and simplifies access to differences when opening the modal. 

### UI logic and cleanup:
* Updated the conditional display of the "eye" icon in the summary table to depend on the presence of differences in `readingDifferencesMap` instead of the previous `newEntries` check, ensuring more accurate UI feedback.
* Removed the alert message that appeared when there were no differences between existing and imported meter readings, decluttering the UI.

### Modal interaction:
* Refactored the modal-opening logic to use the precomputed differences from `readingDifferencesMap`, further simplifying the code and improving performance.