### PR TITLE
Issue 2291 - sorted the year options

### DIFF
--- a/src/app/data-evaluation/facility/analysis/analysis-dashboard/analysis-details-table/analysis-details-table.component.ts
+++ b/src/app/data-evaluation/facility/analysis/analysis-dashboard/analysis-details-table/analysis-details-table.component.ts
@@ -18,7 +18,6 @@ import { IdbUtilityMeterGroup } from 'src/app/models/idbModels/utilityMeterGroup
 import { CalanderizationService } from 'src/app/shared/helper-services/calanderization.service';
 import { SharedDataService } from 'src/app/shared/helper-services/shared-data.service';
 import { AnalysisGroupItem } from '../../analysis.service';
-import * as _ from 'lodash';
 
 @Component({
   selector: 'app-analysis-details-table',
@@ -46,7 +45,6 @@ export class AnalysisDetailsTableComponent {
   filteredAnalysisItems: Array<IdbAnalysisItem>;
   yearOptionsEnergy: Array<number>;
   yearOptionsWater: Array<number>;
-  yearOptions: Array<number>;
   selectedYearCategoryMap: { [year: number]: { [category: string]: boolean } } = {};
   errorList: Array<{ year: number, category: string }> = [];
 
@@ -94,8 +92,7 @@ export class AnalysisDetailsTableComponent {
       this.selectedFacility = val;
       this.yearOptionsEnergy = this.calendarizationService.getYearOptions('energy', true, this.selectedFacility.guid);
       this.yearOptionsWater = this.calendarizationService.getYearOptions('water', true, this.selectedFacility.guid);
-      this.yearOptions = _.uniq([...this.yearOptionsEnergy, ...this.yearOptionsWater]);
-      this.yearOptions = _.orderBy(this.yearOptions, (year) => { return year }, 'asc');
+     
       if (this.yearOptionsEnergy) {
         this.baselineYearErrorMinEnergy = this.yearOptionsEnergy[0] > this.selectedFacility.sustainabilityQuestions.energyReductionBaselineYear;
         this.baselineYearErrorMaxEnergy = this.yearOptionsEnergy[this.yearOptionsEnergy.length - 1] < this.selectedFacility.sustainabilityQuestions.energyReductionBaselineYear;

--- a/src/app/data-evaluation/facility/facility-reports/facility-reports.service.ts
+++ b/src/app/data-evaluation/facility/facility-reports/facility-reports.service.ts
@@ -31,7 +31,6 @@ export class FacilityReportsService {
         }
       }
       else if (report.facilityReportType == 'emissionFactors') {
-        console.log(report);
         if (report.emissionFactorsReportSettings.startYear != undefined && report.emissionFactorsReportSettings.endYear != undefined && report.emissionFactorsReportSettings.endYear < report.emissionFactorsReportSettings.startYear) {
           errorMessage = 'Start year cannot be later than the end year.';
         }

--- a/src/app/shared/helper-services/calanderization.service.ts
+++ b/src/app/shared/helper-services/calanderization.service.ts
@@ -273,6 +273,7 @@ export class CalanderizationService {
         yearsWithFullData = yearsWithFullData.concat(facilityYearsWithData);
       }
     });
+    yearsWithFullData = _.orderBy(yearsWithFullData, (year) => { return year }, 'asc');
     return _.uniq(yearsWithFullData);
   }
 


### PR DESCRIPTION
connects #2291 

This pull request primarily refactors how year options are handled and sorted in the analysis details table and calendarization services. The main change is moving the sorting logic for year options from the component to the `CalanderizationService`, ensuring that year arrays are consistently sorted at the service level. Additionally, unused code and unnecessary imports are removed for clarity and maintainability.

**Refactoring and Code Cleanup:**

* Removed the unused `yearOptions` property and related logic from the `AnalysisDetailsTableComponent`, relying instead on the already separated `yearOptionsEnergy` and `yearOptionsWater` arrays. 
* Removed the unused Lodash import from `analysis-details-table.component.ts`.

**Service Improvements:**

* Moved the sorting of `yearsWithFullData` into the `getYearOptions` method of `CalanderizationService`, ensuring that year options are always returned in ascending order.

**Minor Cleanup:**

* Removed an unnecessary `console.log` statement from `FacilityReportsService` for cleaner logs.