### PR TITLE
Issue 2161: remove unused models on export to reduce file size

### DIFF
--- a/src/app/data-evaluation/facility/analysis/analysis-banner/analysis-banner.component.ts
+++ b/src/app/data-evaluation/facility/analysis/analysis-banner/analysis-banner.component.ts
@@ -36,7 +36,7 @@ export class AnalysisBannerComponent implements OnInit {
     this.analysisItemSub = this.analysisDbService.selectedAnalysisItem.subscribe(item => {
       this.analysisItem = item;
       this.isDisabled = false;
-      if (this.analysisItem.setupErrors.groupsHaveErrors) {
+      if (this.analysisItem?.setupErrors.groupsHaveErrors) {
         this.checkButtonState();
       }
     })

--- a/src/app/shared/helper-services/backup-data.service.ts
+++ b/src/app/shared/helper-services/backup-data.service.ts
@@ -66,7 +66,7 @@ export class BackupDataService {
       accountReports: this.accountReportsDbService.accountReports.getValue(),
       groups: this.trimGroups(this.utilityMeterGroupDbService.accountMeterGroups.getValue()),
       accountAnalysisItems: this.accountAnalysisDbService.accountAnalysisItems.getValue(),
-      facilityAnalysisItems: this.analysisDbService.accountAnalysisItems.getValue(),
+      facilityAnalysisItems: this.trimAnalysisModels(this.analysisDbService.accountAnalysisItems.getValue()),
       predictorData: [],
       predictorDataV2: this.predictorDataDbService.accountPredictorData.getValue(),
       predictors: this.predictorDbService.accountPredictors.getValue(),
@@ -97,7 +97,8 @@ export class BackupDataService {
 
     let analysisItems: Array<IdbAnalysisItem> = this.analysisDbService.accountAnalysisItems.getValue();
     let facilityAnalysisItems: Array<IdbAnalysisItem> = analysisItems.filter(meter => { return meter.facilityId == facility.guid });
-
+    facilityAnalysisItems = this.trimAnalysisModels(facilityAnalysisItems);
+    
     let predictorData: Array<IdbPredictorData> = this.predictorDataDbService.accountPredictorData.getValue();
     let facilityPredictorData: Array<IdbPredictorData> = predictorData.filter(meter => { return meter.facilityId == facility.guid });
 
@@ -819,6 +820,22 @@ export class BackupDataService {
       delete group.combinedMonthlyData;
       return group;
     })
+  }
+
+  //only export selected model in analysis items
+  trimAnalysisModels(analysisItems: Array<IdbAnalysisItem>): Array<IdbAnalysisItem> {
+    analysisItems.forEach(item => {
+      item.groups.forEach(group => {
+        if (group.analysisType == 'regression' && group.models) {
+          group.models = group.models.filter(model => {
+            return model.modelId == group.selectedModelId;
+          });
+        } else {
+          group.models = [];
+        }
+      });
+    });
+    return analysisItems;
   }
 }
 


### PR DESCRIPTION
connects #2161 

When exporting to a backup file, remove any unused models. these can be re-generated later if the user wants. Used models get saved. We were backing-up hundreds of thousands of models that were unused in some instances. 
