### PR TITLE
Issue 2131 - added a predictor validation check in analysis for annual and monthly tables

### DIFF
--- a/src/app/calculations/analysis-calculations/annualAccountAnalysisSummaryClass.ts
+++ b/src/app/calculations/analysis-calculations/annualAccountAnalysisSummaryClass.ts
@@ -82,7 +82,8 @@ export class AnnualAccountAnalysisSummaryClass {
                 isBanked: false,
                 isIntermediateBanked: false,
                 savingsBanked: checkAnalysisValue(summaryDataClass.savingsBanked),
-                savingsUnbanked: checkAnalysisValue(summaryDataClass.savingsUnbanked)
+                savingsUnbanked: checkAnalysisValue(summaryDataClass.savingsUnbanked),
+                missingPredictorValue: summaryDataClass.missingPredictorValue
             }
         })
     }

--- a/src/app/calculations/analysis-calculations/annualAnalysisSummaryDataClass.ts
+++ b/src/app/calculations/analysis-calculations/annualAnalysisSummaryDataClass.ts
@@ -39,6 +39,7 @@ export class AnnualAnalysisSummaryDataClass {
     baselineAdjustmentInput: number;
     isBanked: boolean;
     isIntermediateBanked: boolean;
+    missingPredictorValue: boolean;
     constructor(
         monthlyAnalysisSummaryData: Array<MonthlyAnalysisSummaryData>,
         year: number,
@@ -67,6 +68,13 @@ export class AnnualAnalysisSummaryDataClass {
         this.setAnnualSavingsPercentImprovement();
         this.setCummulativeSavings(previousYearsSummaryData);
         this.setNewSavings();
+        this.setMissingPredictorValue(monthlyAnalysisSummaryData);
+    }
+
+    setMissingPredictorValue(monthlyAnalysisSummaryData: Array<MonthlyAnalysisSummaryData>) {
+        this.missingPredictorValue = monthlyAnalysisSummaryData.some(data =>
+            data.date.getUTCFullYear() === this.year && data.missingValueWarning
+        );
     }
 
     setYearAnalysisSummaryData(monthlyAnalysisSummaryData: Array<MonthlyAnalysisSummaryData>) {
@@ -231,7 +239,8 @@ export class AnnualAnalysisSummaryDataClass {
             isBanked: this.isBanked,
             isIntermediateBanked: this.isIntermediateBanked,
             savingsBanked: checkAnalysisValue(this.savingsBanked),
-            savingsUnbanked: checkAnalysisValue(this.savingsUnbanked)
+            savingsUnbanked: checkAnalysisValue(this.savingsUnbanked),
+            missingPredictorValue: this.missingPredictorValue
         }
     }
 

--- a/src/app/calculations/analysis-calculations/annualFacilityAnalysisSummaryClass.ts
+++ b/src/app/calculations/analysis-calculations/annualFacilityAnalysisSummaryClass.ts
@@ -97,7 +97,8 @@ export class AnnualFacilityAnalysisSummaryClass {
                 isBanked: false,
                 isIntermediateBanked: false,
                 savingsBanked: checkAnalysisValue(summaryDataClass.savingsBanked),
-                savingsUnbanked: checkAnalysisValue(summaryDataClass.savingsUnbanked)
+                savingsUnbanked: checkAnalysisValue(summaryDataClass.savingsUnbanked),
+                missingPredictorValue: summaryDataClass.missingPredictorValue
             }
         })
     }

--- a/src/app/calculations/analysis-calculations/annualGroupAnalysisSummaryClass.ts
+++ b/src/app/calculations/analysis-calculations/annualGroupAnalysisSummaryClass.ts
@@ -122,7 +122,8 @@ export class AnnualGroupAnalysisSummaryClass {
             isBanked: summaryDataClass.isBanked,
             isIntermediateBanked: summaryDataClass.isIntermediateBanked,
             savingsUnbanked: checkAnalysisValue(summaryDataClass.savingsUnbanked),
-            savingsBanked: checkAnalysisValue(summaryDataClass.savingsBanked)
+            savingsBanked: checkAnalysisValue(summaryDataClass.savingsBanked),
+            missingPredictorValue: summaryDataClass.missingPredictorValue
         }
     }
 

