### PR TITLE
Issue 2130 - validation for performance report changed

### DIFF
--- a/src/app/data-evaluation/account/account-reports/account-reports.service.ts
+++ b/src/app/data-evaluation/account/account-reports/account-reports.service.ts
@@ -71,7 +71,7 @@ export class AccountReportsService {
       }
     }
 
-    if (report.reportType == 'performance' || report.reportType == 'betterClimate' || report.reportType == 'dataOverview' || report.reportType == 'accountSavings') {
+    if (report.reportType == 'betterClimate' || report.reportType == 'dataOverview' || report.reportType == 'accountSavings') {
       let form: FormGroup = this.formBuilder.group({
         reportName: [report.name, Validators.required],
         reportType: [report.reportType, Validators.required],
@@ -84,7 +84,7 @@ export class AccountReportsService {
       });
       return form;
     }
-    else if (report.reportType == 'betterPlants' || report.reportType == 'analysis') {
+    else if (report.reportType == 'betterPlants' || report.reportType == 'analysis' || report.reportType == 'performance') {
       let form: FormGroup = this.formBuilder.group({
         reportName: [report.name, Validators.required],
         reportType: [report.reportType, Validators.required],


### PR DESCRIPTION
connects #2130 

This pull request updates the logic for report form creation in the `AccountReportsService`. The main change is the reclassification of the `performance` report type, moving it from the group with `betterClimate`, `dataOverview`, and `accountSavings` to the group with `betterPlants` and `analysis`. This affects which form fields and validations are applied based on the report type.

Report type classification changes:

* The `performance` report type is now grouped with `betterPlants` and `analysis` for form creation, instead of with `betterClimate`, `dataOverview`, and `accountSavings`. 