### PR TITLE
Issue 2134 - allow xls files to be imported

### DIFF
--- a/src/app/data-management/data-management-import/upload-files/upload-files.component.html
+++ b/src/app/data-management/data-management-import/upload-files/upload-files.component.html
@@ -33,7 +33,7 @@
                         Download Template</a>
                 </p>
                 <input class="form-control" [ngClass]="{'drag-in': dragOver}" type="file" #importFile id="importFile"
-                    (dragenter)="setDragEnter()" (input)="setImportFile($event.target)" multiple accept=".xlsx"
+                    (dragenter)="setDragEnter()" (input)="setImportFile($event.target)" multiple accept=".xlsx, .xls"
                     (dragleave)="setDragOut()">
                 <div *ngIf="fileUploadError">
                     <div class="p-2 alert-danger">

--- a/src/app/data-management/data-management-import/upload-files/upload-files.component.ts
+++ b/src/app/data-management/data-management-import/upload-files/upload-files.component.ts
@@ -45,7 +45,7 @@ export class UploadFilesComponent {
     let files: FileList = (event as HTMLInputElement).files;
     if (files) {
       if (files.length !== 0) {
-        let regex3 = /.xlsx$/;
+        let regex3 =  /\.(xlsx|xls)$/i;
         this.loadingService.setLoadingMessage('Uploading Files...');
         this.loadingService.setLoadingStatus(true);
         for (let index = 0; index < files.length; index++) {


### PR DESCRIPTION
connects #2134 

This pull request updates the file upload functionality in the data management import module to support both `.xlsx` and `.xls` file formats, improving compatibility for users. The most important changes are:

**File Upload Input Enhancements:**
* The `accept` attribute in the file input element in `upload-files.component.html` now allows both `.xlsx` and `.xls` files, enabling users to upload either format.

**Validation Logic Update:**
* The regular expression used to validate uploaded files in `upload-files.component.ts` has been updated to match both `.xlsx` and `.xls` file extensions, ensuring correct file type validation for both formats.