### PR TITLE
Issue 2154 - functionality to check the differences in the existing and imported predictor readings

### DIFF
--- a/src/app/data-management/data-management-import/import-services/upload-data-v3.service.ts
+++ b/src/app/data-management/data-management-import/import-services/upload-data-v3.service.ts
@@ -973,8 +973,9 @@ export class UploadDataV3Service {
                     return facilityPredictor.guid == pData.predictorId && checkSameMonth(new Date(pData.date), readDate)
                   });
                   if (existingPredictorData) {
-                    existingPredictorData.amount = predictorValue;
-                    importPredictorData.push(existingPredictorData);
+                    let predictorDataCopy: IdbPredictorData = _.cloneDeep(existingPredictorData);
+                    predictorDataCopy.amount = predictorValue;
+                    importPredictorData.push(predictorDataCopy);
                   } else {
                     let newPredictorData: IdbPredictorData = getNewIdbPredictorData(facilityPredictor);
                     newPredictorData.date = readDate;

--- a/src/app/data-management/data-management-import/shared-process-file/process-predictor-readings/process-predictor-readings.component.css
+++ b/src/app/data-management/data-management-import/shared-process-file/process-predictor-readings/process-predictor-readings.component.css
@@ -1,0 +1,71 @@
+.popup {
+  top: 10px;
+  left: 10px;
+  width: calc(100vw - 20px)
+}
+
+.popup .popup-body {
+  max-height: calc(100vh - 100px);
+  overflow-y: auto;
+}
+
+.popup-header .fa {
+  color: white;
+}
+
+.fa {
+  color: inherit;
+}
+
+.meter-text {
+  font-size: 1.2em;
+  text-decoration: underline;
+}
+
+.btn-text {
+  font-size: 1.2em;
+  text-align: center;
+  color: green;
+  font-style: italic;
+}
+
+.col-date {
+  background-color: #154c79;
+  color: white;
+  text-align: center;
+  border: 1px solid black;
+}
+
+.col-existing {
+  background-color: #cad2d6;
+  text-align: center;
+  border: 1px solid black;
+}
+
+.col-new {
+  background-color: #e1e1f3;
+  text-align: center;
+  border: 1px solid black;
+}
+
+.col-difference {
+  background-color: #c2dede;
+  text-align: center;
+  border: 1px solid black;
+}
+
+.col-percentage-difference {
+  background-color: #c7bcaf;
+  text-align: center;
+  border: 1px solid black;
+}
+
+thead tr:not(.table-mh) th.can-click:hover{
+    cursor: pointer;
+    text-decoration: underline;
+}
+
+.icon-style {
+  font-size: 14px;
+  color: #972d79;
+}

--- a/src/app/data-management/data-management-import/shared-process-file/process-predictor-readings/process-predictor-readings.component.html
+++ b/src/app/data-management/data-management-import/shared-process-file/process-predictor-readings/process-predictor-readings.component.html
@@ -30,7 +30,9 @@
                                         New Predictors Entries
                                     </th>
                                     <th>
-                                        Existing Predictors Entries
+                                        <app-label-with-tooltip [isBold]="true" [label]="'Existing Predictors Entries'"
+                                            [field]="'checkPredictorDifferences'" [isFloatRight]="true">
+                                        </app-label-with-tooltip>
                                     </th>
                                     <th>
 
@@ -64,6 +66,11 @@
                                         {{summary.existingEntries}}
                                         <span *ngIf="summary.existingStart">
                                             ({{summary.existingStart | date}} - {{summary.existingEnd | date}})
+                                        </span>
+
+                                        <span class="float-end"
+                                            *ngIf="readingDifferencesMap[summary.predictor.guid + '_' + summary.predictor.facilityId]?.length > 0">
+                                            <i class="fa-solid fa-eye icon-style" (click)="openModal(summary)"></i>
                                         </span>
                                     </td>
                                     <td>
@@ -99,3 +106,68 @@
 <!--TODO: disable next-->
 <app-data-management-import-footer [fileReference]="fileReference"
     [navOption]="'predictor-data'"></app-data-management-import-footer>
+
+<div [ngClass]="{'windowOverlay': showModal}"></div>
+<div class="popup" [class.open]="showModal">
+    <div class="popup-header" *ngIf="showModal"><i class="fa fa-clipboard-check me-2"></i>Compare Predictor Data:
+        {{selectedPredictorName}}
+        <button class="item-right" (click)="hideModal()">x</button>
+    </div>
+    <div class="popup-body">
+        <div class="mt-3" *ngIf="comparisonSummaryWithDifferences.length > 0">
+            <div class="table-responsive">
+                <table class="table table-sm table-bordered table-hover utility-data">
+                    <thead class="table-mh table-info">
+                        <tr>
+                            <th class="col-date can-click" (click)="setOrderDataField('readDate')"
+                                [ngClass]="{'active': orderDataField == 'readDate'}">
+                                Predictor Read Date
+                            </th>
+                            <th class="col-existing can-click" (click)="setOrderDataField('oldReading')"
+                                [ngClass]="{'active': orderDataField == 'oldReading'}">
+                                Current {{selectedPredictorName}} {{selectedPredictorUnit}}
+                            </th>
+                            <th class="col-new can-click" (click)="setOrderDataField('newReading')"
+                                [ngClass]="{'active': orderDataField == 'newReading'}">
+                                Imported {{selectedPredictorName}} {{selectedPredictorUnit}}
+                            </th>
+                            <th class="col-difference can-click" (click)="setOrderDataField('difference')"
+                                [ngClass]="{'active': orderDataField == 'difference'}">
+                                Difference
+                            </th>
+                            <th class="col-percentage-difference can-click"
+                                (click)="setOrderDataField('percentageDifference')"
+                                [ngClass]="{'active': orderDataField == 'percentageDifference'}">
+                                % Difference
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody class="table-group-divider">
+                        <tr
+                            *ngFor="let summary of comparisonSummaryWithDifferences | orderBy: orderDataField: orderByDirection">
+                            <td class="col-date">
+                                {{ summary.readDate | date }}
+                            </td>
+                            <td class="col-existing">
+                                {{ summary.oldReading | number: '1.2-4' }}
+                            </td>
+                            <td class="col-new">
+                                {{ summary.newReading | number: '1.2-4' }}
+                            </td>
+                            <td class="col-difference">
+                                {{ summary.difference | number: '1.2-4' }}
+                            </td>
+                            <td class="col-percentage-difference">
+                                {{ summary.percentageDifference | number: '1.2-2' }}%
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+    <div class="saveCancel popup-footer text-end">
+        <hr class="my-1">
+        <button class="btn btn-secondary" (click)="hideModal()">Close</button>
+    </div>
+</div>

--- a/src/app/data-management/data-management-import/shared-process-file/process-predictor-readings/process-predictor-readings.component.ts
+++ b/src/app/data-management/data-management-import/shared-process-file/process-predictor-readings/process-predictor-readings.component.ts
@@ -7,6 +7,7 @@ import { FileReference } from 'src/app/data-management/data-management-import/im
 import * as _ from 'lodash';
 import { IdbPredictorData } from 'src/app/models/idbModels/predictorData';
 import { IdbFacility } from 'src/app/models/idbModels/facility';
+import { PredictorDataDbService } from 'src/app/indexedDB/predictor-data-db.service';
 
 @Component({
   selector: 'app-process-predictor-readings',
@@ -21,7 +22,16 @@ export class ProcessPredictorReadingsComponent {
   predictorDataSummaries: Array<PredictorDataSummary>;
   predictorsExist: boolean;
   skipAll: boolean = false;
-  constructor(private activatedRoute: ActivatedRoute, private dataManagementService: DataManagementService) { }
+  showModal: boolean = false;
+  readingDifferencesMap: { [predictorId: string]: Array<PredictorReadingComparison> } = {};
+  selectedPredictorName: string;
+  selectedPredictorUnit: string;
+  comparisonSummaryWithDifferences: Array<PredictorReadingComparison> = [];
+  orderDataField: string = 'readDate';
+  orderByDirection: 'asc' | 'desc' = 'desc';
+
+  constructor(private activatedRoute: ActivatedRoute, private dataManagementService: DataManagementService,
+    private predictorDataDbService: PredictorDataDbService) { }
 
   ngOnInit(): void {
     this.paramsSub = this.activatedRoute.parent.params.subscribe(param => {
@@ -29,11 +39,69 @@ export class ProcessPredictorReadingsComponent {
       this.fileReference = this.dataManagementService.getFileReferenceById(id);
       this.predictorsExist = this.fileReference.predictors.length != 0 || this.fileReference.predictorData.length != 0;
       this.setSummary();
+      this.comparePredictorReadings();
     });
   }
 
   ngOnDestroy() {
     this.paramsSub.unsubscribe();
+  }
+
+  comparePredictorReadings() {
+    this.readingDifferencesMap = {};
+
+    this.fileReference.predictorData.forEach(newData => {
+      const key = `${newData.predictorId}_${newData.facilityId}`;
+      if (!this.readingDifferencesMap[key]) {
+        this.readingDifferencesMap[key] = [];
+      }
+
+      const existingPredictorReadings = this.predictorDataDbService.accountPredictorData.getValue().filter(data => (data.predictorId === newData.predictorId && data.facilityId === newData.facilityId));
+
+      existingPredictorReadings.forEach(oldData => {
+        const oldDateObj = new Date(oldData.date);
+        const newDateObj = new Date(newData.date);
+        const existingDateStr = oldDateObj.getFullYear() + '-' + (oldDateObj.getMonth() + 1) + '-' + oldDateObj.getDate();
+        const newDateStr = newDateObj.getFullYear() + '-' + (newDateObj.getMonth() + 1) + '-' + newDateObj.getDate();
+
+        if (existingDateStr === newDateStr) {
+          let difference: number = Math.abs(newData.amount - oldData.amount);
+          let percentageDifference: number = (oldData.amount !== 0) ? (difference / oldData.amount * 100) : null;
+          if (difference !== 0) {
+            this.readingDifferencesMap[key].push({
+              readDate: new Date(newData.date),
+              oldReading: oldData.amount,
+              newReading: newData.amount,
+              difference: difference,
+              percentageDifference: percentageDifference
+            });
+          }
+        }
+      });
+    });
+  }
+
+  openModal(summary: PredictorDataSummary) {
+    this.showModal = true;
+    this.selectedPredictorName = summary.predictor.name;
+    this.selectedPredictorUnit = summary.predictor.unit;
+    this.comparisonSummaryWithDifferences = this.readingDifferencesMap[summary.predictor.guid + '_' + summary.predictor.facilityId];
+  }
+
+  hideModal() {
+    this.showModal = false;
+  }
+
+  setOrderDataField(str: string) {
+    if (str == this.orderDataField) {
+      if (this.orderByDirection == 'desc') {
+        this.orderByDirection = 'asc';
+      } else {
+        this.orderByDirection = 'desc';
+      }
+    } else {
+      this.orderDataField = str;
+    }
   }
 
   setSummary() {
@@ -80,7 +148,7 @@ export class ProcessPredictorReadingsComponent {
           })
         }
       }
-    })
+    });
     this.predictorDataSummaries = dataSummaries;
   }
 
