### PR TITLE
fixup(issue-2374): model validation report year bug

### DIFF
--- a/src/app/shared/shared-analysis/calculations/regression-models.service.ts
+++ b/src/app/shared/shared-analysis/calculations/regression-models.service.ts
@@ -25,7 +25,7 @@ export class RegressionModelsService {
     analysisItem.calculatedReportYear = getLatestYearWithData(calanderizedMeters, [facility]);
     let monthlyStartAndEndDate: { baselineDate: Date, endDate: Date } = getMonthlyStartAndEndDate(facility, analysisItem, analysisGroup);
     let baselineDate: Date = monthlyStartAndEndDate.baselineDate;
-    let endYear: number = monthlyStartAndEndDate.endDate.getFullYear();
+    let endYear: number = analysisItem.calculatedReportYear;
     let baselineYear: number = getFiscalYear(baselineDate, facility);
     let predictorVariables: Array<AnalysisGroupPredictorVariable> = new Array();
     let predictorVariableIds: Array<string> = new Array();


### PR DESCRIPTION
connects #2374 

The report year being used in model validation when generating models was from the end date which is one month after the last full year of data ends. This was meaning that the validation was using a report year without data and not correct. Updated to use the last full year of data for the report year.