### PR TITLE
Issue 2206 - changed logic for the years shown in the dropdown

### DIFF
--- a/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-selection.component.html
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-selection.component.html
@@ -27,8 +27,8 @@
 <hr>
 
 @if(generatedModels && generatedModels.length !== 0 && selectedGroup.userDefinedModel) {
-<div class="container-fluid px-4 mb-3">
-  <div class="d-flex justify-content-end align-items-center gap-3 mb-2">
+<div class="container-fluid px-4 mb-5">
+  <div class="d-flex justify-content-start align-items-center gap-3 mb-2">
     @if (generatedModels) {
     <div class="d-flex align-items-center me-3">
       <label class="show-models-label bold me-2" for="showInvalid">
@@ -65,12 +65,12 @@
         </button>
         @if (dropdownOpen) {
         <div class="dropdown-content dropdown-menu-end p-2">
-          @for (option of dropdownOptions; track option) {
+          @for (option of optionSelections; track option) {
           <label class="multiselect-option d-flex align-items-center"
-            [ngClass]="{'text-muted': option === selectedModel?.modelYear}">
-            <input type="checkbox" class="me-2" [value]="option" [checked]="isOptionSelected(option)"
-              (change)="toggleOption(option)" [disabled]="option === selectedModel?.modelYear">
-            {{option}}
+            [ngClass]="{'text-muted': option.year === selectedModel?.modelYear}">
+            <input type="checkbox" class="me-2" [value]="option" [checked]="option.isChecked"
+              (change)="toggleOption(option.year)" [disabled]="option.year === selectedModel?.modelYear">
+            {{option.year}}
           </label>
           }
         </div>

--- a/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-selection.component.ts
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-selection.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, HostListener, OnInit, Output, ViewChild } from '@angular/core';
+import { Component, ElementRef, HostListener, OnInit, ViewChild } from '@angular/core';
 import { Subscription, firstValueFrom } from 'rxjs';
 import { AccountdbService } from 'src/app/indexedDB/account-db.service';
 import { AnalysisDbService } from 'src/app/indexedDB/analysis-db.service';
@@ -14,9 +14,9 @@ import { IdbAnalysisItem } from 'src/app/models/idbModels/analysisItem';
 import { NavigationStart, Router } from '@angular/router';
 import { IdbUtilityMeterData } from 'src/app/models/idbModels/utilityMeterData';
 import { getEarliestMeterData, getLatestMeterData } from 'src/app/shared/dateHelperFunctions';
-import { IdbPredictorData } from 'src/app/models/idbModels/predictorData';
-import { PredictorDataDbService } from 'src/app/indexedDB/predictor-data-db.service';
 import { UtilityMeterDatadbService } from 'src/app/indexedDB/utilityMeterData-db.service';
+import { IdbUtilityMeter } from 'src/app/models/idbModels/utilityMeter';
+import { UtilityMeterdbService } from 'src/app/indexedDB/utilityMeter-db.service';
 @Component({
   selector: 'app-regression-model-selection',
   templateUrl: './regression-model-selection.component.html',
@@ -44,13 +44,13 @@ export class RegressionModelSelectionComponent implements OnInit {
   dropdownOpen: boolean = false;
   yearOptions: Array<number> = [];
   dropdownOptions: Array<number> = [];
-  selectedOptions: Array<number> = [];
   facilityMeterData: Array<IdbUtilityMeterData>;
-  facilityPredictorData: Array<IdbPredictorData>;
   analysisItem: IdbAnalysisItem;
   noValidModels: boolean;
   noDataValidationModels: boolean;
   selectedModel: JStatRegressionModel;
+  facilityMeters: Array<IdbUtilityMeter>;
+  optionSelections: Array<{ year: number, isChecked: boolean }> = [];
 
   @ViewChild('dropdown') dropdownRef: ElementRef;
 
@@ -59,15 +59,15 @@ export class RegressionModelSelectionComponent implements OnInit {
     private accountDbService: AccountdbService,
     private analysisValidationService: AnalysisValidationService,
     private accountAnalysisDbService: AccountAnalysisDbService,
-    private predictorDataDbService: PredictorDataDbService,
     private utilityMeterDataDbService: UtilityMeterDatadbService,
+    private utilityMeterDbService: UtilityMeterdbService,
     private router: Router) { }
 
   ngOnInit(): void {
     this.selectedFacility = this.facilityDbService.selectedFacility.getValue();
     this.analysisItem = this.analysisDbService.selectedAnalysisItem.getValue();
+    this.facilityMeters = this.utilityMeterDbService.facilityMeters.getValue();
     this.facilityMeterData = this.utilityMeterDataDbService.facilityMeterData.getValue();
-    this.facilityPredictorData = this.predictorDataDbService.facilityPredictorData.getValue();
     this.setYears();
     this.selectedGroupSub = this.analysisService.selectedGroup.subscribe(group => {
       this.selectedGroup = group;
@@ -211,18 +211,12 @@ export class RegressionModelSelectionComponent implements OnInit {
     this.dropdownOpen = !this.dropdownOpen;
   }
 
-  isOptionSelected(option: number): boolean {
-    return this.selectedOptions.includes(option);
-  }
-
   toggleOption(option: number) {
-    if (this.isOptionSelected(option)) {
-      this.selectedOptions = this.selectedOptions.filter(selected => selected !== option);
+    const selection = this.optionSelections.find(selection => selection.year == option);
+    if (selection) {
+      selection.isChecked = !selection.isChecked;
     }
-    else {
-      this.selectedOptions = [...this.selectedOptions, option];
-    }
-    this.includedYears = this.selectedOptions;
+    this.includedYears = this.optionSelections.filter(selection => selection.isChecked).map(selection => selection.year);
     this.isYearSelectionChanged = true;
   }
 
@@ -251,24 +245,34 @@ export class RegressionModelSelectionComponent implements OnInit {
     this.dropdownOptions = [...this.yearOptions];
     this.dropdownOptions = this.dropdownOptions.filter(year => year >= this.analysisItem.baselineYear);
     this.dropdownOptions = this.dropdownOptions.filter(year => year <= new Date().getFullYear());
-    this.checkCompleteYearDataPresent();
+    this.checkYearsIncluded();
     if (this.selectedGroup) {
       this.selectedModel = this.selectedGroup.selectedModelId ? this.selectedGroup.models.find(model => model.modelId == this.selectedGroup.selectedModelId) : undefined;
     }
-    this.selectedOptions = [...this.dropdownOptions];
   }
 
-  checkCompleteYearDataPresent() {
+  checkYearsIncluded() {
+    this.optionSelections = [];
+    let metersInGroup: Array<IdbUtilityMeter> = this.facilityMeters.filter(meter => { return meter.groupId == this.selectedGroup.idbGroupId });
     for (let year of this.dropdownOptions) {
       let meterDataForYear = this.facilityMeterData.filter(meterData => meterData.year == year);
-      let predictorDataForYear = this.facilityPredictorData.filter(predictorData => predictorData.year == year);
+      let meterDataForYearAndGroup = meterDataForYear.filter(meterData => metersInGroup.some(meter => meter.guid == meterData.meterId));
+      let monthsWithData = 0;
       for (let monthNum = 1; monthNum <= 12; monthNum++) {
-        let monthMeterData = meterDataForYear.filter(meterData => meterData.month == monthNum);
-        let monthPredictorData = predictorDataForYear.filter(predictorData => predictorData.month == monthNum);
-        if (monthMeterData.length == 0 || monthPredictorData.length == 0) {
-          this.dropdownOptions = this.dropdownOptions.filter(option => option != year);
+        let monthMeterData = meterDataForYearAndGroup.filter(meterData => meterData.month == monthNum);
+        if (monthMeterData && monthMeterData.length > 0) {
+          monthsWithData++;
+        }
+      }
+      if (monthsWithData >= 10) {
+        if (monthsWithData < 12) {
+          this.optionSelections.push({ year: year, isChecked: false });
+        }
+        else {
+          this.optionSelections.push({ year: year, isChecked: true });
         }
       }
     }
   }
 }
+


### PR DESCRIPTION
connects #2206 

This pull request refactors the regression model selection component to improve the handling of year options and streamline the selection logic. The main changes include replacing the old predictor data logic with a new approach based on facility meters, updating how year options are tracked and selected, and simplifying the dropdown UI and state management.

**Year selection and dropdown improvements:**

* Replaced the `selectedOptions` array and related methods with a new `optionSelections` array, which tracks both the year and its checked state for easier management and UI binding. 
* Updated the dropdown UI in `regression-model-selection.component.html` to use `optionSelections` instead of `dropdownOptions`, and improved how the checked state and disabling logic are handled for each year option.

**Data source and filtering changes:**

* Removed all references to predictor data and its service, and replaced them with facility meter data and meter filtering logic, ensuring year options are based on actual meter data available for the selected group. 
* Refactored the year inclusion logic to check for complete or near-complete meter data per year (at least 10 months), and updated how options are included or excluded based on this check.

**UI layout adjustments:**

* Modified container alignment and spacing in the HTML template to improve the visual layout of the regression model selection section.