### PR TITLE
feat: add save modal to energy uses

### DIFF
--- a/src/app/data-management/account-facilities/facility-data/facility-energy-uses/facility-energy-use-equipment/facility-energy-use-equipment.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-energy-uses/facility-energy-use-equipment/facility-energy-use-equipment.component.ts
@@ -1,6 +1,6 @@
 import { Component, computed, inject, Signal, signal, WritableSignal } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { firstValueFrom, Observable, of } from 'rxjs';
+import { firstValueFrom, from, map, Observable, of, switchAll, take } from 'rxjs';
 import { LoadingService } from 'src/app/core-components/loading/loading.service';
 import { ToastNotificationsService } from 'src/app/core-components/toast-notifications/toast-notifications.service';
 import { AccountdbService } from 'src/app/indexedDB/account-db.service';
@@ -16,6 +16,7 @@ import { getYearsWithFullData } from 'src/app/calculations/shared-calculations/c
 import { toSignal } from '@angular/core/rxjs-interop';
 import { CalanderizedMeter } from 'src/app/models/calanderization';
 import { CalanderizationService } from 'src/app/shared/helper-services/calanderization.service';
+import { RouterGuardService } from 'src/app/shared/shared-router-guard-modal/router-guard-service';
 
 @Component({
   selector: 'app-facility-energy-use-equipment',
@@ -34,7 +35,8 @@ export class FacilityEnergyUseEquipmentComponent {
   private accountDbService: AccountdbService = inject(AccountdbService);
   private dbChangesService: DbChangesService = inject(DbChangesService);
   private toastNotificationsService: ToastNotificationsService = inject(ToastNotificationsService);
-  private calanderizationService = inject(CalanderizationService);
+  private calanderizationService: CalanderizationService = inject(CalanderizationService);
+  private routerGuardService: RouterGuardService = inject(RouterGuardService);
 
   energyUseEquipmentSignal: WritableSignal<IdbFacilityEnergyUseEquipment> = signal<IdbFacilityEnergyUseEquipment>(null);
   get energyUseEquipment(): IdbFacilityEnergyUseEquipment {
@@ -44,8 +46,8 @@ export class FacilityEnergyUseEquipmentComponent {
     this.energyUseEquipmentSignal.set(value);
   }
 
-  selectedFacility$: Signal<IdbFacility> = toSignal(this.facilityDbService.selectedFacility, { initialValue: null });
-  calanderizedMeters$: Signal<Array<CalanderizedMeter>> = toSignal(this.calanderizationService.calanderizedMeters, { initialValue: [] });
+  selectedFacility: Signal<IdbFacility> = toSignal(this.facilityDbService.selectedFacility, { initialValue: null });
+  calanderizedMeters: Signal<Array<CalanderizedMeter>> = toSignal(this.calanderizationService.calanderizedMeters, { initialValue: [] });
 
   showDeleteEquipment: boolean = false;
   dataChanged: boolean = false;
@@ -54,8 +56,8 @@ export class FacilityEnergyUseEquipmentComponent {
 
   selectedYear: number;
   yearOptions: Signal<Array<number>> = computed(() => {
-    const calanderizedMeters = this.calanderizedMeters$();
-    const selectedFacility = this.selectedFacility$();
+    const calanderizedMeters = this.calanderizedMeters();
+    const selectedFacility = this.selectedFacility();
     if (calanderizedMeters.length === 0 || !selectedFacility) {
       return [];
     }
@@ -119,11 +121,19 @@ export class FacilityEnergyUseEquipmentComponent {
     this.router.navigateByUrl('/data-management/' + selectedFacility.accountId + '/facilities/' + selectedFacility.guid + '/energy-uses/' + this.energyUseEquipment.energyUseGroupId);
   }
 
+
   canDeactivate(): Observable<boolean> {
-    //TODO modal with save option if data changed
     if (this.dataChanged) {
-      const result = window.confirm('There are unsaved changes! Are you sure you want to leave this page?');
-      return of(result);
+      this.routerGuardService.setShowModal(true);
+      return this.routerGuardService.getModalAction().pipe(map(action => {
+        if (action == 'save') {
+          return from(this.saveChanges()).pipe(map(() => true));
+        } else if (action == 'discard') {
+          return of(true);
+        }
+        return of(false);
+      }),
+        take(1), switchAll());
     }
     return of(true);
   }

--- a/src/app/data-management/account-facilities/facility-data/facility-energy-uses/facility-energy-use-group/facility-energy-use-group.component.html
+++ b/src/app/data-management/account-facilities/facility-data/facility-energy-uses/facility-energy-use-group/facility-energy-use-group.component.html
@@ -63,7 +63,7 @@
                             </div>
                         </div>
                         @let groupEquipment = (energyUseGroup.guid |
-                        facilityEnergyEquipmentList:facilityEnergyUseEquipment$());
+                        facilityEnergyEquipmentList:facilityEnergyUseEquipment());
                         @if(groupEquipment.length != 0){
                         <table class="table table-bordered">
                             <thead>

--- a/src/app/data-management/account-facilities/facility-data/facility-energy-uses/facility-energy-use-group/facility-energy-use-group.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-energy-uses/facility-energy-use-group/facility-energy-use-group.component.ts
@@ -1,7 +1,7 @@
 import { Component, inject, Signal } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { firstValueFrom, Observable, of } from 'rxjs';
+import { firstValueFrom, from, map, Observable, of, switchAll, take } from 'rxjs';
 import { FacilitydbService } from 'src/app/indexedDB/facility-db.service';
 import { FacilityEnergyUseGroupsDbService } from 'src/app/indexedDB/facility-energy-use-groups-db.service';
 import { IdbFacility } from 'src/app/models/idbModels/facility';
@@ -18,6 +18,7 @@ import { FacilityEnergyUseEquipmentDbService } from 'src/app/indexedDB/facility-
 import { getNewIdbFacilityEnergyUseEquipment, IdbFacilityEnergyUseEquipment } from 'src/app/models/idbModels/facilityEnergyUseEquipment';
 import { UtilityMeterDatadbService } from 'src/app/indexedDB/utilityMeterData-db.service';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { RouterGuardService } from 'src/app/shared/shared-router-guard-modal/router-guard-service';
 
 @Component({
   selector: 'app-facility-energy-use-group',
@@ -26,33 +27,34 @@ import { toSignal } from '@angular/core/rxjs-interop';
   styleUrl: './facility-energy-use-group.component.css'
 })
 export class FacilityEnergyUseGroupComponent {
-  private facilityEnergyUseEquipmentDbService = inject(FacilityEnergyUseEquipmentDbService);
-  private activatedRoute = inject(ActivatedRoute);
-  private facilityDbService = inject(FacilitydbService);
-  private router = inject(Router);
-  private facilityEnergyUseGroupsDbService = inject(FacilityEnergyUseGroupsDbService);
-  private facilityEnergyUseGroupFormService = inject(FacilityEnergyUseGroupFormService);
-  private sharedDataService = inject(SharedDataService);
-  private loadingService = inject(LoadingService);
-  private accountDbService = inject(AccountdbService);
-  private dbChangesService = inject(DbChangesService);
-  private toastNotificationsService = inject(ToastNotificationsService);
-  private utilityMeterDataDbService = inject(UtilityMeterDatadbService);
+  private facilityEnergyUseEquipmentDbService: FacilityEnergyUseEquipmentDbService = inject(FacilityEnergyUseEquipmentDbService);
+  private activatedRoute: ActivatedRoute = inject(ActivatedRoute);
+  private facilityDbService: FacilitydbService = inject(FacilitydbService);
+  private router: Router = inject(Router);
+  private facilityEnergyUseGroupsDbService: FacilityEnergyUseGroupsDbService = inject(FacilityEnergyUseGroupsDbService);
+  private facilityEnergyUseGroupFormService: FacilityEnergyUseGroupFormService = inject(FacilityEnergyUseGroupFormService);
+  private sharedDataService: SharedDataService = inject(SharedDataService);
+  private loadingService: LoadingService = inject(LoadingService);
+  private accountDbService: AccountdbService = inject(AccountdbService);
+  private dbChangesService: DbChangesService = inject(DbChangesService);
+  private toastNotificationsService: ToastNotificationsService = inject(ToastNotificationsService);
+  private utilityMeterDataDbService: UtilityMeterDatadbService = inject(UtilityMeterDatadbService);
+  private routerGuardService: RouterGuardService = inject(RouterGuardService);
 
-  facilityEnergyUseEquipment$: Signal<Array<IdbFacilityEnergyUseEquipment>> = toSignal(this.facilityEnergyUseEquipmentDbService.facilityEnergyUseEquipment, { initialValue: [] });
-  facilityEnergyUseGroups$: Signal<Array<IdbFacilityEnergyUseGroup>> = toSignal(this.facilityEnergyUseGroupsDbService.facilityEnergyUseGroups, { initialValue: [] });
+  facilityEnergyUseEquipment: Signal<Array<IdbFacilityEnergyUseEquipment>> = toSignal(this.facilityEnergyUseEquipmentDbService.facilityEnergyUseEquipment, { initialValue: [] });
+  facilityEnergyUseGroups: Signal<Array<IdbFacilityEnergyUseGroup>> = toSignal(this.facilityEnergyUseGroupsDbService.facilityEnergyUseGroups, { initialValue: [] });
 
   get hasSelectedEquipment(): boolean {
-    return this.facilityEnergyUseEquipment$().some(equip => equip.selected);
+    return this.facilityEnergyUseEquipment().some(equip => equip.selected);
   }
 
   get selectedEquipment(): Array<IdbFacilityEnergyUseEquipment> {
-    return this.facilityEnergyUseEquipment$().filter(equip => equip.selected);
+    return this.facilityEnergyUseEquipment().filter(equip => equip.selected);
   }
 
   get transferGroupOptions(): Array<IdbFacilityEnergyUseGroup> {
     let currentGroupId = this.energyUseGroup.guid;
-    return this.facilityEnergyUseGroups$().filter(group => group.guid !== currentGroupId);
+    return this.facilityEnergyUseGroups().filter(group => group.guid !== currentGroupId);
   }
 
 
@@ -126,8 +128,16 @@ export class FacilityEnergyUseGroupComponent {
 
   canDeactivate(): Observable<boolean> {
     if (this.form && this.form.dirty) {
-      const result = window.confirm('There are unsaved changes! Are you sure you want to leave this page?');
-      return of(result);
+      this.routerGuardService.setShowModal(true);
+      return this.routerGuardService.getModalAction().pipe(map(action => {
+        if (action == 'save') {
+          return from(this.saveChanges()).pipe(map(() => true));
+        } else if (action == 'discard') {
+          return of(true);
+        }
+        return of(false);
+      }),
+        take(1), switchAll());
     }
     return of(true);
   }
@@ -166,7 +176,7 @@ export class FacilityEnergyUseGroupComponent {
   }
 
   cancelBulkTransfer() {
-    let facilityEnergyUseEquipment = this.facilityEnergyUseEquipment$();
+    let facilityEnergyUseEquipment = this.facilityEnergyUseEquipment();
     for (let i = 0; i < facilityEnergyUseEquipment.length; i++) {
       facilityEnergyUseEquipment[i].selected = false;
     }
@@ -192,7 +202,7 @@ export class FacilityEnergyUseGroupComponent {
   }
 
   cancelBulkDelete() {
-    let facilityEnergyUseEquipment = this.facilityEnergyUseEquipment$();
+    let facilityEnergyUseEquipment = this.facilityEnergyUseEquipment();
     for (let i = 0; i < facilityEnergyUseEquipment.length; i++) {
       facilityEnergyUseEquipment[i].selected = false;
     }


### PR DESCRIPTION
connects #2394 

This pull request refactors the handling of signals and router guard modal logic in the facility energy use equipment and group components. The key improvements include replacing the old suffixed signal variables with new naming, integrating the `RouterGuardService` to manage unsaved changes with a modal dialog, and updating all relevant references throughout the components and templates.

**Signal Refactoring and Naming Consistency**
- Replaced all suffixed signal variables with unsuffixed names (e.g., `selectedFacility`, `facilityEnergyUseEquipment`) for clarity and consistency. Updated all usages accordingly in both TypeScript and HTML template files. [[1]](diffhunk://#diff-f57d4d919e16e4f9688c30652146924bd35a7c5c03cd2744e42312660b8c3dc3L47-R50) [[2]](diffhunk://#diff-232a50ffd7f832da243d804769e662cb68f36ff64709a9fdf6da08399bdaae8bL29-R57) [[3]](diffhunk://#diff-f6ae2ef5151df1814d13ebebad10282edd071424024c5409f68b4a8d8183d6d8L66-R66) [[4]](diffhunk://#diff-232a50ffd7f832da243d804769e662cb68f36ff64709a9fdf6da08399bdaae8bL169-R179) [[5]](diffhunk://#diff-232a50ffd7f832da243d804769e662cb68f36ff64709a9fdf6da08399bdaae8bL195-R205)

**Router Guard Modal Integration for Unsaved Changes**
- Replaced the native `window.confirm` prompt in the `canDeactivate()` methods with the new `RouterGuardService`, which shows a custom modal dialog to handle unsaved changes. The modal provides options to save, discard, or cancel navigation, and the logic now properly handles asynchronous save operations. [[1]](diffhunk://#diff-f57d4d919e16e4f9688c30652146924bd35a7c5c03cd2744e42312660b8c3dc3R124-R136) [[2]](diffhunk://#diff-232a50ffd7f832da243d804769e662cb68f36ff64709a9fdf6da08399bdaae8bL129-R140)

**Dependency Injection and Type Annotations**
- Added explicit type annotations to injected services for improved type safety and code readability. [[1]](diffhunk://#diff-f57d4d919e16e4f9688c30652146924bd35a7c5c03cd2744e42312660b8c3dc3L37-R39) [[2]](diffhunk://#diff-232a50ffd7f832da243d804769e662cb68f36ff64709a9fdf6da08399bdaae8bL29-R57)

**Imports Update**
- Added necessary imports for RxJS operators (`from`, `map`, `switchAll`, `take`) and the new `RouterGuardService`. [[1]](diffhunk://#diff-f57d4d919e16e4f9688c30652146924bd35a7c5c03cd2744e42312660b8c3dc3L3-R3) [[2]](diffhunk://#diff-f57d4d919e16e4f9688c30652146924bd35a7c5c03cd2744e42312660b8c3dc3R19) [[3]](diffhunk://#diff-232a50ffd7f832da243d804769e662cb68f36ff64709a9fdf6da08399bdaae8bL4-R4) [[4]](diffhunk://#diff-232a50ffd7f832da243d804769e662cb68f36ff64709a9fdf6da08399bdaae8bR21)

These changes improve code maintainability, user experience when navigating with unsaved changes, and overall consistency in signal handling.