### PR TITLE
fixup: perc. contribution calculation in annual analysis results

### DIFF
--- a/src/app/shared/shared-analysis/annual-analysis-group-savings-table/annual-analysis-group-savings-table.component.html
+++ b/src/app/shared/shared-analysis/annual-analysis-group-savings-table/annual-analysis-group-savings-table.component.html
@@ -1,85 +1,79 @@
 <hr>
 
-  @if (groupAnalysisData?.length > 0) {
-    <div class="mt-3">
-      @for (groupSummary of groupAnalysisData; track groupSummary; let i = $index) {
-        <div>
-          <h4>{{groupSummary.groupId | groupName}} Analysis</h4>
-          <table class="table utility-data table-sm table-bordered table-hover mt-5" #savingsTable>
-            <thead>
-              <tr class="table-mh">
-                <th class="text-center sortable-header" (click)="setOrderDataField('year')"
-                  [ngClass]="{'active': orderDataField == 'year'}">
-                  Year
-                </th>
-                <th class="text-center sortable-header" (click)="setOrderDataField('savings')"
-                  [ngClass]="{'active': orderDataField == 'savings'}">
-                  Savings
-                </th>
-                <th class="text-center sortable-header" (click)="setOrderDataField('totalSavingsPercentImprovement')"
-                  [ngClass]="{'active': orderDataField == 'totalSavingsPercentImprovement'}">
-                  % Savings
-                </th>
-                <th class="text-center sortable-header" (click)="setOrderDataField('contributionPercent')"
-                  [ngClass]="{'active': orderDataField == 'contributionPercent'}">
-                  % Contribution
-                </th>
-              </tr>
-            </thead>
-            <tbody class="table-group-divider">
-              @for (data of groupSummary.data | orderBy: orderDataField: orderByDirection; track data; let i = $index) {
-                <tr
-                  >
-                  <td class="text-center"> {{data.year}} </td>
-                  @if (data.savings) {
-                    <td class="text-center">
-                      <span [ngClass]="{'red': data.savings < 0}">
-                        {{data.savings | number:'1.0-2'}}
-                      </span>
-                    </td>
-                  }
-                  @if (!data.savings || data.savings == null) {
-                    <td class="text-center">
-                      &mdash;
-                    </td>
-                  }
-                  @if (data.totalSavingsPercentImprovement) {
-                    <td class="text-center"
-                      >
-                      <span [ngClass]="{'red': data.totalSavingsPercentImprovement < 0}">
-                        {{data.totalSavingsPercentImprovement | number:'1.0-3'}} %
-                      </span>
-                    </td>
-                  }
-                  @if (!data.totalSavingsPercentImprovement) {
-                    <td class="text-center"
-                      >
-                      &mdash;
-                    </td>
-                  }
-                  @if (data.savings && annualAnalysisSummary[i]?.adjusted) {
-                    <td class="text-center"
-                      >
-                      <span
-                        [ngClass]="{'red': (data.savings / annualAnalysisSummary[i].adjusted) < 0}">
-                      {{(data.savings / annualAnalysisSummary[i].adjusted) | number:'1.0-3'}} %</span>
-                    </td>
-                  }
-                  @if (!data.savings || !annualAnalysisSummary[i]?.adjusted) {
-                    <td class="text-center"
-                      >
-                      &mdash;
-                    </td>
-                  }
-                </tr>
-              }
-            </tbody>
-          </table>
-          <button class="btn action-btn btn-sm mt-3" (click)="copyTable(i)">
-            <span class="fa fa-copy"></span> Copy Table
-          </button>
-          <hr>
-          </div>
+@if (groupAnalysisData?.length > 0) {
+<div class="mt-3">
+  @for (groupSummary of groupAnalysisData; track groupSummary; let i = $index) {
+  <div>
+    <h4>{{groupSummary.groupId | groupName}} Analysis</h4>
+    <table class="table utility-data table-sm table-bordered table-hover mt-5" #savingsTable>
+      <thead>
+        <tr class="table-mh">
+          <th class="text-center sortable-header" (click)="setOrderDataField('year')"
+            [ngClass]="{'active': orderDataField == 'year'}">
+            Year
+          </th>
+          <th class="text-center sortable-header" (click)="setOrderDataField('savings')"
+            [ngClass]="{'active': orderDataField == 'savings'}">
+            Savings
+          </th>
+          <th class="text-center sortable-header" (click)="setOrderDataField('totalSavingsPercentImprovement')"
+            [ngClass]="{'active': orderDataField == 'totalSavingsPercentImprovement'}">
+            % Savings
+          </th>
+          <th class="text-center sortable-header" (click)="setOrderDataField('contributionPercent')"
+            [ngClass]="{'active': orderDataField == 'contributionPercent'}">
+            % Contribution
+          </th>
+        </tr>
+      </thead>
+      <tbody class="table-group-divider">
+        @for (data of groupSummary.data | orderBy: orderDataField: orderByDirection; track data; let i = $index) {
+        <tr>
+          <td class="text-center"> {{data.year}} </td>
+          @if (data.savings) {
+          <td class="text-center">
+            <span [ngClass]="{'red': data.savings < 0}">
+              {{data.savings | number:'1.0-2'}}
+            </span>
+          </td>
+          }
+          @if (!data.savings || data.savings == null) {
+          <td class="text-center">
+            &mdash;
+          </td>
+          }
+          @if (data.totalSavingsPercentImprovement) {
+          <td class="text-center">
+            <span [ngClass]="{'red': data.totalSavingsPercentImprovement < 0}">
+              {{data.totalSavingsPercentImprovement | number:'1.0-3'}} %
+            </span>
+          </td>
+          }
+          @if (!data.totalSavingsPercentImprovement) {
+          <td class="text-center">
+            &mdash;
+          </td>
+          }
+          @if (data.contributionPercent) {
+          <td class="text-center">
+            <span [ngClass]="{'red': data.contributionPercent < 0}">
+              {{data.contributionPercent | number:'1.0-3'}} %</span>
+          </td>
+          }
+          @if (!data.contributionPercent) {
+          <td class="text-center">
+            &mdash;
+          </td>
+          }
+        </tr>
         }
-      </div>
-    }
+      </tbody>
+    </table>
+    <button class="btn action-btn btn-sm mt-3" (click)="copyTable(i)">
+      <span class="fa fa-copy"></span> Copy Table
+    </button>
+    <hr>
+  </div>
+  }
+</div>
+}

--- a/src/app/shared/shared-analysis/annual-analysis-group-savings-table/annual-analysis-group-savings-table.component.ts
+++ b/src/app/shared/shared-analysis/annual-analysis-group-savings-table/annual-analysis-group-savings-table.component.ts
@@ -33,11 +33,12 @@ export class AnnualAnalysisGroupSavingsTableComponent {
     this.groupSummaries.forEach(summary => {
       const grpId = summary.group.idbGroupId;
       const data = summary.annualAnalysisSummaryData.map(yearData => {
+        let adjusted: number = this.annualAnalysisSummary.find(y => y.year == yearData.year).adjusted;
         return {
           year: yearData.year,
           savings: yearData.savings,
           totalSavingsPercentImprovement: yearData.totalSavingsPercentImprovement,
-          contributionPercent: yearData.savings / this.annualAnalysisSummary.find(y => y.year == yearData.year).adjusted
+          contributionPercent: yearData.savings / adjusted * 100
         }
       });
       this.groupAnalysisData.push({ groupId: grpId, data: data });


### PR DESCRIPTION
connects #2297 
This pull request refactors the calculation and display of the "contribution percent" in the annual analysis group savings table, improving clarity and consistency. The changes simplify the template logic and correct the calculation to represent a percentage value.

Calculation improvements:

* The `contributionPercent` value is now calculated as `(savings / adjusted) * 100` to properly represent a percentage, instead of just a ratio. (`annual-analysis-group-savings-table.component.ts`)

Template simplification and update:

* The template now uses `data.contributionPercent` directly for display, replacing the previous calculation and conditional logic based on `savings` and `adjusted`. (`annual-analysis-group-savings-table.component.html`)
* Table row and cell markup has been simplified for readability and maintainability, removing unnecessary attributes and indentation. (`annual-analysis-group-savings-table.component.html`) [[1]](diffhunk://#diff-72bcdba709a602607b68b4af9beb59c1c2babb014f0c3c2db12a8bf6f78e5fdcL31-R31) [[2]](diffhunk://#diff-72bcdba709a602607b68b4af9beb59c1c2babb014f0c3c2db12a8bf6f78e5fdcL47-R64)