### PR TITLE
fix(#2384): fix id mapping on import of selected analysis items

### DIFF
--- a/src/app/shared/helper-services/backup-data.service.ts
+++ b/src/app/shared/helper-services/backup-data.service.ts
@@ -210,7 +210,7 @@ export class BackupDataService {
       facility.guid = newGUID;
       delete facility.id;
       facility.accountId = accountGUIDs.newId;
-      await firstValueFrom(this.facilityDbService.addWithObservable(facility));
+      backupFile.facilities[i] = await firstValueFrom(this.facilityDbService.addWithObservable(facility));
     }
 
     this.loadingService.setCurrentLoadingIndex(++currIdx);
@@ -500,6 +500,37 @@ export class BackupDataService {
       }
       await firstValueFrom(this.accountReportsDbService.addWithObservable(accountReport));
     }
+
+    //update account selected analysis items
+    let needsAccountUpdate: boolean = false;
+    if (newAccount.selectedEnergyAnalysisId) {
+      newAccount.selectedEnergyAnalysisId = this.getNewId(newAccount.selectedEnergyAnalysisId, accountAnalysisGUIDs);
+      needsAccountUpdate = true;
+    }
+    if (newAccount.selectedWaterAnalysisId) {
+      newAccount.selectedWaterAnalysisId = this.getNewId(newAccount.selectedWaterAnalysisId, accountAnalysisGUIDs);
+      needsAccountUpdate = true;
+    }
+    if (needsAccountUpdate) {
+      await firstValueFrom(this.accountDbService.updateWithObservable(newAccount));
+    }
+    //update facility analysis items
+    for (let i = 0; i < backupFile.facilities.length; i++) {
+      let facility: IdbFacility = backupFile.facilities[i];
+      let needsFacilityUpdate: boolean = false;
+      if (facility.selectedEnergyAnalysisId) {
+        facility.selectedEnergyAnalysisId = this.getNewId(facility.selectedEnergyAnalysisId, facilityAnalysisGUIDs);
+        needsFacilityUpdate = true;
+      }
+      if (facility.selectedWaterAnalysisId) {
+        facility.selectedWaterAnalysisId = this.getNewId(facility.selectedWaterAnalysisId, facilityAnalysisGUIDs);
+        needsFacilityUpdate = true;
+      }
+      if (needsFacilityUpdate) {
+        await firstValueFrom(this.facilityDbService.updateWithObservable(facility));
+      }
+    }
+
     return newAccount;
   }
 
@@ -641,7 +672,6 @@ export class BackupDataService {
       }
     }
 
-
     if (backupFile.predictors) {
       for (let i = 0; i < backupFile.predictors.length; i++) {
         let predictor: IdbPredictor = backupFile.predictors[i];
@@ -771,6 +801,18 @@ export class BackupDataService {
       await firstValueFrom(this.accountReportsDbService.updateWithObservable(accountReports[reportIndex]));
     }
 
+    let needsFacilityUpdate: boolean = false;
+    if (newFacility.selectedEnergyAnalysisId) {
+      newFacility.selectedEnergyAnalysisId = this.getNewId(newFacility.selectedEnergyAnalysisId, facilityAnalysisGUIDs);
+      needsFacilityUpdate = true;
+    }
+    if (newFacility.selectedWaterAnalysisId) {
+      newFacility.selectedWaterAnalysisId = this.getNewId(newFacility.selectedWaterAnalysisId, facilityAnalysisGUIDs);
+      needsFacilityUpdate = true;
+    }
+    if (needsFacilityUpdate) {
+      await firstValueFrom(this.facilityDbService.updateWithObservable(newFacility));
+    }
     return { facility: newFacility, index: currIdx };
   }
 


### PR DESCRIPTION
connects #2384

This pull request enhances the backup and restore logic in the `BackupDataService` to ensure that references to selected analysis items (energy and water) are properly updated with new IDs after restoration. It also ensures that the restored facility objects in the backup file are kept in sync with the database after insertion.

Key improvements include:

### Data Consistency Improvements

* After inserting a facility during restore, the corresponding facility object in `backupFile.facilities` is updated with the newly inserted facility from the database to ensure the backup file stays in sync with the database state.

### Reference Integrity for Analysis Items

* When restoring accounts, the code now updates `selectedEnergyAnalysisId` and `selectedWaterAnalysisId` fields to use new analysis IDs, and persists these changes to the database if needed.
* Similarly, for each facility in the backup, the code updates the facility’s `selectedEnergyAnalysisId` and `selectedWaterAnalysisId` fields to the new analysis IDs and saves the changes if necessary.
* When restoring a facility, the facility’s `selectedEnergyAnalysisId` and `selectedWaterAnalysisId` fields are also updated with new IDs and persisted if changes were made.