### PR TITLE
Issue 1550 - calculation changes for user defined models

### DIFF
--- a/src/app/data-evaluation/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.ts
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.ts
@@ -217,7 +217,7 @@ export class AnalysisSetupComponent implements OnInit {
       let group: AnalysisGroup = this.analysisItem.groups[i];
       if (group.analysisType == 'regression') {
         for (let m = 0; m < group.models.length; m++) {
-          this.analysisItem.groups[i].models[m] = this.regressionModelsService.updateModelReportYear(this.analysisItem.groups[i].models[m], this.analysisItem.reportYear, this.facility, this.analysisItem.baselineYear);
+          this.analysisItem.groups[i].models[m] = this.regressionModelsService.updateModelReportYear(this.analysisItem.groups[i].models[m], this.analysisItem.reportYear, this.facility, this.analysisItem.baselineYear, group);
         }
       }
     }

--- a/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-user-defined-model-inspection/regression-user-defined-model-inspection.component.ts
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-user-defined-model-inspection/regression-user-defined-model-inspection.component.ts
@@ -129,7 +129,7 @@ export class RegressionUserDefinedModelInspectionComponent {
       modelValidationNotes: ['']
     };
 
-    const validatedModel = this.regressionsModelsService.setModelVaildAndNotes(this.userModel, facilityPredictorData, reportYear, this.selectedFacility, baselineYear);
+    const validatedModel = this.regressionsModelsService.setModelVaildAndNotes(this.userModel, facilityPredictorData, reportYear, this.selectedFacility, baselineYear, this.selectedGroup);
     this.userModel = validatedModel;
   }
 

--- a/src/app/shared/helper-services/analysis-validation.service.ts
+++ b/src/app/shared/helper-services/analysis-validation.service.ts
@@ -100,6 +100,7 @@ export class AnalysisValidationService {
         missingRegressionConstant = this.checkValueValid(group.regressionConstant) == false;
         missingRegressionModelYear = this.checkValueValid(group.regressionModelYear) == false;
         if (!group.userDefinedModel) {
+          missingRegressionModelYear = false;
           missingRegressionModelStartMonth = this.checkValueValid(group.regressionModelStartMonth) == false;
           missingRegressionStartYear = this.checkValueValid(group.regressionStartYear) == false;
           missingRegressionModelEndMonth = this.checkValueValid(group.regressionModelEndMonth) == false;

--- a/src/app/shared/shared-analysis/calculations/regression-models.service.ts
+++ b/src/app/shared/shared-analysis/calculations/regression-models.service.ts
@@ -53,7 +53,7 @@ export class RegressionModelsService {
               modelPredictorVariables.push(variable);
             });
             model['predictorVariables'] = modelPredictorVariables;
-            model = this.setModelVaildAndNotes(model, facilityPredictorData, reportYear, facility, baselineYear);
+            model = this.setModelVaildAndNotes(model, facilityPredictorData, reportYear, facility, baselineYear, analysisGroup);
 
             let modelId: string = '';
             let predictorVariableIds: string = '';
@@ -208,7 +208,7 @@ export class RegressionModelsService {
     }
   }
 
