### PR TITLE
Issue 1457: add ability to map predictors to existing predictors on upload

### DIFF
--- a/src/app/data-management/data-management-import/shared-process-file/process-predictors/process-predictors.component.html
+++ b/src/app/data-management/data-management-import/shared-process-file/process-predictors/process-predictors.component.html
@@ -121,6 +121,36 @@
                         <app-edit-predictor-form [predictorForm]="editPredictorForm" [predictor]="editPredictor"
                             [facility]="editPredictorFacility"></app-edit-predictor-form>
                         <!--TODO: map predictor to existing if new predictor like in meters-->
+                        <ng-container *ngIf="editPredictor.id == undefined">
+                            <hr>
+                            <div class="d-flex w-100 alert alert-warning" *ngIf="!showExisting">
+                                If this is showing up as a new predictor and you would like the data to be applied to an
+                                existing predictor.
+                                <a class="ps-1 click-link" (click)="setShowExisting()">Click here</a>.
+                            </div>
+                            <div class="d-flex flex-column">
+                                <ng-container *ngIf="showExisting && existingPredictorOptions.length != 0">
+                                    <div class="alert alert-info">
+                                        Select an available existing predictors:
+                                    </div>
+                                    <ul>
+                                        <li *ngFor="let existingPredictor of existingPredictorOptions">
+                                            <a class="click-link" (click)="selectExistingPredictor(existingPredictor)">
+                                                {{existingPredictor.name}}
+                                            </a>
+                                        </li>
+                                    </ul>
+                                </ng-container>
+                                <ng-container *ngIf="showExisting && existingPredictorOptions.length == 0">
+                                    <div class="alert alert-info">
+                                        No existing predictors are available for selection. Either no predictors exist for the
+                                        corresponding
+                                        facility or all existing predictors are already being used for import.
+                                    </div>
+                                </ng-container>
+                            </div>
+                        </ng-container>
+
                     </ng-template>
                 </ng-template>
                 <ng-template #noPredictorsIncludedBlock>

--- a/src/app/data-management/data-management-import/shared-process-file/process-predictors/process-predictors.component.ts
+++ b/src/app/data-management/data-management-import/shared-process-file/process-predictors/process-predictors.component.ts
@@ -7,11 +7,12 @@ import { IdbFacility } from 'src/app/models/idbModels/facility';
 import { FileReference, getEmptyFileReference } from 'src/app/data-management/data-management-import/import-services/upload-data-models';
 import { EditPredictorFormService } from 'src/app/shared/shared-predictors-content/edit-predictor-form.service';
 import { IdbPredictor } from 'src/app/models/idbModels/predictor';
+import { PredictorDbService } from 'src/app/indexedDB/predictor-db.service';
 
 @Component({
   selector: 'app-process-predictors',
   standalone: false,
-  
+
   templateUrl: './process-predictors.component.html',
   styleUrl: './process-predictors.component.css'
 })
@@ -25,11 +26,15 @@ export class ProcessPredictorsComponent {
   editPredictorForm: FormGroup;
   editPredictor: IdbPredictor;
   editPredictorFacility: IdbFacility;
+  editPredictorPrevGUID: string;
 
   skipAll: boolean = false;
+  showExisting: boolean = false;
+  existingPredictorOptions: Array<IdbPredictor> = [];
   constructor(private activatedRoute: ActivatedRoute,
     private dataManagementService: DataManagementService,
-    private editPredictorFormService: EditPredictorFormService) { }
+    private editPredictorFormService: EditPredictorFormService,
+    private predictorDbService: PredictorDbService) { }
 
   ngOnInit(): void {
     this.paramsSub = this.activatedRoute.parent.params.subscribe(param => {
@@ -63,6 +68,9 @@ export class ProcessPredictorsComponent {
   }
 
   setEditPredictor(predictor: IdbPredictor) {
+    if (predictor.id == undefined) {
+      this.editPredictorPrevGUID = predictor.guid;
+    }
     this.editPredictorFacility = this.fileReference.importFacilities.find(f => { return f.guid == predictor.guid });
     this.editPredictor = predictor;
     this.editPredictorForm = this.editPredictorFormService.getFormFromPredictor(predictor);
@@ -82,9 +90,36 @@ export class ProcessPredictorsComponent {
   }
 
   submitPredictor() {
+    let editPredictorIndex: number;
+    if (this.editPredictorPrevGUID) {
+      editPredictorIndex = this.fileReference.predictors.findIndex(filePredictor => { return filePredictor.guid == this.editPredictorPrevGUID });
+    } else {
+      editPredictorIndex = this.fileReference.predictors.findIndex(filePredictor => { return filePredictor.guid == this.editPredictor.guid });
+    }
     this.editPredictorFormService.setPredictorDataFromForm(this.editPredictor, this.editPredictorForm);
-    this.editPredictor.isValid = this.editPredictorForm.valid;
+    this.fileReference.predictors[editPredictorIndex] = this.editPredictor;
+    this.fileReference.predictors[editPredictorIndex].isValid = this.editPredictorForm.valid;
     this.setValidPredictors();
     this.cancelEdit();
+  }
+
+  setShowExisting() {
+    let accountPredictors: Array<IdbPredictor> = this.predictorDbService.accountPredictors.getValue();
+    let facilityPredictors: Array<IdbPredictor> = accountPredictors.filter(p => { return p.facilityId == this.editPredictor.facilityId; });
+    let existingPredictorsInUse: Array<string> = this.fileReference.predictors.flatMap(predictor => {
+      return predictor.guid
+    });
+    this.existingPredictorOptions = facilityPredictors.filter(fPredictor => {
+      return !existingPredictorsInUse.includes(fPredictor.guid);
+    });
+    this.showExisting = true;
+  }
+
+  selectExistingPredictor(predictor: IdbPredictor) {
+    let importWizardName: string = this.editPredictor.importWizardName;
+    this.editPredictor = predictor;
+    this.editPredictor.importWizardName = importWizardName;
+    this.editPredictorForm = this.editPredictorFormService.getFormFromPredictor(predictor);
+    this.showExisting = false;
   }
 }


### PR DESCRIPTION
connects #1457 

This pull request enhances the workflow for importing predictors by allowing users to map new predictors to existing ones during the import process. The changes improve usability and data integrity by providing a clear UI and logic for selecting existing predictors, preventing duplicates, and ensuring correct data mapping. This functionality is consistent with behavior in meters.

**User interface improvements for predictor selection:**

* Added a UI section to `process-predictors.component.html` that prompts users to map a new predictor to an existing one if desired, with a clickable link to display available options and informative alerts when no options are available.

**Logic and state management for existing predictors:**

* Introduced new state variables (`showExisting`, `existingPredictorOptions`, `editPredictorPrevGUID`) and injected `PredictorDbService` to manage and display available existing predictors for selection.
* Implemented the `setShowExisting()` method to filter and display existing predictors that are not already in use for the current import, based on facility and usage.
* Added the `selectExistingPredictor()` method to update the editing context when an existing predictor is chosen, preserving the import wizard name and updating the form.

**Import logic updates:**

* Modified `submitPredictor()` to correctly update the predictor list, using either the previous GUID or the current one, ensuring that the correct predictor is updated when mapping to an existing predictor. [[1]](diffhunk://#diff-6d05c6484b1b08172bd55c8d7ac443717eedb4ece73e54fd3cd5b25422e273f6R93-R124) [[2]](diffhunk://#diff-6d05c6484b1b08172bd55c8d7ac443717eedb4ece73e54fd3cd5b25422e273f6R71-R73)