--- a/src/app/calculations/analysis-calculations/monthlyAccountAnalysisClass.ts
+++ b/src/app/calculations/analysis-calculations/monthlyAccountAnalysisClass.ts
@@ -171,7 +171,8 @@ export class MonthlyAccountAnalysisClass {
                 tenPercentSavings: checkAnalysisValue(summaryDataItem.monthlyAnalysisCalculatedValues.tenPercentSavings),
                 fivePercentSavings: checkAnalysisValue(summaryDataItem.monthlyAnalysisCalculatedValues.fivePercentSavings),
                 thirtyPercentTarget: checkAnalysisValue(summaryDataItem.monthlyAnalysisCalculatedValues.thirtyPercentTarget),
-                thirtyPercentSavings: checkAnalysisValue(summaryDataItem.monthlyAnalysisCalculatedValues.thirtyPercentSavings)
+                thirtyPercentSavings: checkAnalysisValue(summaryDataItem.monthlyAnalysisCalculatedValues.thirtyPercentSavings),
+                missingValueWarning: summaryDataItem.monthlyAnalysisCalculatedValues.missingValueWarning
             }
         })
     }

--- a/src/app/calculations/analysis-calculations/monthlyAnalysisCalculatedValuesClassSummation.ts
+++ b/src/app/calculations/analysis-calculations/monthlyAnalysisCalculatedValuesClassSummation.ts
@@ -43,6 +43,7 @@ export class MonthlyAnalysisCalculatedValuesSummation {
     fivePercentSavings: number;
     thirtyPercentTarget: number;
     thirtyPercentSavings: number;
+    missingValueWarning: boolean;
     constructor(
         currentMonthData: Array<MonthlyAnalysisSummaryDataClass>,
         baselineAdjustmentForNew: number,
@@ -78,8 +79,12 @@ export class MonthlyAnalysisCalculatedValuesSummation {
         this.setFivePercentSavings();
         this.setThirtyPercentTarget();
         this.setThirtyPercentSavings();
+        this.setMissingValueWarning(currentMonthData);
     }
 
+    setMissingValueWarning(currentMonthData: Array<MonthlyAnalysisSummaryDataClass>) {
+        this.missingValueWarning = currentMonthData.some(data => data.missingValueWarning == true);
+    }
 
     initializeYearToDateValues(previousMonthsValues: Array<MonthlyAnalysisCalculatedValuesSummation>) {
         this.summaryDataIndex = previousMonthsValues.length;

--- a/src/app/calculations/analysis-calculations/monthlyAnalysisSummaryClass.ts
+++ b/src/app/calculations/analysis-calculations/monthlyAnalysisSummaryClass.ts
@@ -53,7 +53,7 @@ export class MonthlyAnalysisSummaryClass {
             baselineYearEndDate.setFullYear(baselineYearEndDate.getFullYear() + 1);
             baselineActualSummaryData = new Array();
             while (baselineDate < baselineYearEndDate) {
-                let monthlyAnalysisSummaryDataClass: MonthlyAnalysisSummaryDataClass = new MonthlyAnalysisSummaryDataClass(this.monthlyGroupAnalysisClass, baselineDate, baselineActualSummaryData, this.facility, this.lastBankedMonthSummaryData, undefined)
+                let monthlyAnalysisSummaryDataClass: MonthlyAnalysisSummaryDataClass = new MonthlyAnalysisSummaryDataClass(this.monthlyGroupAnalysisClass, baselineDate, baselineActualSummaryData, this.facility, this.lastBankedMonthSummaryData, undefined);
                 baselineActualSummaryData.push(monthlyAnalysisSummaryDataClass);
                 let currentMonth: number = baselineDate.getUTCMonth()
                 let nextMonth: number = currentMonth + 1;
@@ -158,7 +158,8 @@ export class MonthlyAnalysisSummaryClass {
                 twentyPercentSavings: checkAnalysisValue(summaryDataItem.monthlyAnalysisRollingValues.twentyPercentSavings),
                 fifteenPercentSavings: checkAnalysisValue(summaryDataItem.monthlyAnalysisRollingValues.fifteenPercentSavings),
                 thirtyPercentTarget: checkAnalysisValue(summaryDataItem.monthlyAnalysisRollingValues.thirtyPercentTarget),
-                thirtyPercentSavings: checkAnalysisValue(summaryDataItem.monthlyAnalysisRollingValues.thirtyPercentSavings)
+                thirtyPercentSavings: checkAnalysisValue(summaryDataItem.monthlyAnalysisRollingValues.thirtyPercentSavings),
+                missingValueWarning: summaryDataItem.missingValueWarning
             }
         })
     }

--- a/src/app/calculations/analysis-calculations/monthlyAnalysisSummaryDataClass.ts
+++ b/src/app/calculations/analysis-calculations/monthlyAnalysisSummaryDataClass.ts
@@ -44,6 +44,8 @@ export class MonthlyAnalysisSummaryDataClass {
     baselineYear: number;
     bankedAnalysisYear: number;
     originalBaselineYearBaselineActualEnergyUse: number;
+
+    missingValueWarning: boolean;
     constructor(
         monthlyGroupAnalysisClass: MonthlyGroupAnalysisClass,
         monthDate: Date,
@@ -53,6 +55,7 @@ export class MonthlyAnalysisSummaryDataClass {
         baselineActualSummaryData: Array<MonthlyAnalysisSummaryDataClass>
     ) {
         this.date = monthDate;
+        this.missingValueWarning = false;
         this.group = monthlyGroupAnalysisClass.selectedGroup;
         this.isNew = facility.isNewFacility;
         this.baselineYear = monthlyGroupAnalysisClass.baselineYear;
@@ -164,6 +167,7 @@ export class MonthlyAnalysisSummaryDataClass {
             this.modeledEnergy = this.baselineActualEnergyUse;
         } else if (analysisType == 'energyIntensity') {
             this.modeledEnergy = this.calculateEnergyIntensityModeledEnergy(baselineYearEnergyIntensity);
+            this.isProductionDataMissing(predictorVariables);
         } else if (analysisType == 'modifiedEnergyIntensity') {
             this.modeledEnergy = this.calculateModifiedEnegyIntensityModeledEnergy(baselineYearEnergyIntensity);
         }
@@ -185,12 +189,25 @@ export class MonthlyAnalysisSummaryDataClass {
             modeledEnergy = modeledEnergy + (usageVal * variable.regressionCoefficient);
         });
         modeledEnergy = modeledEnergy + this.group.regressionConstant;
+        this.isPredictorDataMissing(predictorVariables);
         return modeledEnergy;
+    }
+
+    isPredictorDataMissing(predictorVariables: Array<AnalysisGroupPredictorVariable>) {
+        this.missingValueWarning = predictorVariables.some(variable =>
+            !this.monthPredictorData.some(data => data.predictorId == variable.id)
+        );
     }
 
     calculateEnergyIntensityModeledEnergy(baselineEnergyIntensity: number): number {
         let totalProductionUsage: number = _.sum(this.productionUsage);
         return baselineEnergyIntensity * totalProductionUsage;
+    }
+
+    isProductionDataMissing(predictorVariables: Array<AnalysisGroupPredictorVariable>) {
+        this.missingValueWarning = predictorVariables.filter(variable => variable.productionInAnalysis).some(variable =>
+            !this.monthPredictorData.some(data => data.predictorId == variable.id)
+        );
     }
 
     calculateModifiedEnegyIntensityModeledEnergy(baselineYearEnergyIntensity: number): number {

--- a/src/app/calculations/analysis-calculations/monthlyFacilityAnalysisClass.ts
+++ b/src/app/calculations/analysis-calculations/monthlyFacilityAnalysisClass.ts
@@ -171,7 +171,8 @@ export class MonthlyFacilityAnalysisClass {
                 twentyPercentSavings: checkAnalysisValue(summaryDataItem.monthlyAnalysisCalculatedValues.twentyPercentSavings),
                 twentyFivePercentSavings: checkAnalysisValue(summaryDataItem.monthlyAnalysisCalculatedValues.twentyFivePercentSavings),
                 thirtyPercentTarget: checkAnalysisValue(summaryDataItem.monthlyAnalysisCalculatedValues.thirtyPercentTarget),
-                thirtyPercentSavings: checkAnalysisValue(summaryDataItem.monthlyAnalysisCalculatedValues.thirtyPercentSavings)
+                thirtyPercentSavings: checkAnalysisValue(summaryDataItem.monthlyAnalysisCalculatedValues.thirtyPercentSavings),
+                missingValueWarning: summaryDataItem.missingValueWarning
             }
         })
     }

--- a/src/app/calculations/analysis-calculations/monthlyFacilityAnalysisDataClass.ts
+++ b/src/app/calculations/analysis-calculations/monthlyFacilityAnalysisDataClass.ts
@@ -25,6 +25,7 @@ export class MonthlyFacilityAnalysisDataClass {
     dataAdjustment: number;
     modelYearDataAdjustment: number;
     isBanked: boolean;
+    missingValueWarning: boolean;
     constructor(
         allFacilityAnalysisData: Array<MonthlyAnalysisSummaryDataClass>,
         monthDate: Date,
@@ -39,6 +40,7 @@ export class MonthlyFacilityAnalysisDataClass {
         this.setCurrentMonthData(allFacilityAnalysisData);
         this.setMonthPredictorData(facilityPredictorEntries);
         this.setPredictorUsage(facilityPredictorEntries, predictors);
+        this.setMissingPredictorWarning(predictors);
         this.setBaselineAdjustmentInput();
         this.setDataAdjustment();
         this.setModelYearDataAdjustment();
@@ -75,6 +77,12 @@ export class MonthlyFacilityAnalysisDataClass {
                 });
             });
         }
