### PR TITLE
Issue 2205 - auto generate models based on number of predictors

### DIFF
--- a/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-menu/regression-model-menu.component.ts
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-menu/regression-model-menu.component.ts
@@ -25,6 +25,7 @@ import { PredictorDataDbService } from 'src/app/indexedDB/predictor-data-db.serv
 import { IdbAnalysisItem } from 'src/app/models/idbModels/analysisItem';
 import { Month, Months } from 'src/app/shared/form-data/months';
 import { getEarliestMeterData, getLatestMeterData } from 'src/app/shared/dateHelperFunctions';
+
 @Component({
   selector: 'app-regression-model-menu',
   templateUrl: './regression-model-menu.component.html',
@@ -92,7 +93,9 @@ export class RegressionModelMenuComponent implements OnInit {
           this.checkHasValidModels();
           this.checkFailedValidationModels();
         } else if (this.group.models == undefined) {
-          this.generateModels();
+          if (group.predictorVariables && group.predictorVariables.length < 7) {
+            this.generateModels();
+          }
         } else {
           this.noValidModels = false;
           this.noDataValidationModels = false;
@@ -213,7 +216,7 @@ export class RegressionModelMenuComponent implements OnInit {
         if (this.group.selectedModelId) {
           const selectedModel = this.generatedModels.find(model => model.modelId === this.group.selectedModelId);
           this.group.models = selectedModel ? [selectedModel] : [];
-          if(selectedModel) {
+          if (selectedModel) {
             this.group.regressionConstant = selectedModel.coef[0];
             this.group.regressionModelYear = selectedModel.modelYear;
             this.group.predictorVariables.forEach(variable => {


### PR DESCRIPTION
connects #2205 

This pull request introduces a conditional check before generating regression models in the `RegressionModelMenuComponent`. Now, models are only generated if the group has fewer than seven predictor variables.

**Logic update for model generation:**

* Added a check to ensure `generateModels()` is only called if `group.predictorVariables` exists and contains fewer than seven items, preventing unnecessary model generation for groups with many predictors.