-  setModelVaildAndNotes(model: JStatRegressionModel, facilityPredictorData: Array<IdbPredictorData>, reportYear: number, facility: IdbFacility, baselineYear: number): JStatRegressionModel {
+  setModelVaildAndNotes(model: JStatRegressionModel, facilityPredictorData: Array<IdbPredictorData>, reportYear: number, facility: IdbFacility, baselineYear: number, selectedGroup: AnalysisGroup): JStatRegressionModel {
     let modelNotes: Array<string> = new Array();
     let dataValidationNotes: Array<string> = new Array();
     let modeValidationNotes: Array<string> = new Array();
@@ -266,7 +266,7 @@ export class RegressionModelsService {
       modelNotes.push('No production variable in model');
     }
 
-    let validationCheck: { SEPNotes: Array<string>, SEPValidation: Array<SEPValidation> } = this.checkSEPNotes(model, facilityPredictorData, reportYear, facility, baselineYear);
+    let validationCheck: { SEPNotes: Array<string>, SEPValidation: Array<SEPValidation> } = this.checkSEPNotes(model, facilityPredictorData, reportYear, facility, baselineYear, selectedGroup);
     validationCheck.SEPNotes.forEach(note => {
       dataValidationNotes.push(note);
     })
@@ -310,12 +310,28 @@ export class RegressionModelsService {
   }
 
 
-  checkSEPNotes(model: JStatRegressionModel, facilityPredictorData: Array<IdbPredictorData>, reportYear: number, facility: IdbFacility, baselineYear: number): { SEPNotes: Array<string>, SEPValidation: Array<SEPValidation> } {
+  checkSEPNotes(model: JStatRegressionModel, facilityPredictorData: Array<IdbPredictorData>, reportYear: number, facility: IdbFacility, baselineYear: number, selectedGroup: AnalysisGroup): { SEPNotes: Array<string>, SEPValidation: Array<SEPValidation> } {
+    let startMonth: number;
+    let startYear: number;
+    let endMonth: number;
+    let endYear: number;
+    let startDate: Date;
+    let endDate: Date;
+    if (selectedGroup && !selectedGroup.userDefinedModel) {
+      startMonth = selectedGroup.regressionModelStartMonth;
+      startYear = selectedGroup.regressionStartYear;
+      endMonth = selectedGroup.regressionModelEndMonth;
+      endYear = selectedGroup.regressionEndYear;
+      startDate = new Date(startYear, startMonth, 1);
+      endDate = new Date(endYear, endMonth, 1);
+    }
+
     let SEPNotes: Array<string> = new Array();
     let SEPValidation: Array<SEPValidation> = new Array();
     let modelPredictorData: Array<IdbPredictorData> = new Array();
     let reportYearPredictorData: Array<IdbPredictorData> = new Array();
     let baselineYearPredictorData: Array<IdbPredictorData> = new Array();
+    let userDefinedModelPredictorData: Array<IdbPredictorData> = new Array();
     for (let i = 0; i < facilityPredictorData.length; i++) {
       let predictorDate: Date = getDateFromPredictorData(facilityPredictorData[i])
       let fiscalYear: number = getFiscalYear(predictorDate, facility);
@@ -328,6 +344,11 @@ export class RegressionModelsService {
       if (fiscalYear == baselineYear) {
         baselineYearPredictorData.push(facilityPredictorData[i]);
       }
+      if (selectedGroup && !selectedGroup.userDefinedModel && startDate && endDate) {
+        if (predictorDate >= startDate && predictorDate <= endDate) {
+          userDefinedModelPredictorData.push(facilityPredictorData[i])
+        }
+      }
     }
 
     model.predictorVariables.forEach(variable => {
@@ -336,7 +357,6 @@ export class RegressionModelsService {
       let modelPlus3StdDevValid: boolean = true;
       let modelMinus3StdDevValid: boolean = true;
 
-
       let variableNotes: Array<string> = new Array();
       let variableValid: boolean = true;
       let variablePredictorData: Array<IdbPredictorData> = modelPredictorData.filter(pData => {
@@ -344,13 +364,25 @@ export class RegressionModelsService {
       });
       let variableReportYearPredictorData: Array<IdbPredictorData> = reportYearPredictorData.filter(pData => {
         return pData.predictorId == variable.id;
-      })
+      });
       let variableBaselineYearPredictorData: Array<IdbPredictorData> = baselineYearPredictorData.filter(pData => {
         return pData.predictorId == variable.id;
-      })
-      let modelYearUsage: Array<number> = variablePredictorData.map(data => {
-        return data.amount;
       });
+      let variableUserDefinedModelPredictorData: Array<IdbPredictorData> = userDefinedModelPredictorData.filter(pData => {
+        return pData.predictorId == variable.id;
+      });
+
+      let modelYearUsage: Array<number>;
+      if (selectedGroup && !selectedGroup.userDefinedModel) {
+        modelYearUsage = variableUserDefinedModelPredictorData.map(data => {
+          return data.amount;
+        });
+      }
+      else {
+        modelYearUsage = variablePredictorData.map(data => {
+          return data.amount;
+        });
+      }
       let modelMin: number = _.min(modelYearUsage);
       let modelMax: number = _.max(modelYearUsage);
 
@@ -449,7 +481,7 @@ export class RegressionModelsService {
         modelMinus3StdDev: standardMin,
         modelMinus3StdDevValid: modelMinus3StdDevValid,
         isValid: variableValid
-      })
+      });
 
       if (variableValid == false) {
         variableNotes.forEach(note => {
@@ -463,9 +495,9 @@ export class RegressionModelsService {
     };
   }
 
-  updateModelReportYear(model: JStatRegressionModel, reportYear: number, facility: IdbFacility, baselineYear: number): JStatRegressionModel {
+  updateModelReportYear(model: JStatRegressionModel, reportYear: number, facility: IdbFacility, baselineYear: number, group: AnalysisGroup): JStatRegressionModel {
     let facilityPredictorData: Array<IdbPredictorData> = this.predictorDataDbService.facilityPredictorData.getValue();
-    model = this.setModelVaildAndNotes(model, facilityPredictorData, reportYear, facility, baselineYear);
+    model = this.setModelVaildAndNotes(model, facilityPredictorData, reportYear, facility, baselineYear, group);
     return model;
   }
 


### PR DESCRIPTION
connects #1550 

This pull request primarily updates the regression model validation and report year update logic to take into account the `AnalysisGroup` context. This allows for more accurate validation and data selection, especially for non-user-defined models using group-specific date ranges. The changes propagate the `AnalysisGroup` parameter through several service and component methods and enhance how predictor data is filtered and validated.

**Regression Model Validation and Data Selection:**

* Updated `setModelVaildAndNotes` and `updateModelReportYear` in `RegressionModelsService` to accept an `AnalysisGroup` parameter, enabling group-specific validation and data handling.
* Enhanced `checkSEPNotes` in `RegressionModelsService` to use group-specific start/end dates for filtering predictor data when the model is not user-defined, resulting in more precise validation. 
* Updated logic in `AnalysisSetupComponent` and `RegressionUserDefinedModelInspectionComponent` to pass the appropriate `AnalysisGroup` when updating or validating regression models. 
* Modified validation logic in `AnalysisValidationService` to skip the regression model year check for non-user-defined models, aligning with the new group-based validation approach.