### PR TITLE
Issue 2317: Export mobile meters to template fixes

### DIFF
--- a/src/app/shared/helper-services/export-to-excel-template-v3.service.ts
+++ b/src/app/shared/helper-services/export-to-excel-template-v3.service.ts
@@ -20,9 +20,9 @@ import { IdbPredictor } from 'src/app/models/idbModels/predictor';
 import { PredictorDbService } from 'src/app/indexedDB/predictor-db.service';
 import { PredictorDataDbService } from 'src/app/indexedDB/predictor-data-db.service';
 import { IdbPredictorData } from 'src/app/models/idbModels/predictorData';
-import { checkSameMonth, checkSameMonthPredictorData } from 'src/app/data-management/data-management-import/import-services/upload-helper-functions';
+import { checkSameMonthPredictorData } from 'src/app/data-management/data-management-import/import-services/upload-helper-functions';
 import { FirstNaicsList, NAICS, SecondNaicsList } from '../form-data/naics-data';
-import { ChargesTypes, MeterChargeType } from '../shared-meter-content/edit-meter-form/meter-charges-form/meterChargesOptions';
+import { ChargesTypes } from '../shared-meter-content/edit-meter-form/meter-charges-form/meterChargesOptions';
 import { getDateFromMeterData } from '../dateHelperFunctions';
 
 @Injectable({
@@ -447,6 +447,9 @@ export class ExportToExcelTemplateV3Service {
   }
 
   getVehicleType(meter: IdbUtilityMeter): string {
+    if(meter.vehicleCategory == 1){
+      return "Material Transport Onsite";
+    }
     let vehicleType = VehicleTypes.find(vType => {
       return vType.value == meter.vehicleType
     });

--- a/src/app/shared/helper-services/export-to-excel-template-v3.service.ts
+++ b/src/app/shared/helper-services/export-to-excel-template-v3.service.ts
@@ -362,6 +362,11 @@ export class ExportToExcelTemplateV3Service {
       facilityMeters = facilityMeters.filter(meter => { return meter.facilityId == facilityId });
     }
     let mobileMeters: Array<IdbUtilityMeter> = facilityMeters.filter(meter => { return meter.source == 'Other Fuels' && meter.scope == 2 });
+    if(mobileMeters.length == 0){
+      return worksheet;
+    }
+    worksheet.state = 'visible';
+    
     let accountFacilities: Array<IdbFacility> = this.facilityDbService.accountFacilities.getValue();
     let index: number = 3;
     mobileMeters.forEach(meter => {
@@ -414,6 +419,10 @@ export class ExportToExcelTemplateV3Service {
       facilityMeters = facilityMeters.filter(meter => { return meter.facilityId == facilityId });
     }
     let mobileMeters: Array<IdbUtilityMeter> = facilityMeters.filter(meter => { return meter.source == 'Other Fuels' && meter.scope == 2 });
+    if(mobileMeters.length == 0){
+      return worksheet;
+    }
+    worksheet.state = 'visible';
     let index: number = 3;
     mobileMeters.forEach(meter => {
       let meterData: Array<IdbUtilityMeterData> = this.utilityMeterDataDbService.getMeterDataFromMeterId(meter.guid);
@@ -483,6 +492,11 @@ export class ExportToExcelTemplateV3Service {
       facilityMeters = facilityMeters.filter(meter => { return meter.facilityId == facilityId });
     }
     let otherEnergyMeters: Array<IdbUtilityMeter> = facilityMeters.filter(meter => { return meter.source == 'Other Energy' });
+    if(otherEnergyMeters.length == 0){
+      return worksheet;
+    }
+    worksheet.state = 'visible';
+
     let accountFacilities: Array<IdbFacility> = this.facilityDbService.accountFacilities.getValue();
     let index: number = 3;
     otherEnergyMeters.forEach(meter => {
@@ -529,6 +543,10 @@ export class ExportToExcelTemplateV3Service {
       facilityMeters = facilityMeters.filter(meter => { return meter.facilityId == facilityId });
     }
     let otherEnergyMeters: Array<IdbUtilityMeter> = facilityMeters.filter(meter => { return meter.source == 'Other Energy' });
+    if(otherEnergyMeters.length == 0){
+      return worksheet;
+    }
+    worksheet.state = 'visible';
     let index: number = 3;
     otherEnergyMeters.forEach(meter => {
       let meterData: Array<IdbUtilityMeterData> = this.utilityMeterDataDbService.getMeterDataFromMeterId(meter.guid);
@@ -560,6 +578,10 @@ export class ExportToExcelTemplateV3Service {
       facilityMeters = facilityMeters.filter(meter => { return meter.facilityId == facilityId });
     }
     let otherMeters: Array<IdbUtilityMeter> = facilityMeters.filter(meter => { return meter.source == 'Other' });
+    if(otherMeters.length == 0){
+      return worksheet;
+    }
+    worksheet.state = 'visible';
     let accountFacilities: Array<IdbFacility> = this.facilityDbService.accountFacilities.getValue();
     let index: number = 3;
     otherMeters.forEach(meter => {
@@ -607,6 +629,10 @@ export class ExportToExcelTemplateV3Service {
       facilityMeters = facilityMeters.filter(meter => { return meter.facilityId == facilityId });
     }
     let otherMeters: Array<IdbUtilityMeter> = facilityMeters.filter(meter => { return meter.source == 'Other' });
+    if(otherMeters.length == 0){
+      return worksheet;
+    }
+    worksheet.state = 'visible';
     let index: number = 3;
     otherMeters.forEach(meter => {
       let meterData: Array<IdbUtilityMeterData> = this.utilityMeterDataDbService.getMeterDataFromMeterId(meter.guid);
@@ -637,6 +663,10 @@ export class ExportToExcelTemplateV3Service {
       facilityMeters = facilityMeters.filter(meter => { return meter.facilityId == facilityId });
     }
     let waterMeters: Array<IdbUtilityMeter> = facilityMeters.filter(meter => { return meter.source == 'Water Intake' || meter.source == 'Water Discharge' });
+    if(waterMeters.length == 0){
+      return worksheet;
+    }
+    worksheet.state = 'visible';
     let accountFacilities: Array<IdbFacility> = this.facilityDbService.accountFacilities.getValue();
     let index: number = 3;
     waterMeters.forEach(meter => {
@@ -688,6 +718,10 @@ export class ExportToExcelTemplateV3Service {
       facilityMeters = facilityMeters.filter(meter => { return meter.facilityId == facilityId });
     }
     let waterMeters: Array<IdbUtilityMeter> = facilityMeters.filter(meter => { return meter.source == 'Water Intake' || meter.source == 'Water Discharge' });
+    if(waterMeters.length == 0){
+      return worksheet;
+    }
+    worksheet.state = 'visible';
     let index: number = 3;
     waterMeters.forEach(meter => {
       let meterData: Array<IdbUtilityMeterData> = this.utilityMeterDataDbService.getMeterDataFromMeterId(meter.guid);


### PR DESCRIPTION
connects #2317 
connects #2338 

This pull request improves the robustness and clarity of the `ExportToExcelTemplateV3Service` by adding early exit conditions for empty meter lists in several export methods, ensuring worksheets are only processed and set to visible when relevant data exists. Additionally, it refines imports and enhances the vehicle type determination logic.

**Improvements to export methods:**

* Added early returns in export methods (`exportMobileMeters`, `exportOtherEnergyMeters`, `exportOtherMeters`, `exportWaterMeters`) to immediately return the worksheet if the filtered meter list is empty, preventing unnecessary processing and ensuring worksheet visibility is only set when data is present. [[1]](diffhunk://#diff-0462649e9bb5297c4bd0070466371bd9b47c754f013640d26cdf893e5ecd376eR365-R369) [[2]](diffhunk://#diff-0462649e9bb5297c4bd0070466371bd9b47c754f013640d26cdf893e5ecd376eR422-R425) [[3]](diffhunk://#diff-0462649e9bb5297c4bd0070466371bd9b47c754f013640d26cdf893e5ecd376eR498-R502) [[4]](diffhunk://#diff-0462649e9bb5297c4bd0070466371bd9b47c754f013640d26cdf893e5ecd376eR549-R552) [[5]](diffhunk://#diff-0462649e9bb5297c4bd0070466371bd9b47c754f013640d26cdf893e5ecd376eR584-R587) [[6]](diffhunk://#diff-0462649e9bb5297c4bd0070466371bd9b47c754f013640d26cdf893e5ecd376eR635-R638) [[7]](diffhunk://#diff-0462649e9bb5297c4bd0070466371bd9b47c754f013640d26cdf893e5ecd376eR669-R672) [[8]](diffhunk://#diff-0462649e9bb5297c4bd0070466371bd9b47c754f013640d26cdf893e5ecd376eR724-R727)

**Code quality and logic enhancements:**

* Improved the `getVehicleType` method to return "Material Transport Onsite" when `vehicleCategory` is 1, providing clearer categorization for specific meter types.
* Cleaned up imports by removing unused imports (`checkSameMonth`, `MeterChargeType`) from `export-to-excel-template-v3.service.ts`.