### PR TITLE
Issue 2144: updated date parsing in template v3 upload logic

### DIFF
--- a/src/app/data-evaluation/account/account-reports/account-reports.service.ts
+++ b/src/app/data-evaluation/account/account-reports/account-reports.service.ts
@@ -23,8 +23,10 @@ export class AccountReportsService {
     this.compareBaselineYearToReportYearError = new BehaviorSubject<boolean>(false);
 
     this.accountReportDbService.selectedReport.subscribe(report => {
-      this.validateReport(report);
-      this.compareBaselineYearToReportYear(report);
+      if (report) {
+        this.validateReport(report);
+        this.compareBaselineYearToReportYear(report);
+      }
     });
   }
 
@@ -493,7 +495,7 @@ export class AccountReportsService {
         }
       };
     }
-    
+
     accountSavingsReportSetup.analysisItemId = form.controls.analysisItemId.value;
     accountSavingsReportSetup.includeAnnualResults = form.controls.includeAnnualResults.value;
     accountSavingsReportSetup.includeAnnualResultsTable = form.controls.includeAnnualResultsTable.value;

--- a/src/app/data-management/data-management-import/import-services/upload-data-v3.service.ts
+++ b/src/app/data-management/data-management-import/import-services/upload-data-v3.service.ts
@@ -502,7 +502,7 @@ export class UploadDataV3Service {
       let readDateStr: string = dataPoint['Read Date'];
       let totalUsage: number = checkImportCellNumber(dataPoint['Total Usage']);
       if (meterNumber && readDateStr && isNaN(totalUsage) == false) {
-        let readDate: Date = new Date(readDateStr);
+        const readDate = this.getTemplateReadDate(readDateStr);
         let meter: IdbUtilityMeter = importMeters.find(meter => { return meter.meterNumber == meterNumber });
         if (meter) {
           let dbDataPoint: IdbUtilityMeterData = this.getExistingDbEntry(utilityMeterData, meter, readDate);
@@ -532,7 +532,7 @@ export class UploadDataV3Service {
       let readDateStr: string = dataPoint['Read Date'];
       let totalUsage: number = checkImportCellNumber(dataPoint['Total Usage']);
       if (meterNumber && readDateStr && isNaN(totalUsage) == false) {
-        let readDate: Date = new Date(readDateStr);
+        let readDate: Date = this.getTemplateReadDate(readDateStr);
         let meter: IdbUtilityMeter = importMeters.find(meter => { return meter.meterNumber == meterNumber });
         if (meter) {
           let dbDataPoint: IdbUtilityMeterData = this.getExistingDbEntry(utilityMeterData, meter, readDate);
@@ -577,7 +577,7 @@ export class UploadDataV3Service {
       let readDateStr: string = dataPoint['Read Date'];
       let totalUsage: number = checkImportCellNumber(dataPoint['Total Usage or Distance']);
       if (meterNumber && readDateStr && isNaN(totalUsage) == false) {
-        let readDate: Date = new Date(readDateStr);
+        let readDate: Date = this.getTemplateReadDate(readDateStr);
         let meter: IdbUtilityMeter = importMeters.find(meter => { return meter.meterNumber == meterNumber });
         if (meter) {
           let dbDataPoint: IdbUtilityMeterData = this.getExistingDbEntry(utilityMeterData, meter, readDate);
@@ -617,7 +617,7 @@ export class UploadDataV3Service {
       let readDateStr: string = dataPoint['Read Date'];
       let totalUsage: number = checkImportCellNumber(dataPoint['Total Usage']);
       if (meterNumber && readDateStr && isNaN(totalUsage) == false) {
-        let readDate: Date = new Date(readDateStr);
+        let readDate: Date = this.getTemplateReadDate(readDateStr);
         let meter: IdbUtilityMeter = importMeters.find(meter => { return meter.meterNumber == meterNumber });
         if (meter) {
           let dbDataPoint: IdbUtilityMeterData = this.getExistingDbEntry(utilityMeterData, meter, readDate);
@@ -663,7 +663,7 @@ export class UploadDataV3Service {
       let readDateStr: string = dataPoint['Read Date'];
       let totalUsage: number = checkImportCellNumber(dataPoint['Total Usage or Emission']);
       if (meterNumber && readDateStr && isNaN(totalUsage) == false) {
-        let readDate: Date = new Date(readDateStr);
+        let readDate: Date = this.getTemplateReadDate(readDateStr);
         let meter: IdbUtilityMeter = importMeters.find(meter => { return meter.meterNumber == meterNumber });
         if (meter) {
           let dbDataPoint: IdbUtilityMeterData = this.getExistingDbEntry(utilityMeterData, meter, readDate);
@@ -690,7 +690,7 @@ export class UploadDataV3Service {
       let readDateStr: string = dataPoint['Read Date'];
       let totalUsage: number = checkImportCellNumber(dataPoint['Total Usage']);
       if (meterNumber && readDateStr && isNaN(totalUsage) == false) {
-        let readDate: Date = new Date(readDateStr);
+        let readDate: Date = this.getTemplateReadDate(readDateStr);
         let meter: IdbUtilityMeter = importMeters.find(meter => { return meter.meterNumber == meterNumber });
         if (meter) {
           let dbDataPoint: IdbUtilityMeterData = this.getExistingDbEntry(utilityMeterData, meter, readDate);
@@ -956,7 +956,7 @@ export class UploadDataV3Service {
       if (facilityName && readDateStr) {
         let facility: IdbFacility = importFacilities.find(facility => { return facility.name == facilityName });
         if (facility) {
-          let readDate: Date = new Date(readDateStr);
+          let readDate: Date = this.getTemplateReadDate(readDateStr);
           for (let i = 1; i < 16; i++) {
             let predictorName: string = excelPredictorData['Predictor ' + i + ' Name'];
             if (predictorName) {
@@ -989,5 +989,15 @@ export class UploadDataV3Service {
       }
     });
     return importPredictorData;
+  }
+
+  getTemplateReadDate(readDateStr: string): Date {
+    //Check for YYYY-MM-DD format
+    if (/^\d{4}-\d{2}-\d{2}$/.test(readDateStr)) {
+      const [year, month, day] = readDateStr.split('-').map(Number);
+      const readDate = new Date(year, month - 1, day);
+      return readDate;
+    }
+    return new Date(readDateStr)
   }
 }


### PR DESCRIPTION
connects #2144 

This pull request improves how read dates are parsed during data import, ensuring consistent handling of different date formats. The main change is the introduction of a new `getTemplateReadDate` method in `UploadDataV3Service`, which standardizes date parsing across multiple import scenarios. Additionally, a minor fix was made in `AccountReportsService` to prevent errors when the selected report is `null`.

**Date parsing improvements:**

* Added the `getTemplateReadDate` method to `UploadDataV3Service` to correctly parse dates in `YYYY-MM-DD` format and fallback to the default `Date` constructor for other formats. This change helps handle template dates more reliably.
* Replaced all instances of direct `new Date(readDateStr)` calls with `getTemplateReadDate(readDateStr)` throughout `UploadDataV3Service`, ensuring consistent date parsing for utility meter and facility data imports. [[1]](diffhunk://#diff-fb77084ad0dc3f263fcbe272c7ef3cb465159080c4360b025ccfd1e9aca71aaaL505-R505) [[2]](diffhunk://#diff-fb77084ad0dc3f263fcbe272c7ef3cb465159080c4360b025ccfd1e9aca71aaaL535-R535) [[3]](diffhunk://#diff-fb77084ad0dc3f263fcbe272c7ef3cb465159080c4360b025ccfd1e9aca71aaaL580-R580) [[4]](diffhunk://#diff-fb77084ad0dc3f263fcbe272c7ef3cb465159080c4360b025ccfd1e9aca71aaaL620-R620) [[5]](diffhunk://#diff-fb77084ad0dc3f263fcbe272c7ef3cb465159080c4360b025ccfd1e9aca71aaaL666-R666) [[6]](diffhunk://#diff-fb77084ad0dc3f263fcbe272c7ef3cb465159080c4360b025ccfd1e9aca71aaaL693-R693) [[7]](diffhunk://#diff-fb77084ad0dc3f263fcbe272c7ef3cb465159080c4360b025ccfd1e9aca71aaaL959-R959)

**Error prevention:**

* Updated `AccountReportsService` to only validate and compare reports when a report is actually selected, preventing potential errors when the report is `null`.