### PR TITLE
Issue 2307 - added option to save forms using shortcut

### DIFF
--- a/src/app/data-evaluation/facility/utility-data/predictors/edit-predictor/edit-predictor.component.ts
+++ b/src/app/data-evaluation/facility/utility-data/predictors/edit-predictor/edit-predictor.component.ts
@@ -30,7 +30,10 @@ import { RouterGuardService } from 'src/app/shared/shared-router-guard-modal/rou
   selector: 'app-edit-predictor',
   templateUrl: './edit-predictor.component.html',
   styleUrl: './edit-predictor.component.css',
-  standalone: false
+  standalone: false,
+  host: {
+    '(window:keydown)': 'handleKeyDown($event)'
+  }
 })
 export class EditPredictorComponent {
 
@@ -42,7 +45,6 @@ export class EditPredictorComponent {
   latestMeterReading: Date;
   firstMeterReading: Date;
 
-  @HostListener('window:keydown', ['$event'])
   handleKeyDown(event: KeyboardEvent) {
     if ((event.ctrlKey || event.metaKey) && event.key === 's') {
       event.preventDefault();

--- a/src/app/data-evaluation/facility/utility-data/predictors/edit-predictor/edit-predictor.component.ts
+++ b/src/app/data-evaluation/facility/utility-data/predictors/edit-predictor/edit-predictor.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, HostListener } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { firstValueFrom, from, map, Observable, of, switchAll, take } from 'rxjs';
@@ -41,6 +41,17 @@ export class EditPredictorComponent {
   destroyed: boolean = false;
   latestMeterReading: Date;
   firstMeterReading: Date;
+
+  @HostListener('window:keydown', ['$event'])
+  handleKeyDown(event: KeyboardEvent) {
+    if ((event.ctrlKey || event.metaKey) && event.key === 's') {
+      event.preventDefault();
+      if(!this.predictorForm.invalid) {
+         this.saveChanges();
+      }
+    }
+  }
+
   constructor(private activatedRoute: ActivatedRoute,
     private predictorDbService: PredictorDbService,
     private toastNotificationService: ToastNotificationsService,

--- a/src/app/data-evaluation/facility/utility-data/predictors/predictors-data/predictors-data-form/predictors-data-form.component.ts
+++ b/src/app/data-evaluation/facility/utility-data/predictors/predictors-data/predictors-data-form/predictors-data-form.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, HostListener } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { firstValueFrom, from, map, Observable, of, Subscription, switchAll, take } from 'rxjs';
 import { LoadingService } from 'src/app/core-components/loading/loading.service';
@@ -29,6 +29,17 @@ export class PredictorsDataFormComponent {
   calculatingDegreeDays: boolean;
   isSaved: boolean = true;
   paramsSub: Subscription;
+
+  @HostListener('window:keydown', ['$event'])
+  handleKeyDown(event: KeyboardEvent) {
+    if ((event.ctrlKey || event.metaKey) && event.key === 's') {
+      event.preventDefault();
+      if (!this.calculatingDegreeDays) {
+        this.saveAndQuit();
+      }
+    }
+  }
+
   constructor(private activatedRoute: ActivatedRoute, private predictorDbService: PredictorDbService,
     private router: Router, private facilityDbService: FacilitydbService,
     private accountDbService: AccountdbService, private dbChangesService: DbChangesService,

--- a/src/app/data-evaluation/facility/utility-data/predictors/predictors-data/predictors-data-form/predictors-data-form.component.ts
+++ b/src/app/data-evaluation/facility/utility-data/predictors/predictors-data/predictors-data-form/predictors-data-form.component.ts
@@ -19,7 +19,10 @@ import { RouterGuardService } from 'src/app/shared/shared-router-guard-modal/rou
   selector: 'app-predictors-data-form',
   templateUrl: './predictors-data-form.component.html',
   styleUrl: './predictors-data-form.component.css',
-  standalone: false
+  standalone: false,
+  host: {
+    '(window:keydown)': 'handleKeyDown($event)'
+  }
 })
 export class PredictorsDataFormComponent {
 
@@ -30,7 +33,6 @@ export class PredictorsDataFormComponent {
   isSaved: boolean = true;
   paramsSub: Subscription;
 
-  @HostListener('window:keydown', ['$event'])
   handleKeyDown(event: KeyboardEvent) {
     if ((event.ctrlKey || event.metaKey) && event.key === 's') {
       event.preventDefault();

--- a/src/app/data-management/account-facilities/facility-data/facility-meters/facility-meter/facility-meter.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-meters/facility-meter/facility-meter.component.ts
@@ -21,7 +21,10 @@ import { RouterGuardService } from 'src/app/shared/shared-router-guard-modal/rou
   selector: 'app-facility-meter',
   templateUrl: './facility-meter.component.html',
   styleUrl: './facility-meter.component.css',
-  standalone: false
+  standalone: false,
+  host: {
+    '(window:keydown)': 'handleKeyDown($event)'
+  }
 })
 export class FacilityMeterComponent {
 
@@ -33,13 +36,11 @@ export class FacilityMeterComponent {
   meterForm: FormGroup;
   showDeleteMeter: boolean = false;
 
-  @HostListener('window:keydown', ['$event'])
   async handleKeyDown(event: KeyboardEvent) {
     if ((event.ctrlKey || event.metaKey) && event.key === 's') {
       event.preventDefault();
       if (!this.meterForm.invalid && !this.meterForm.pristine) {
         await this.saveChanges();
-        this.goToMeterList();
       }
     }
   }

--- a/src/app/data-management/account-facilities/facility-data/facility-meters/facility-meter/facility-meter.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-meters/facility-meter/facility-meter.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, HostListener } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { firstValueFrom, from, map, Observable, of, Subscription, switchAll, take } from 'rxjs';
@@ -32,6 +32,18 @@ export class FacilityMeterComponent {
   utilityMeter: IdbUtilityMeter;
   meterForm: FormGroup;
   showDeleteMeter: boolean = false;
+
+  @HostListener('window:keydown', ['$event'])
+  async handleKeyDown(event: KeyboardEvent) {
+    if ((event.ctrlKey || event.metaKey) && event.key === 's') {
+      event.preventDefault();
+      if (!this.meterForm.invalid && !this.meterForm.pristine) {
+        await this.saveChanges();
+        this.goToMeterList();
+      }
+    }
+  }
+  
   constructor(private activatedRoute: ActivatedRoute,
     private utilityMeterDbService: UtilityMeterdbService,
     private facilityDbService: FacilitydbService,

--- a/src/app/data-management/account-facilities/facility-data/facility-predictors/facility-predictor-data-entry/facility-predictor-data-entry.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-predictors/facility-predictor-data-entry/facility-predictor-data-entry.component.ts
@@ -1,7 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, HostListener } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { firstValueFrom, from, map, Observable, of, switchAll, take } from 'rxjs';
-import { LoadingService } from 'src/app/core-components/loading/loading.service';
 import { ToastNotificationsService } from 'src/app/core-components/toast-notifications/toast-notifications.service';
 import { AccountdbService } from 'src/app/indexedDB/account-db.service';
 import { DbChangesService } from 'src/app/indexedDB/db-changes.service';
@@ -29,12 +28,22 @@ export class FacilityPredictorDataEntryComponent {
   showDeletePredictorEntry: boolean = false;
   isSaved: boolean = true;
   calculatingDegreeDays: boolean;
+
+  @HostListener('window:keydown', ['$event'])
+  handleKeyDown(event: KeyboardEvent) {
+    if ((event.ctrlKey || event.metaKey) && event.key === 's') {
+      event.preventDefault();
+      if (!this.calculatingDegreeDays) {
+        this.saveAndQuit();
+      }
+    }
+  }
+  
   constructor(private activatedRoute: ActivatedRoute,
     private predictorDbService: PredictorDbService,
     private toastNotificationService: ToastNotificationsService,
     private facilityDbService: FacilitydbService,
     private router: Router,
-    private loadingService: LoadingService,
     private predictorDataDbService: PredictorDataDbService,
     private accountDbService: AccountdbService,
     private dbChangesService: DbChangesService,

--- a/src/app/data-management/account-facilities/facility-data/facility-predictors/facility-predictor-data-entry/facility-predictor-data-entry.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-predictors/facility-predictor-data-entry/facility-predictor-data-entry.component.ts
@@ -17,7 +17,10 @@ import { RouterGuardService } from 'src/app/shared/shared-router-guard-modal/rou
   selector: 'app-facility-predictor-data-entry',
   templateUrl: './facility-predictor-data-entry.component.html',
   styleUrl: './facility-predictor-data-entry.component.css',
-  standalone: false
+  standalone: false,
+  host: {
+    '(window:keydown)': 'handleKeyDown($event)'
+  }
 })
 export class FacilityPredictorDataEntryComponent {
 
@@ -29,7 +32,6 @@ export class FacilityPredictorDataEntryComponent {
   isSaved: boolean = true;
   calculatingDegreeDays: boolean;
 
-  @HostListener('window:keydown', ['$event'])
   handleKeyDown(event: KeyboardEvent) {
     if ((event.ctrlKey || event.metaKey) && event.key === 's') {
       event.preventDefault();

--- a/src/app/data-management/account-facilities/facility-data/facility-predictors/facility-predictor/facility-predictor.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-predictors/facility-predictor/facility-predictor.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, HostListener } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { firstValueFrom, from, map, Observable, of, switchAll, take } from 'rxjs';
@@ -44,6 +44,18 @@ export class FacilityPredictorComponent {
   firstMeterReading: Date;
 
   showDeletePredictor: boolean = false;
+
+  @HostListener('window:keydown', ['$event'])
+  async handleKeyDown(event: KeyboardEvent) {
+    if ((event.ctrlKey || event.metaKey) && event.key === 's') {
+      event.preventDefault();
+      if (!this.predictorForm.invalid && !this.predictorForm.pristine) {
+        await this.saveChanges();
+        this.goToManagePredictors();
+      }
+    }
+  }
+
   constructor(private activatedRoute: ActivatedRoute,
     private predictorDbService: PredictorDbService,
     private toastNotificationService: ToastNotificationsService,

--- a/src/app/data-management/account-facilities/facility-data/facility-predictors/facility-predictor/facility-predictor.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-predictors/facility-predictor/facility-predictor.component.ts
@@ -32,7 +32,10 @@ import { RouterGuardService } from 'src/app/shared/shared-router-guard-modal/rou
   selector: 'app-facility-predictor',
   templateUrl: './facility-predictor.component.html',
   styleUrl: './facility-predictor.component.css',
-  standalone: false
+  standalone: false,
+  host: {
+    '(window:keydown)': 'handleKeyDown($event)'
+  }
 })
 export class FacilityPredictorComponent {
 
@@ -45,13 +48,11 @@ export class FacilityPredictorComponent {
 
   showDeletePredictor: boolean = false;
 
-  @HostListener('window:keydown', ['$event'])
   async handleKeyDown(event: KeyboardEvent) {
     if ((event.ctrlKey || event.metaKey) && event.key === 's') {
       event.preventDefault();
       if (!this.predictorForm.invalid && !this.predictorForm.pristine) {
         await this.saveChanges();
-        this.goToManagePredictors();
       }
     }
   }

--- a/src/app/shared/shared-meter-content/edit-bill/edit-bill.component.ts
+++ b/src/app/shared/shared-meter-content/edit-bill/edit-bill.component.ts
@@ -23,7 +23,10 @@ import { RouterGuardService } from '../../shared-router-guard-modal/router-guard
   selector: 'app-edit-bill',
   templateUrl: './edit-bill.component.html',
   styleUrls: ['./edit-bill.component.css'],
-  standalone: false
+  standalone: false,
+  host: {
+    '(window:keydown)': 'handleKeyDown($event)'
+  }
 })
 export class EditBillComponent implements OnInit {
 
@@ -41,7 +44,6 @@ export class EditBillComponent implements OnInit {
   paramsSub: Subscription;
   isElectron: boolean;
 
-  @HostListener('window:keydown', ['$event'])
   handleKeyDown(event: KeyboardEvent) {
     if ((event.ctrlKey || event.metaKey) && event.key === 's') {
       event.preventDefault();

--- a/src/app/shared/shared-meter-content/edit-bill/edit-bill.component.ts
+++ b/src/app/shared/shared-meter-content/edit-bill/edit-bill.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
+import { Component, HostListener, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { LoadingService } from 'src/app/core-components/loading/loading.service';
@@ -40,6 +40,17 @@ export class EditBillComponent implements OnInit {
   inDataManagement: boolean;
   paramsSub: Subscription;
   isElectron: boolean;
+
+  @HostListener('window:keydown', ['$event'])
+  handleKeyDown(event: KeyboardEvent) {
+    if ((event.ctrlKey || event.metaKey) && event.key === 's') {
+      event.preventDefault();
+      if (!this.meterDataForm.invalid && !this.invalidDate) {
+        this.saveAndQuit();
+      }
+    }
+  }
+
   constructor(private activatedRoute: ActivatedRoute, private utilityMeterDataDbService: UtilityMeterDatadbService,
     private utilityMeterDbService: UtilityMeterdbService, private loadingService: LoadingService,
     private dbChangesService: DbChangesService, private facilityDbService: FacilitydbService, private accountDbService: AccountdbService,

--- a/src/app/shared/shared-meter-content/edit-meter/edit-meter.component.ts
+++ b/src/app/shared/shared-meter-content/edit-meter/edit-meter.component.ts
@@ -20,7 +20,10 @@ import { RouterGuardService } from '../../shared-router-guard-modal/router-guard
   selector: 'app-edit-meter',
   templateUrl: './edit-meter.component.html',
   styleUrls: ['./edit-meter.component.css'],
-  standalone: false
+  standalone: false,
+  host: {
+    '(window:keydown)': 'handleKeyDown($event)'
+  }
 })
 export class EditMeterComponent implements OnInit {
 
@@ -30,7 +33,6 @@ export class EditMeterComponent implements OnInit {
   addOrEdit: 'add' | 'edit';
   selectedFacility: IdbFacility;
 
-  @HostListener('window:keydown', ['$event'])
   handleKeyDown(event: KeyboardEvent) {
     if ((event.ctrlKey || event.metaKey) && event.key === 's') {
       event.preventDefault();

--- a/src/app/shared/shared-meter-content/edit-meter/edit-meter.component.ts
+++ b/src/app/shared/shared-meter-content/edit-meter/edit-meter.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, HostListener, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { FacilitydbService } from 'src/app/indexedDB/facility-db.service';
 import { UtilityMeterdbService } from 'src/app/indexedDB/utilityMeter-db.service';
@@ -9,7 +9,6 @@ import { EditMeterFormService } from '../edit-meter-form/edit-meter-form.service
 import { AccountdbService } from 'src/app/indexedDB/account-db.service';
 import { DbChangesService } from 'src/app/indexedDB/db-changes.service';
 import { ActivatedRoute, Router } from '@angular/router';
-import { getIsEnergyMeter, getIsEnergyUnit } from 'src/app/shared/sharedHelperFunctions';
 import { Observable, firstValueFrom, from, map, of, switchAll, take } from 'rxjs';
 import { IdbAccount } from 'src/app/models/idbModels/account';
 import { IdbFacility } from 'src/app/models/idbModels/facility';
@@ -25,12 +24,22 @@ import { RouterGuardService } from '../../shared-router-guard-modal/router-guard
 })
 export class EditMeterComponent implements OnInit {
 
-
   meterForm: FormGroup;
   meterDataExists: boolean;
   editMeter: IdbUtilityMeter;
   addOrEdit: 'add' | 'edit';
   selectedFacility: IdbFacility;
+
+  @HostListener('window:keydown', ['$event'])
+  handleKeyDown(event: KeyboardEvent) {
+    if ((event.ctrlKey || event.metaKey) && event.key === 's') {
+      event.preventDefault();
+      if(!this.meterForm.invalid) {
+        this.saveChanges();
+      }
+    }
+  }
+
   constructor(private utilityMeterDbService: UtilityMeterdbService, private facilityDbService: FacilitydbService,
     private editMeterFormService: EditMeterFormService,
     private utilityMeterDataDbService: UtilityMeterDatadbService, private loadingService: LoadingService,

--- a/src/app/shared/shared-meter-content/set-meter-grouping/meter-group-form/meter-group-form.component.ts
+++ b/src/app/shared/shared-meter-content/set-meter-grouping/meter-group-form/meter-group-form.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, HostListener } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { firstValueFrom, from, map, Observable, of, switchAll, take } from 'rxjs';
 import { AccountdbService } from 'src/app/indexedDB/account-db.service';
@@ -38,6 +38,18 @@ export class MeterGroupFormComponent {
   hasWaterMeters: boolean;
 
   showDeleteModal: boolean = false;
+
+  @HostListener('window:keydown', ['$event'])
+  async handleKeyDown(event: KeyboardEvent) {
+    if ((event.ctrlKey || event.metaKey) && event.key === 's') {
+      event.preventDefault();
+      if ((!this.groupForm.invalid && !this.groupForm.pristine) || this.selectionsChanged) {
+        await this.saveChanges();
+        this.cancel();
+      }
+    }
+  }
+  
   constructor(private facilityDbService: FacilitydbService, private utilityMeterGroupDbService: UtilityMeterGroupdbService,
     private formBuilder: FormBuilder,
     private utilityMeterDbService: UtilityMeterdbService,

--- a/src/app/shared/shared-meter-content/set-meter-grouping/meter-group-form/meter-group-form.component.ts
+++ b/src/app/shared/shared-meter-content/set-meter-grouping/meter-group-form/meter-group-form.component.ts
@@ -23,9 +23,11 @@ import { RouterGuardService } from 'src/app/shared/shared-router-guard-modal/rou
 @Component({
   selector: 'app-meter-group-form',
   standalone: false,
-
   templateUrl: './meter-group-form.component.html',
-  styleUrl: './meter-group-form.component.css'
+  styleUrl: './meter-group-form.component.css',
+  host: {
+    '(window:keydown)': 'handleKeyDown($event)'
+  }
 })
 export class MeterGroupFormComponent {
 
@@ -38,18 +40,20 @@ export class MeterGroupFormComponent {
   hasWaterMeters: boolean;
 
   showDeleteModal: boolean = false;
+  inDataManagement: boolean = false;
 
-  @HostListener('window:keydown', ['$event'])
   async handleKeyDown(event: KeyboardEvent) {
     if ((event.ctrlKey || event.metaKey) && event.key === 's') {
       event.preventDefault();
       if ((!this.groupForm.invalid && !this.groupForm.pristine) || this.selectionsChanged) {
         await this.saveChanges();
-        this.cancel();
+        if (!this.inDataManagement) {
+          this.cancel();
+        }
       }
     }
   }
-  
+
   constructor(private facilityDbService: FacilitydbService, private utilityMeterGroupDbService: UtilityMeterGroupdbService,
     private formBuilder: FormBuilder,
     private utilityMeterDbService: UtilityMeterdbService,
@@ -67,6 +71,7 @@ export class MeterGroupFormComponent {
   }
 
   ngOnInit() {
+    this.setInDataManagement();
     this.setHasMetersBools();
     this.activatedRoute.params.subscribe(params => {
       let meterGroupId: string = params['id'];
@@ -87,6 +92,10 @@ export class MeterGroupFormComponent {
         this.hasExistingGroups = this.meterGroupOptions.find(option => { return option.inAnotherGroup }) != undefined;
       }
     });
+  }
+
+  setInDataManagement() {
+    this.inDataManagement = this.router.url.includes('data-management');
   }
 
   cancel() {


### PR DESCRIPTION
connects #2307 

This pull request adds a new keyboard shortcut (Ctrl+S or Cmd+S) to multiple form-based components across the application, allowing users to quickly save their changes using the familiar "save" shortcut. The shortcut is only active when the form is valid and, in some cases, not pristine or not in a loading/calculating state. This improves user experience and efficiency, especially for power users.

**Keyboard Shortcut Integration:**

* Added a `@HostListener` for `'window:keydown'` in the following components to handle Ctrl+S/Cmd+S for saving:
  - [`EditPredictorComponent`]
  - [`PredictorsDataFormComponent`]
  - [`FacilityMeterComponent`]
  - [`FacilityPredictorDataEntryComponent`]
  - [`FacilityPredictorComponent`]
  - [`EditBillComponent`]
  - [`EditMeterComponent`]
  - [`MeterGroupFormComponent`]

These changes provide a consistent and efficient save experience throughout the app.



