### PR TITLE
Issue 2247 - updated download failure toast message

### DIFF
--- a/src/app/core-components/electron-update/electron-update.component.html
+++ b/src/app/core-components/electron-update/electron-update.component.html
@@ -4,33 +4,38 @@
     <i class="fa fa-exclamation-circle item-left me-2"></i>
 
     @if (!updateError) {
-      A new version of VERIFI is available!
+    A new version of VERIFI is available!
     }
     @if (updateError) {
-      Ooops! Something went wrong!
+    Ooops! Something went wrong!
     }
     <button type="button" class="btn-close" aria-label="Close" (click)="closeUpdateAvailable()"></button>
   </div>
   @if (updateInfo && !downloading) {
-    <div class="card-body">
-      <p class="card-text">{{updateInfo.releaseName}} is now available! Click the download link below to download the
+  <div class="card-body">
+    <p class="card-text">{{updateInfo.releaseName}} is now available! Click the download link below to download the
       updated version of the application.</p>
-    </div>
+  </div>
   }
   @if (updateError) {
-    <div class="card-body alert alert-danger">
-      <p class="card-text">Something went wrong, please contact ORNL to inform them that there was an error
-        downloading the
-      update and they will fix the issue as quickly as possible.</p>
-      <hr>
-        <p class="card-text">
-          Use the <a class="router-link" routerLink="/feedback">Feedback</a> page in the side bar to find information on reporting bugs.
-        </p>
-      </div>
-    }
-    @if (!downloading) {
-      <div class="card-footer text-end bg-dark">
-        <a class="click-link" (click)="update()">Download Update</a>
-      </div>
-    }
+  <div class="card-body alert alert-danger">
+    <p class="card-text">Something went wrong, please contact ORNL at <a
+        href="mailto:verifi-help@ornl.gov">verifi-help&#64;ornl.gov</a> for assistance.</p>
+    <hr>
+    <p class="card-text">
+      You can also download the latest version of VERIFI at <a
+        href="https://industrialresources.ornl.gov/verifi/downloads">ORNL's Industrial Resources</a>.
+    </p>
+    <hr>
+    <p class="card-text">
+      Use the <a class="router-link" routerLink="/feedback">Feedback</a> page in the side bar to find information on
+      reporting bugs.
+    </p>
   </div>
+  }
+  @if (!downloading) {
+  <div class="card-footer text-end bg-dark">
+    <a class="click-link" (click)="update()">Download Update</a>
+  </div>
+  }
+</div>


### PR DESCRIPTION
connects #2247 

This pull request updates the error messaging in the `electron-update.component.html` to provide clearer instructions and additional resources for users encountering update errors.

Improvements to user support and error messaging:

* Updated the error message to include a direct email link to ORNL support (`verifi-help@ornl.gov`) for assistance.
* Added a link to download the latest version of VERIFI from ORNL's Industrial Resources site, offering users an alternative solution if the update fails.
* Clarified instructions for reporting bugs using the Feedback page, improving guidance for users.