### PR TITLE
Issue 2345 - user defined model dropdown and graph changes

### DIFF
--- a/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-menu/regression-model-menu.component.ts
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-menu/regression-model-menu.component.ts
@@ -24,6 +24,7 @@ import { PredictorDataDbService } from 'src/app/indexedDB/predictor-data-db.serv
 import { IdbAnalysisItem } from 'src/app/models/idbModels/analysisItem';
 import { Month, Months } from 'src/app/shared/form-data/months';
 import { CalanderizationService } from 'src/app/shared/helper-services/calanderization.service';
+import { getAllYearsWithData } from 'src/app/calculations/shared-calculations/calculationsHelpers';
 
 @Component({
   selector: 'app-regression-model-menu',
@@ -101,15 +102,8 @@ export class RegressionModelMenuComponent implements OnInit {
   }
 
   setYears() {
-    this.yearOptions = [];
-    if (this.calanderizedMeters && this.calanderizedMeters.length > 0 && this.selectedFacility) {
-      const fiscalYears = this.calanderizedMeters
-        .flatMap(meter => meter.monthlyData.map(data => getFiscalYear(data.date, this.selectedFacility)));
-      const uniqueFiscalYears = Array.from(new Set(fiscalYears)).sort((a, b) => a - b);
-      this.yearOptions = uniqueFiscalYears;
-    } else {
-      this.yearOptions = [];
-    }
+    this.yearOptions = getAllYearsWithData(this.calanderizedMeters, this.selectedFacility);
+    this.yearOptions.sort((a, b) => a - b);
   }
 
   setUserDefinedDefaultData() {

--- a/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-menu/regression-model-menu.component.ts
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-menu/regression-model-menu.component.ts
@@ -13,7 +13,7 @@ import { RegressionModelsService } from 'src/app/shared/shared-analysis/calculat
 import * as _ from 'lodash';
 import { SharedDataService } from 'src/app/shared/helper-services/shared-data.service';
 import { getCalanderizedMeterData } from 'src/app/calculations/calanderization/calanderizeMeters';
-import { getNeededUnits } from 'src/app/calculations/shared-calculations/calanderizationFunctions';
+import { getFiscalYear, getNeededUnits } from 'src/app/calculations/shared-calculations/calanderizationFunctions';
 import { LoadingService } from 'src/app/core-components/loading/loading.service';
 import { IdbAccount } from 'src/app/models/idbModels/account';
 import { IdbFacility } from 'src/app/models/idbModels/facility';
@@ -24,7 +24,6 @@ import { PredictorDataDbService } from 'src/app/indexedDB/predictor-data-db.serv
 import { IdbAnalysisItem } from 'src/app/models/idbModels/analysisItem';
 import { Month, Months } from 'src/app/shared/form-data/months';
 import { CalanderizationService } from 'src/app/shared/helper-services/calanderization.service';
-import { PredictorDataHelperService } from 'src/app/shared/helper-services/predictor-data-helper.service';
 
 @Component({
   selector: 'app-regression-model-menu',
@@ -103,21 +102,13 @@ export class RegressionModelMenuComponent implements OnInit {
 
   setYears() {
     this.yearOptions = [];
-    if (this.calanderizedMeters && this.calanderizedMeters.length > 0) {
-      const allDates = this.calanderizedMeters.flatMap(meter => meter.monthlyData.map(data => data.date));
-      if (allDates.length > 0) {
-        const firstReading = new Date(Math.min(...allDates.map(date => date.getTime())));
-        const latestReading = new Date(Math.max(...allDates.map(date => date.getTime())));
-
-        if (firstReading && latestReading) {
-          let firstYear: number = firstReading.getFullYear();
-          let lastYear: number = latestReading.getFullYear();
-          this.yearOptions = [];
-          for (let year = firstYear; year <= lastYear; year++) {
-            this.yearOptions.push(year);
-          }
-        }
-      }
+    if (this.calanderizedMeters && this.calanderizedMeters.length > 0 && this.selectedFacility) {
+      const fiscalYears = this.calanderizedMeters
+        .flatMap(meter => meter.monthlyData.map(data => getFiscalYear(data.date, this.selectedFacility)));
+      const uniqueFiscalYears = Array.from(new Set(fiscalYears)).sort((a, b) => a - b);
+      this.yearOptions = uniqueFiscalYears;
+    } else {
+      this.yearOptions = [];
     }
   }
 

--- a/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-menu/regression-model-menu.component.ts
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-menu/regression-model-menu.component.ts
@@ -8,7 +8,7 @@ import { FacilitydbService } from 'src/app/indexedDB/facility-db.service';
 import { UtilityMeterdbService } from 'src/app/indexedDB/utilityMeter-db.service';
 import { UtilityMeterDatadbService } from 'src/app/indexedDB/utilityMeterData-db.service';
 import { AnalysisGroup, JStatRegressionModel } from 'src/app/models/analysis';
-import { CalanderizedMeter, MonthlyData } from 'src/app/models/calanderization';
+import { CalanderizedMeter } from 'src/app/models/calanderization';
 import { RegressionModelsService } from 'src/app/shared/shared-analysis/calculations/regression-models.service';
 import * as _ from 'lodash';
 import { SharedDataService } from 'src/app/shared/helper-services/shared-data.service';
@@ -23,8 +23,9 @@ import { IdbPredictorData } from 'src/app/models/idbModels/predictorData';
 import { PredictorDataDbService } from 'src/app/indexedDB/predictor-data-db.service';
 import { IdbAnalysisItem } from 'src/app/models/idbModels/analysisItem';
 import { Month, Months } from 'src/app/shared/form-data/months';
-import { getYearsWithFullData } from 'src/app/calculations/shared-calculations/calculationsHelpers';
 import { CalanderizationService } from 'src/app/shared/helper-services/calanderization.service';
+import { PredictorDataHelperService } from 'src/app/shared/helper-services/predictor-data-helper.service';
+
 @Component({
   selector: 'app-regression-model-menu',
   templateUrl: './regression-model-menu.component.html',
@@ -54,6 +55,7 @@ export class RegressionModelMenuComponent implements OnInit {
 
   calanderizedMeters: Array<CalanderizedMeter>;
   calanderizedMetersSub: Subscription;
+
   constructor(private analysisDbService: AnalysisDbService, private analysisService: AnalysisService,
     private dbChangesService: DbChangesService, private accountDbService: AccountdbService,
     private facilityDbService: FacilitydbService,
@@ -62,7 +64,8 @@ export class RegressionModelMenuComponent implements OnInit {
     private sharedDataService: SharedDataService,
     private loadingService: LoadingService,
     private predictorDataDbService: PredictorDataDbService,
-    private calanderizationService: CalanderizationService) { }
+    private calanderizationService: CalanderizationService
+  ) { }
 
   ngOnInit(): void {
     this.selectedFacility = this.facilityDbService.selectedFacility.getValue();
@@ -99,10 +102,23 @@ export class RegressionModelMenuComponent implements OnInit {
   }
 
   setYears() {
-    let fullYearsWithData: Array<number> = getYearsWithFullData(this.calanderizedMeters, this.selectedFacility);
-    this.yearOptions = fullYearsWithData.filter(year => {
-      return year >= this.analysisItem.baselineYear;
-    })
+    this.yearOptions = [];
+    if (this.calanderizedMeters && this.calanderizedMeters.length > 0) {
+      const allDates = this.calanderizedMeters.flatMap(meter => meter.monthlyData.map(data => data.date));
+      if (allDates.length > 0) {
+        const firstReading = new Date(Math.min(...allDates.map(date => date.getTime())));
+        const latestReading = new Date(Math.max(...allDates.map(date => date.getTime())));
+
+        if (firstReading && latestReading) {
+          let firstYear: number = firstReading.getFullYear();
+          let lastYear: number = latestReading.getFullYear();
+          this.yearOptions = [];
+          for (let year = firstYear; year <= lastYear; year++) {
+            this.yearOptions.push(year);
+          }
+        }
+      }
+    }
   }
 
   setUserDefinedDefaultData() {

--- a/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-user-defined-model-inspection/regression-user-defined-model-inspection.component.ts
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-user-defined-model-inspection/regression-user-defined-model-inspection.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Input, SimpleChange, SimpleChanges, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { AnalysisGroup, JStatRegressionModel, MonthlyAnalysisSummaryData } from 'src/app/models/analysis';
 import { AnalysisService } from '../../../../analysis.service';
 import { Subscription } from 'rxjs';
@@ -7,7 +7,7 @@ import { AnalysisDbService } from 'src/app/indexedDB/analysis-db.service';
 import { IdbAnalysisItem } from 'src/app/models/idbModels/analysisItem';
 import { MonthlyAnalysisSummaryClass } from 'src/app/calculations/analysis-calculations/monthlyAnalysisSummaryClass';
 import { getCalanderizedMeterData } from 'src/app/calculations/calanderization/calanderizeMeters';
-import { getFiscalYear, getNeededUnits } from 'src/app/calculations/shared-calculations/calanderizationFunctions';
+import { getNeededUnits } from 'src/app/calculations/shared-calculations/calanderizationFunctions';
 import { AccountdbService } from 'src/app/indexedDB/account-db.service';
 import { FacilitydbService } from 'src/app/indexedDB/facility-db.service';
 import { PredictorDataDbService } from 'src/app/indexedDB/predictor-data-db.service';
@@ -46,6 +46,7 @@ export class RegressionUserDefinedModelInspectionComponent {
   facilityMeters: Array<IdbUtilityMeter>;
   facilityMeterData: Array<IdbUtilityMeterData>;
   account: IdbAccount;
+  analysisItemCopy: IdbAnalysisItem;
 
   @ViewChild('monthlyAnalysisGraph', { static: false }) monthlyAnalysisGraph: ElementRef;
 
@@ -92,10 +93,12 @@ export class RegressionUserDefinedModelInspectionComponent {
 
   generateUserDefinedModel() {
     let analysisItem: IdbAnalysisItem = this.analysisDbService.selectedAnalysisItem.getValue();
+    this.analysisItemCopy = JSON.parse(JSON.stringify(analysisItem));
+    this.analysisItemCopy.baselineYear = this.selectedGroup.regressionStartYear;
     //report year is determined by the latest full year of data
     let calanderizedMeters: Array<CalanderizedMeter> = this.calanderizationService.getCalanderizedMetersByGroupId(this.selectedGroup.idbGroupId);
     let reportYear: number = getLatestYearWithData(calanderizedMeters, [this.selectedFacility]);
-    this.userModel = this.regressionsModelsService.getUserDefinedModel(this.selectedGroup, this.selectedFacility, analysisItem, reportYear);
+    this.userModel = this.regressionsModelsService.getUserDefinedModel(this.selectedGroup, this.selectedFacility, this.analysisItemCopy, reportYear);
   }
 
   calculateInspectedModel() {
@@ -118,7 +121,7 @@ export class RegressionUserDefinedModelInspectionComponent {
       this.calculating = true;
       this.worker.postMessage({
         selectedGroup: groupCopy,
-        analysisItem: this.analysisItem,
+        analysisItem: this.analysisItemCopy,
         facility: this.selectedFacility,
         meters: this.facilityMeters,
         meterData: this.facilityMeterData,
@@ -128,8 +131,8 @@ export class RegressionUserDefinedModelInspectionComponent {
       });
     } else {
       // Web Workers are not supported in this environment.  
-      let calanderizedMeters: Array<CalanderizedMeter> = getCalanderizedMeterData(this.facilityMeters, this.facilityMeterData, this.selectedFacility, false, { energyIsSource: this.analysisItem.energyIsSource, neededUnits: getNeededUnits(this.analysisItem) }, [], [], [this.selectedFacility], this.account.assessmentReportVersion, []);
-      let monthlyAnalysisSummaryClass: MonthlyAnalysisSummaryClass = new MonthlyAnalysisSummaryClass(groupCopy, this.analysisItem, this.selectedFacility, calanderizedMeters, this.accountPredictorEntries, false, this.accountAnalysisItems);
+      let calanderizedMeters: Array<CalanderizedMeter> = getCalanderizedMeterData(this.facilityMeters, this.facilityMeterData, this.selectedFacility, false, { energyIsSource: this.analysisItemCopy.energyIsSource, neededUnits: getNeededUnits(this.analysisItemCopy) }, [], [], [this.selectedFacility], this.account.assessmentReportVersion, []);
+      let monthlyAnalysisSummaryClass: MonthlyAnalysisSummaryClass = new MonthlyAnalysisSummaryClass(groupCopy, this.analysisItemCopy, this.selectedFacility, calanderizedMeters, this.accountPredictorEntries, false, this.accountAnalysisItems);
       this.inspectedMonthlyAnalysisSummaryData = monthlyAnalysisSummaryClass.getResults().monthlyAnalysisSummaryData;
       this.calculating = false;
       this.loadingService.setLoadingStatus(false);
@@ -141,10 +144,10 @@ export class RegressionUserDefinedModelInspectionComponent {
     if (this.monthlyAnalysisGraph) {
       let name: string = this.getGraphName();
 
-      let yAxisTitle: string = this.analysisItem.energyUnit;
+      let yAxisTitle: string = this.analysisItemCopy.energyUnit;
       let traceColor: string = '#7D3C98'
-      if (this.analysisItem.analysisCategory == 'water') {
-        yAxisTitle = this.analysisItem.waterUnit;
+      if (this.analysisItemCopy.analysisCategory == 'water') {
+        yAxisTitle = this.analysisItemCopy.waterUnit;
         traceColor = '#3498DB';
       }
 
@@ -244,26 +247,26 @@ export class RegressionUserDefinedModelInspectionComponent {
   }
 
   getGraphName(): string {
-    if (this.analysisItem.analysisCategory == 'energy') {
+    if (this.analysisItemCopy.analysisCategory == 'energy') {
       return 'Modeled Energy';
-    } else if (this.analysisItem.analysisCategory == 'water') {
+    } else if (this.analysisItemCopy.analysisCategory == 'water') {
       return 'Modeled Water';
     }
     return '';
   }
 
   getTrace3Name(): string {
-    if (this.analysisItem.analysisCategory == 'energy') {
+    if (this.analysisItemCopy.analysisCategory == 'energy') {
       return 'Actual Energy';
-    } else if (this.analysisItem.analysisCategory == 'water') {
+    } else if (this.analysisItemCopy.analysisCategory == 'water') {
       return 'Actual Consumption';
     }
   }
 
   getGraphTitle(): string {
-    if (this.analysisItem.analysisCategory == 'energy') {
+    if (this.analysisItemCopy.analysisCategory == 'energy') {
       return 'Comparison of Actual and Modeled Energy Use';
-    } else if (this.analysisItem.analysisCategory == 'water') {
+    } else if (this.analysisItemCopy.analysisCategory == 'water') {
       return 'Comparison of Actual and Modeled Water Consumption';
     }
   }


### PR DESCRIPTION
connects #2345 

This pull request improves the handling of analysis items and year selection in the regression model selection and inspection components. The main changes include refactoring how the available years are determined, ensuring immutability of analysis item data during user-defined model inspection, and cleaning up unused imports.

**Year selection and data handling improvements:**

* The `setYears()` method in `regression-model-menu.component.ts` was refactored to directly compute available years from meter data, instead of relying on the `getYearsWithFullData` helper. This makes the logic more transparent and less dependent on external utilities.
* In the user-defined model inspection component, a deep copy of the selected analysis item (`analysisItemCopy`) is now used and modified for calculations, ensuring the original data remains unchanged. All relevant methods and graph labels now consistently reference this copy. 

**Code cleanup and dependency management:**

* Removed unused imports such as `MonthlyData`, `getYearsWithFullData`, and `getFiscalYear`, and added missing imports like `PredictorDataHelperService` to keep the codebase clean and up-to-date. 
* Minor formatting improvements and constructor signature adjustments for better readability and maintainability. 