+    }
+
+    setMissingPredictorWarning(predictors: Array<IdbPredictor>) {
+        this.missingValueWarning = predictors.some(variable =>
+            !this.monthPredictorData.some(data => data.predictorId == variable.guid)
+        );
     }
 
     setFiscalYear(facility: IdbFacility) {

--- a/src/app/models/analysis.ts
+++ b/src/app/models/analysis.ts
@@ -93,7 +93,8 @@ export interface MonthlyAnalysisSummaryData {
   twentyPercentSavings: number,
   twentyFivePercentSavings: number,
   thirtyPercentTarget: number,
-  thirtyPercentSavings: number
+  thirtyPercentSavings: number,
+  missingValueWarning: boolean
 }
 
 export interface AnnualAnalysisSummary {
@@ -120,7 +121,8 @@ export interface AnnualAnalysisSummary {
   // adjustedStar: number,
   // adjustedStarStar: number
   isBanked: boolean,
-  isIntermediateBanked: boolean
+  isIntermediateBanked: boolean,
+  missingPredictorValue: boolean
 }
 
 

--- a/src/app/shared/helper-services/analysis-validation.service.ts
+++ b/src/app/shared/helper-services/analysis-validation.service.ts
@@ -92,8 +92,8 @@ export class AnalysisValidationService {
     let isTwelveMonthSelected: boolean = true;
     let allMeterReadingsPresent: boolean = true;
     let allPredictorReadingsPresent: boolean = true;
-    this.facilityMeterData = this.utilityMeterDataDbService.facilityMeterData.getValue();
-    this.facilityPredictorData = this.predictorDataDbService.facilityPredictorData.getValue();
+    this.facilityMeterData = this.utilityMeterDataDbService.getFacilityMeterDataByFacilityGuid(analysisItem.facilityId);
+    this.facilityPredictorData = this.predictorDataDbService.getByFacilityId(analysisItem.facilityId);
 
     let missingGroupMeters: boolean = groupMeters.length == 0;
     if (group.analysisType != 'absoluteEnergyConsumption' && group.analysisType != 'skipAnalysis' && group.analysisType != 'skip') {

--- a/src/app/shared/shared-analysis/annual-analysis-summary-table/annual-analysis-summary-table.component.html
+++ b/src/app/shared/shared-analysis/annual-analysis-summary-table/annual-analysis-summary-table.component.html
@@ -1,3 +1,8 @@
+<div class="alert alert-warning d-flex align-items-center justify-content-center p-2 mb-2"
+    *ngIf="missingPredictorValue">
+    <span class="fa fa-exclamation-triangle">&nbsp;&nbsp;</span>
+    Predictor data is missing. Please review the predictor entries.
+</div>
 <table class="table utility-data table-sm table-bordered table-hover print-break-avoid" #dataTable
     [ngClass]="{'copying-table': copyingTable}">
     <thead class="sortable">
@@ -112,8 +117,8 @@
                 <span class="fa fa-piggy-bank" *ngIf="summary.isBanked && !summary.isIntermediateBanked"></span>
                 <span class="fa fa-building-columns" *ngIf="summary.savingsBanked"></span>
                 <span class="fa fa-paint-roller" *ngIf="summary.isIntermediateBanked"></span>
-                <span class="fa fa-star" *ngIf="group.userDefinedModel && summary.year == modelYear"></span>
-                <span class="fa fa-star" *ngIf="!group.userDefinedModel && isSummaryYear(summary.year)"></span>
+                <span class="fa fa-star" *ngIf="group?.userDefinedModel && summary.year == modelYear"></span>
+                <span class="fa fa-star" *ngIf="!group?.userDefinedModel && isSummaryYear(summary.year)"></span>
                 {{summary.year | yearDisplay: accountOrFacility.fiscalYear}}
             </td>
 

--- a/src/app/shared/shared-analysis/annual-analysis-summary-table/annual-analysis-summary-table.component.ts
+++ b/src/app/shared/shared-analysis/annual-analysis-summary-table/annual-analysis-summary-table.component.ts
@@ -49,6 +49,7 @@ export class AnnualAnalysisSummaryTableComponent implements OnInit {
   modelYear: number;
   modelStartYear: number;
   modelEndYear: number;
+  missingPredictorValue: boolean = false;
   constructor(private analysisService: AnalysisService, private copyTableService: CopyTableService,
     private router: Router) { }
 
@@ -63,12 +64,20 @@ export class AnnualAnalysisSummaryTableComponent implements OnInit {
     });
     this.setHasBanked();
     this.setModelYear();
-    this.modelStartYear = this.group.regressionStartYear;
-    this.modelEndYear = this.group.regressionEndYear;
+    this.modelStartYear = this.group?.regressionStartYear;
+    this.modelEndYear = this.group?.regressionEndYear;
+    this.missingPredictorValue = this.checkPredictorData();
   }
 
   ngOnDestroy() {
     this.analysisTableColumnsSub.unsubscribe();
+  }
+
+  checkPredictorData() {
+    if(this.annualAnalysisSummary) {
+      return this.annualAnalysisSummary.some(data => data.missingPredictorValue);
+    }
+    return false;
   }
 
   setPredictorVariables() {

--- a/src/app/shared/shared-analysis/monthly-analysis-summary-table/monthly-analysis-summary-table.component.html
+++ b/src/app/shared/shared-analysis/monthly-analysis-summary-table/monthly-analysis-summary-table.component.html
@@ -1,3 +1,10 @@
+<div class="alert alert-warning d-flex align-items-center justify-content-center p-2 mb-2"
+    *ngIf="isPredictorDataMissing">
+    <span class="fa fa-exclamation-triangle">&nbsp;&nbsp;</span>
+    Predictor data is missing for {{missingMonthCount}} months. Results may be
+    inaccurate as the missing values are assumed to be zero.
+    Please review the predictor entries.
+</div>
 <table class="table utility-data table-sm table-bordered table-hover print-break-avoid" #dataTable
     [ngClass]="{'copying-table': copyingTable}">
     <thead class="sortable">
@@ -98,7 +105,7 @@
                     [ngClass]="{'active': orderDataField == 'savings'}">
                     Savings
                 </th>
-               <!--<th *ngIf="analysisTableColumns.percentSavingsComparedToBaseline"
+                <!--<th *ngIf="analysisTableColumns.percentSavingsComparedToBaseline"
                     (click)="setOrderDataField('percentSavingsComparedToBaseline')"
                     [ngClass]="{'active': orderDataField == 'percentSavingsComparedToBaseline'}">
                     % Savings
@@ -131,8 +138,8 @@
                 <span class="fa fa-piggy-bank" *ngIf="data.isBanked && !data.isIntermediateBanked"></span>
                 <span class="fa fa-building-columns" *ngIf="data.savingsBanked"></span>
                 <span class="fa fa-paint-roller" *ngIf="data.isIntermediateBanked"></span>
-                <span class="fa fa-star" *ngIf="group.userDefinedModel && data.fiscalYear == modelYear"></span>
-                <span class="fa fa-star" *ngIf="!group.userDefinedModel && isModelYearMonth(data.date)"></span>
+                <span class="fa fa-star" *ngIf="group?.userDefinedModel && data.fiscalYear == modelYear"></span>
+                <span class="fa fa-star" *ngIf="!group?.userDefinedModel && isModelYearMonth(data.date)"></span>
                 {{data.date | date: 'MMMM, y'}}
             </td>
             <td>
@@ -230,7 +237,8 @@
                     </ng-template>
                 </td>
                 <td *ngIf="analysisTableColumns.bankedSavings">
-                    <ng-template [ngIf]="data.savingsBanked && !data.isIntermediateBanked" [ngIfElse]="bankedSavingsMdash">
+                    <ng-template [ngIf]="data.savingsBanked && !data.isIntermediateBanked"
+                        [ngIfElse]="bankedSavingsMdash">
                         <span [ngClass]="{'red': data.savingsBanked < 0}">
                             {{data.savingsBanked | customNumber}}
                         </span>
@@ -242,7 +250,8 @@
                     </ng-template>
                 </td>
                 <td *ngIf="analysisTableColumns.savingsUnbanked">
-                    <ng-template [ngIf]="data.savingsUnbanked && !data.isIntermediateBanked" [ngIfElse]="unbankedSavingsMdash">
+                    <ng-template [ngIf]="data.savingsUnbanked && !data.isIntermediateBanked"
+                        [ngIfElse]="unbankedSavingsMdash">
                         <span [ngClass]="{'red': data.savingsUnbanked < 0}">
                             {{data.savingsUnbanked | customNumber}}
                         </span>
@@ -265,7 +274,7 @@
                         </span>
                     </ng-template>
                 </td>
-               <!--  <td *ngIf="analysisTableColumns.percentSavingsComparedToBaseline">
+                <!--  <td *ngIf="analysisTableColumns.percentSavingsComparedToBaseline">
                     <span *ngIf="data.percentSavingsComparedToBaseline"
                         [ngClass]="{'red': data.percentSavingsComparedToBaseline < 0}">
                         {{data.percentSavingsComparedToBaseline | number:'1.0-2'}} %

--- a/src/app/shared/shared-analysis/monthly-analysis-summary-table/monthly-analysis-summary-table.component.ts
+++ b/src/app/shared/shared-analysis/monthly-analysis-summary-table/monthly-analysis-summary-table.component.ts
@@ -61,6 +61,8 @@ export class MonthlyAnalysisSummaryTableComponent implements OnInit {
   modelStartYear: number;
   modelEndMonth: number;
   modelEndYear: number;
+  isPredictorDataMissing: boolean = false;
+  missingMonthCount: number = 0;
   constructor(private analysisService: AnalysisService, private copyTableService: CopyTableService, private router: Router) { }
 
   ngOnInit(): void {
@@ -76,14 +78,24 @@ export class MonthlyAnalysisSummaryTableComponent implements OnInit {
     if (this.inReport) {
       this.setReportLabel();
     }
-    this.modelStartMonth = this.group.regressionModelStartMonth;
-    this.modelStartYear = this.group.regressionStartYear;
-    this.modelEndMonth = this.group.regressionModelEndMonth;
-    this.modelEndYear = this.group.regressionEndYear;
+    this.modelStartMonth = this.group?.regressionModelStartMonth;
+    this.modelStartYear = this.group?.regressionStartYear;
+    this.modelEndMonth = this.group?.regressionModelEndMonth;
+    this.modelEndYear = this.group?.regressionEndYear;
+
+    this.missingMonthCount = this.checkPredictorData();
+    this.isPredictorDataMissing = this.missingMonthCount > 0;
   }
 
   ngOnDestroy() {
     this.analysisTableColumnsSub.unsubscribe();
+  }
+
+  checkPredictorData() {
+    if(this.monthlyAnalysisSummaryData) {
+      return this.monthlyAnalysisSummaryData.filter(data => data.missingValueWarning).length;
+    }
+    return 0;
   }
 
   setPredictorVariables() {


### PR DESCRIPTION
connects #2131 

This pull request introduces a new mechanism for detecting and surfacing missing predictor data across monthly and annual analysis summaries. The changes propagate a `missingValueWarning` (monthly) and `missingPredictorValue` (annual) throughout the data models, calculation classes, and UI, culminating in a warning message for users when predictor data is incomplete.

The most important changes are:

**Data Model & Calculation Enhancements:**

* Added `missingValueWarning` to `MonthlyAnalysisSummaryDataClass`, `MonthlyFacilityAnalysisDataClass`, and their summation/calculation classes, with new logic to determine if predictor or production data is missing for a given month.
* Added `missingPredictorValue` to `AnnualAnalysisSummaryDataClass` and related calculation classes, with logic to aggregate monthly warnings into an annual flag. 

**Interface & Data Propagation:**

* Updated TypeScript interfaces (`MonthlyAnalysisSummaryData`, `AnnualAnalysisSummary`) to include the new warning fields. 
* Ensured all summary/aggregation classes (account, facility, group) propagate the missing predictor value to their respective summaries. 

**UI Enhancements:**

* Added a warning banner to the annual analysis summary table UI to alert users when predictor data is missing, and updated the component logic to check for and display this state. 
* Improved template bindings to handle optional chaining for group model properties in the summary table.
