### PR TITLE
fixup: flagging missing predictor data not being used in analysis

### DIFF
--- a/src/app/calculations/analysis-calculations/monthlyAnalysisSummaryDataClass.ts
+++ b/src/app/calculations/analysis-calculations/monthlyAnalysisSummaryDataClass.ts
@@ -205,9 +205,11 @@ export class MonthlyAnalysisSummaryDataClass {
     }
 
     isPredictorDataMissing(predictorVariables: Array<AnalysisGroupPredictorVariable>) {
-        this.missingValueWarning = predictorVariables.some(variable =>
-            !this.monthPredictorData.some(data => data.predictorId == variable.id)
-        );
+        this.missingValueWarning = predictorVariables.some(variable => {
+            if (variable.productionInAnalysis) {
+                !this.monthPredictorData.some(data => data.predictorId == variable.id)
+            }
+        });
     }
 
     calculateEnergyIntensityModeledEnergy(baselineEnergyIntensity: number): number {

--- a/src/app/calculations/analysis-calculations/monthlyFacilityAnalysisDataClass.ts
+++ b/src/app/calculations/analysis-calculations/monthlyFacilityAnalysisDataClass.ts
@@ -80,9 +80,11 @@ export class MonthlyFacilityAnalysisDataClass {
     }
 
     setMissingPredictorWarning(predictors: Array<IdbPredictor>) {
-        this.missingValueWarning = predictors.some(variable =>
-            !this.monthPredictorData.some(data => data.predictorId == variable.guid)
-        );
+        this.missingValueWarning = predictors.some(variable => {
+            if (variable.productionInAnalysis) {
+                return !this.monthPredictorData.some(data => data.predictorId == variable.guid)
+            }
+        });
     }
 
     setFiscalYear(facility: IdbFacility) {


### PR DESCRIPTION
connects #2365 
This pull request updates the logic for detecting missing predictor data in both the `MonthlyAnalysisSummaryDataClass` and `MonthlyFacilityAnalysisDataClass` classes. The main improvement is that missing value warnings are now only triggered for predictor variables that are actually used in the analysis (i.e., those with `productionInAnalysis` set to true).

**Predictor data validation improvements:**

* Updated `isPredictorDataMissing` in `MonthlyAnalysisSummaryDataClass` to only consider predictor variables with `productionInAnalysis` enabled when checking for missing data.
* Updated `setMissingPredictorWarning` in `MonthlyFacilityAnalysisDataClass` to only trigger warnings for predictors with `productionInAnalysis` set to true, improving accuracy of missing data detection.