### PR TITLE
Patch release_desktop codesigning process

### DIFF
--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Codesign
         run: |
           TMP_CERT_PATH="$RUNNER_TEMP/cert.pem"
-          BUNDLE_PATH=$(find . -name "VERIFI-Setup-*.exe")
+          BUNDLE_PATH=$(find output -name "VERIFI-Setup-*.exe")
 
           echo -n "${{ secrets.WIN_CERT_BASE64 }}" | base64 --decode > $TMP_CERT_PATH
 
@@ -231,6 +231,8 @@ jobs:
           compression-level: 0
           if-no-files-found: error
           retention-days: 1
+      - name: Cleanup
+        run: rm -rf ./output
 
   release:
     if: github.ref_name == 'master'


### PR DESCRIPTION
The following changes have been made to ensure the appropriate exe is both signed and uploaded for release. Prior to addition of cleanup, using the `find` pattern of `VERIFI-Setup-*.exe` _could_ produce multiple .exe files, which would cause the `latest.yml` to have no `sha512` attribute set.
```
Changes:
  - Set explicit search path for target exe
  - Add cleanup step post artifact upload
```