### PR TITLE
Issue 2126 - bulk analysis baseline year bug resolved

### DIFF
--- a/src/app/data-evaluation/account/account-analysis/account-analysis-setup/account-analysis-setup.component.ts
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-setup/account-analysis-setup.component.ts
@@ -193,6 +193,18 @@ export class AccountAnalysisSetupComponent implements OnInit {
       this.dbChangesService.selectFacility(facility);
       let newIdbItem: IdbAnalysisItem = getNewIdbAnalysisItem(this.account, facility, accountMeterGroups, accountPredictors, this.analysisItem.analysisCategory);
       newIdbItem.energyIsSource = this.analysisItem.energyIsSource;
+      let facilityBaselineYear: number;
+      if (this.analysisItem.analysisCategory == 'energy') {
+        facilityBaselineYear = facility.sustainabilityQuestions.energyReductionBaselineYear;
+      }
+      else if (this.analysisItem.analysisCategory == 'water') {
+        facilityBaselineYear = facility.sustainabilityQuestions.waterReductionBaselineYear;
+      }
+      if (facility.isNewFacility && (facilityBaselineYear > this.analysisItem.baselineYear)) {
+        newIdbItem.baselineYear = facilityBaselineYear;
+      } else {
+        newIdbItem.baselineYear = this.analysisItem.baselineYear;
+      }
       newIdbItem.reportYear = this.analysisItem.reportYear;
       if (this.analysisItem.name != '') {
         newIdbItem.name = this.analysisItem.name;


### PR DESCRIPTION
connects #2126 

This pull request updates the logic for setting the baseline year in the `AccountAnalysisSetupComponent`, ensuring that new facilities use the correct baseline year based on their sustainability questions. The main improvement is making the baseline year assignment more dynamic and accurate for energy and water analyses.

Baseline year assignment improvements:

* Updated the baseline year logic in `AccountAnalysisSetupComponent` so that for new facilities, the baseline year is set from the facility's sustainability questions (`energyReductionBaselineYear` or `waterReductionBaselineYear`) if it is greater than the current analysis item's baseline year. Otherwise, it defaults to the analysis item's baseline year.