### PR TITLE
Update release_desktop

### DIFF
--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Build
         run: npm run build-prod-electron
       - name: Package [Mac]
-        run: npm run dist-nopublish
+        run: npm run dist-nopublish -- --mac --universal
       - name: Notarize
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}


### PR DESCRIPTION
Changes:
  - Bump bundle_mac `runs-on` target due to deprecation of macos-13 runner
  - Switch mac bundle to universal for ARM64, AMD64 support