### PR TITLE
Issue 2314 - changed navigation for data quality report for predictors in data management

### DIFF
--- a/src/app/shared/shared-predictors-content/predictors-data-table/predictors-data-table.component.css
+++ b/src/app/shared/shared-predictors-content/predictors-data-table/predictors-data-table.component.css
@@ -37,3 +37,7 @@
   max-height: 70vh;
   overflow-y: auto;
 }
+
+.btn .fa{
+    color: inherit;
+}

--- a/src/app/shared/shared-predictors-content/predictors-data-table/predictors-data-table.component.html
+++ b/src/app/shared/shared-predictors-content/predictors-data-table/predictors-data-table.component.html
@@ -48,8 +48,15 @@
   </div>
   }
   <div class="ps-1 pe-1 mb-2">
+    @if (inDataManagement) {
+    <button class="btn" (click)="goToDataQualityReport()"
+      [ngClass]="predictor | predictorDataQualityStatus: predictorData: true"><i class="fa fa-clipboard-check"></i>
+      Data
+      Quality Report</button>
+    } @else {
     <app-predictor-data-quality-report-modal [selectedPredictor]="predictor"
       [predictorData]="predictorData"></app-predictor-data-quality-report-modal>
+    }
   </div>
 </div>
 @if (hasWeatherDataWarnings) {
@@ -192,7 +199,7 @@
 
 <div [ngClass]="{'windowOverlay': predictorDataToDelete || showBulkDelete}"></div>
 <div class="popup" [class.open]="predictorDataToDelete">
-@if(predictorDataToDelete) {
+  @if(predictorDataToDelete) {
   <div class="popup-header">
     Delete {{predictorDataToDelete | displayPredictorDataDate}}?
     <button class="item-right" (click)="cancelDeletePredictorData()">x</button>
@@ -206,7 +213,7 @@
     <button class="btn btn-secondary" (click)="cancelDeletePredictorData()">Cancel</button>
     <button class="btn btn-danger" (click)="confirmDeletePredictorData()">Confirm Delete</button>
   </div>
-}
+  }
 </div>
 <div class="popup" [class.open]="showBulkDelete">
   <div class="popup-header">

--- a/src/app/shared/shared-predictors-content/predictors-data-table/predictors-data-table.component.ts
+++ b/src/app/shared/shared-predictors-content/predictors-data-table/predictors-data-table.component.ts
@@ -53,6 +53,7 @@ export class PredictorsDataTableComponent {
   latestMeterDataReading: Date;
   filterErrors: boolean = false;
   hasCalculatedOverride: boolean = false;
+  inDataManagement: boolean;
 
   constructor(private activatedRoute: ActivatedRoute, private predictorDbService: PredictorDbService,
     private predictorDataDbService: PredictorDataDbService,
@@ -73,6 +74,7 @@ export class PredictorsDataTableComponent {
   }
 
   ngOnInit() {
+    this.setInDataManagement();
     this.predictorDataSub = this.predictorDataDbService.facilityPredictorData.subscribe(() => {
       this.setPredictorData();
     });
@@ -100,6 +102,10 @@ export class PredictorsDataTableComponent {
     this.itemsPerPageSub.unsubscribe();
     this.predictorDataSub.unsubscribe();
     this.paramSub.unsubscribe();
+  }
+
+  setInDataManagement() {
+    this.inDataManagement = this.router.url.includes('data-management');
   }
 
   setInDataWizard() {
@@ -329,5 +335,9 @@ export class PredictorsDataTableComponent {
 
   toggleFilterErrors() {
     this.filterErrors = !this.filterErrors;
+  }
+
+  goToDataQualityReport() {
+    this.router.navigateByUrl('/data-management/' + this.predictor.accountId + '/facilities/' + this.predictor.facilityId + '/predictors/' + this.predictor.guid + '/data-quality-report');
   }
 }


### PR DESCRIPTION
connects #2314 

This pull request updates the `PredictorsDataTableComponent` to improve the handling and display of the Data Quality Report button, specifically when the component is used within the data management context. The changes add conditional rendering for the Data Quality Report button, provide a navigation method, and ensure consistent button styling.

**UI and Navigation Improvements:**

* Added a Data Quality Report button that only appears when `PredictorsDataTableComponent` is used within the data management section, and implemented navigation to the corresponding report page when clicked (`predictors-data-table.component.html`, `predictors-data-table.component.ts`). 

**Styling Enhancements:**

* Ensured that FontAwesome icons inside `.btn` elements inherit their color for consistent appearance (`predictors-data-table.component.css`).