@@ -101,4 +169,12 @@ export interface PredictorDataSummary {
   newStart: Date,
   newEnd: Date,
   skipExisting: boolean
+}
+
+export interface PredictorReadingComparison {
+  readDate?: Date;
+  oldReading?: number;
+  newReading?: number;
+  difference: number;
+  percentageDifference: number;
 }

--- a/src/app/shared/label-with-tooltip/labelTooltips.ts
+++ b/src/app/shared/label-with-tooltip/labelTooltips.ts
@@ -67,5 +67,8 @@ export const LabelTooltips = {
     }, 
     "estimatedReading": {
         "tooltip": "Filter meter data to show estimated readings."
+    },
+    "checkPredictorDifferences": {
+        "tooltip": "Click the icon to check the differences between the existing predictor entries and the imported predictor entries."
     }
 }


### PR DESCRIPTION
connects #2154 

This pull request adds functionality to compare imported predictor readings against existing data, allowing users to view differences in a modal dialog. It introduces new UI elements for displaying comparison results, including sortable tables and tooltips, and improves data handling to prevent unintended mutations. The changes are grouped into enhancements to comparison logic, UI updates, and code/data improvements.

**Comparison logic enhancements:**

* Added `comparePredictorReadings()` method and supporting state to `ProcessPredictorReadingsComponent` to compute and store differences between imported and existing predictor readings by predictor and facility, including difference and percentage difference calculations. 
* Introduced `PredictorReadingComparison` interface to structure comparison data for display.

**UI updates:**

* Added a modal popup to display a sortable table of predictor reading differences, with controls for opening/closing and ordering by various fields. 
* Updated the predictor readings summary table to show an eye icon for predictors with differences, allowing users to open the modal for detailed comparison.
* Replaced static "Existing Predictors Entries" header with a tooltip-enabled label for improved user guidance. 

**Code/data improvements:**

* Modified data import logic in `UploadDataV3Service` to clone existing predictor data before modifying, preventing unintended mutations to original data objects.