### PR TITLE
Issue 2394: Router guard for bulk setup screens

### DIFF
--- a/src/app/data-evaluation/facility/utility-data/predictors/edit-predictor/edit-predictor.component.ts
+++ b/src/app/data-evaluation/facility/utility-data/predictors/edit-predictor/edit-predictor.component.ts
@@ -48,8 +48,8 @@ export class EditPredictorComponent {
   handleKeyDown(event: KeyboardEvent) {
     if ((event.ctrlKey || event.metaKey) && event.key === 's') {
       event.preventDefault();
-      if(!this.predictorForm.invalid) {
-         this.saveChanges();
+      if (!this.predictorForm.invalid) {
+        this.saveChanges();
       }
     }
   }
@@ -206,6 +206,7 @@ export class EditPredictorComponent {
 
   canDeactivate(): Observable<boolean> {
     if (this.predictorForm && this.predictorForm.dirty) {
+      this.routerGuardService.setShowSave(true);
       this.routerGuardService.setShowModal(true);
       return this.routerGuardService.getModalAction().pipe(map(action => {
         if (action == 'save') {

--- a/src/app/data-evaluation/facility/utility-data/predictors/predictors-data/predictors-data-form/predictors-data-form.component.ts
+++ b/src/app/data-evaluation/facility/utility-data/predictors/predictors-data/predictors-data-form/predictors-data-form.component.ts
@@ -111,6 +111,7 @@ export class PredictorsDataFormComponent {
 
   canDeactivate(): Observable<boolean> {
     if (!this.isSaved) {
+      this.routerGuardService.setShowSave(true);
       this.routerGuardService.setShowModal(true);
       return this.routerGuardService.getModalAction().pipe(map(action => {
         if (action == 'save') {

--- a/src/app/data-management/account-facilities/facility-data/facility-energy-uses/facility-energy-use-equipment/facility-energy-use-equipment.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-energy-uses/facility-energy-use-equipment/facility-energy-use-equipment.component.ts
@@ -124,6 +124,7 @@ export class FacilityEnergyUseEquipmentComponent {
 
   canDeactivate(): Observable<boolean> {
     if (this.dataChanged) {
+      this.routerGuardService.setShowSave(true);
       this.routerGuardService.setShowModal(true);
       return this.routerGuardService.getModalAction().pipe(map(action => {
         if (action == 'save') {

--- a/src/app/data-management/account-facilities/facility-data/facility-energy-uses/facility-energy-use-group/facility-energy-use-group.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-energy-uses/facility-energy-use-group/facility-energy-use-group.component.ts
@@ -132,6 +132,7 @@ export class FacilityEnergyUseGroupComponent {
 
   canDeactivate(): Observable<boolean> {
     if (this.form && this.form.dirty) {
+      this.routerGuardService.setShowSave(true);
       this.routerGuardService.setShowModal(true);
       return this.routerGuardService.getModalAction().pipe(map(action => {
         if (action == 'save') {

--- a/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-uses-group-setup/facility-energy-uses-group-setup.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-uses-group-setup/facility-energy-uses-group-setup.component.ts
@@ -48,6 +48,7 @@ export class FacilityEnergyUsesGroupSetupComponent {
 
   isNew: boolean;
   setupYear: number;
+  routingAfterSubmit: boolean = false;
 
   ngOnInit() {
     this.activatedRoute.queryParams.subscribe(params => {
@@ -166,6 +167,7 @@ export class FacilityEnergyUsesGroupSetupComponent {
     await this.dbChangesService.setAccountFacilityEnergyUseEquipment(account, this.facility);
     this.loadingService.setLoadingStatus(false);
     this.toastNotificationsService.showToast("Energy Use Groups and Equipment Added", undefined, undefined, false, "alert-success");
+    this.routingAfterSubmit = true;
     this.router.navigateByUrl('/data-management/' + this.facility.accountId + '/facilities/' + this.facility.guid + '/energy-uses');
   }
 
@@ -229,14 +231,17 @@ export class FacilityEnergyUsesGroupSetupComponent {
 
 
   canDeactivate(): Observable<boolean> {
-    this.routerGuardService.setShowSave(false);
-    this.routerGuardService.setShowModal(true);
-    return this.routerGuardService.getModalAction().pipe(map(action => {
-      if (action == 'discard') {
-        return of(true);
-      }
-      return of(false);
-    }),
-      take(1), switchAll());
+    if (!this.routingAfterSubmit) {
+      this.routerGuardService.setShowSave(false);
+      this.routerGuardService.setShowModal(true);
+      return this.routerGuardService.getModalAction().pipe(map(action => {
+        if (action == 'discard') {
+          return of(true);
+        }
+        return of(false);
+      }),
+        take(1), switchAll());
+    }
+    return of(true);
   }
 }

--- a/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-uses-group-setup/facility-energy-uses-group-setup.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-uses-group-setup/facility-energy-uses-group-setup.component.ts
@@ -1,5 +1,5 @@
-import { Component } from '@angular/core';
-import { firstValueFrom, Subscription } from 'rxjs';
+import { Component, inject } from '@angular/core';
+import { firstValueFrom, from, map, Observable, of, Subscription, switchAll, take } from 'rxjs';
 import { FacilitydbService } from 'src/app/indexedDB/facility-db.service';
 import { IdbFacility } from 'src/app/models/idbModels/facility';
 import { getNewIdbFacilityEnergyUseEquipment, IdbFacilityEnergyUseEquipment } from 'src/app/models/idbModels/facilityEnergyUseEquipment';
@@ -15,6 +15,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import * as _ from 'lodash';
 import { UtilityMeterDatadbService } from 'src/app/indexedDB/utilityMeterData-db.service';
 import { FacilityEnergyUsesSetupService } from '../facility-energy-uses-setup.service';
+import { RouterGuardService } from 'src/app/shared/shared-router-guard-modal/router-guard-service';
 
 @Component({
   selector: 'app-facility-energy-uses-group-setup',
@@ -23,6 +24,18 @@ import { FacilityEnergyUsesSetupService } from '../facility-energy-uses-setup.se
   styleUrl: './facility-energy-uses-group-setup.component.css'
 })
 export class FacilityEnergyUsesGroupSetupComponent {
+  private facilityDbService: FacilitydbService = inject(FacilitydbService);
+  private loadingService: LoadingService = inject(LoadingService);
+  private facilityEnergyUseEquipmentDbService: FacilityEnergyUseEquipmentDbService = inject(FacilityEnergyUseEquipmentDbService);
+  private facilityEnergyUseGroupsDbService: FacilityEnergyUseGroupsDbService = inject(FacilityEnergyUseGroupsDbService);
+  private dbChangesService: DbChangesService = inject(DbChangesService);
+  private toastNotificationsService: ToastNotificationsService = inject(ToastNotificationsService);
+  private accountDbService: AccountdbService = inject(AccountdbService);
+  private router: Router = inject(Router);
+  private utilityMeterDataDbService: UtilityMeterDatadbService = inject(UtilityMeterDatadbService);
+  private facilityEnergyUsesSetupService: FacilityEnergyUsesSetupService = inject(FacilityEnergyUsesSetupService);
+  private activatedRoute: ActivatedRoute = inject(ActivatedRoute);
+  private routerGuardService: RouterGuardService = inject(RouterGuardService);
 
   facility: IdbFacility;
   facilitySub: Subscription;
@@ -35,18 +48,6 @@ export class FacilityEnergyUsesGroupSetupComponent {
 
   isNew: boolean;
   setupYear: number;
-  constructor(private facilityDbService: FacilitydbService,
-    private loadingService: LoadingService,
-    private facilityEnergyUseEquipmentDbService: FacilityEnergyUseEquipmentDbService,
-    private facilityEnergyUseGroupsDbService: FacilityEnergyUseGroupsDbService,
-    private dbChangesService: DbChangesService,
-    private toastNotificationsService: ToastNotificationsService,
-    private accountDbService: AccountdbService,
-    private router: Router,
-    private utilityMeterDataDbService: UtilityMeterDatadbService,
-    private facilityEnergyUsesSetupService: FacilityEnergyUsesSetupService,
-    private activatedRoute: ActivatedRoute
-  ) { }
 
   ngOnInit() {
     this.activatedRoute.queryParams.subscribe(params => {
@@ -224,5 +225,18 @@ export class FacilityEnergyUsesGroupSetupComponent {
 
   startOver() {
     this.router.navigate(['../setup-options'], { relativeTo: this.activatedRoute });
+  }
+
+
+  canDeactivate(): Observable<boolean> {
+    this.routerGuardService.setShowSave(false);
+    this.routerGuardService.setShowModal(true);
+    return this.routerGuardService.getModalAction().pipe(map(action => {
+      if (action == 'discard') {
+        return of(true);
+      }
+      return of(false);
+    }),
+      take(1), switchAll());
   }
 }

--- a/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-uses-group-setup/facility-energy-uses-group-setup.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-uses-group-setup/facility-energy-uses-group-setup.component.ts
@@ -1,5 +1,5 @@
 import { Component, inject } from '@angular/core';
-import { firstValueFrom, from, map, Observable, of, Subscription, switchAll, take } from 'rxjs';
+import { firstValueFrom, map, Observable, of, Subscription, switchAll, take } from 'rxjs';
 import { FacilitydbService } from 'src/app/indexedDB/facility-db.service';
 import { IdbFacility } from 'src/app/models/idbModels/facility';
 import { getNewIdbFacilityEnergyUseEquipment, IdbFacilityEnergyUseEquipment } from 'src/app/models/idbModels/facilityEnergyUseEquipment';

--- a/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-uses-modify-annual-data/facility-energy-uses-modify-annual-data.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-uses-modify-annual-data/facility-energy-uses-modify-annual-data.component.ts
@@ -71,7 +71,7 @@ export class FacilityEnergyUsesModifyAnnualDataComponent {
           let equipmentForGroupCopy: Array<IdbFacilityEnergyUseEquipment> = equipmentForGroup.map(equip => { return _.cloneDeep(equip); });
           //add year to equipment that doesn't have data for the year
           for (let equipment of equipmentForGroupCopy) {
-            if (equipment.utilityData.length > 0) {
+            if (equipment.utilityData.length > 0 && equipment.operatingConditionsData?.length > 0) {
               let checkHasDataForYear: EnergyEquipmentOperatingConditionsData = equipment.operatingConditionsData.find(data => data.year == this.selectedYear);
               if (!checkHasDataForYear) {
                 let mostRecentYearOfData: number = Math.max(...equipment.operatingConditionsData.map(data => data.year));

--- a/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-uses-modify-annual-data/facility-energy-uses-modify-annual-data.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-uses-modify-annual-data/facility-energy-uses-modify-annual-data.component.ts
@@ -1,6 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { firstValueFrom, Subscription } from 'rxjs';
+import { firstValueFrom, map, Observable, of, Subscription, switchAll, take } from 'rxjs';
 import { FacilitydbService } from 'src/app/indexedDB/facility-db.service';
 import { FacilityEnergyUseEquipmentDbService } from 'src/app/indexedDB/facility-energy-use-equipment-db.service';
 import { FacilityEnergyUseGroupsDbService } from 'src/app/indexedDB/facility-energy-use-groups-db.service';
@@ -14,6 +14,7 @@ import { AccountdbService } from 'src/app/indexedDB/account-db.service';
 import { DbChangesService } from 'src/app/indexedDB/db-changes.service';
 import { ToastNotificationsService } from 'src/app/core-components/toast-notifications/toast-notifications.service';
 import { IdbAccount } from 'src/app/models/idbModels/account';
+import { RouterGuardService } from 'src/app/shared/shared-router-guard-modal/router-guard-service';
 
 @Component({
   selector: 'app-facility-energy-uses-modify-annual-data',
@@ -22,6 +23,17 @@ import { IdbAccount } from 'src/app/models/idbModels/account';
   styleUrl: './facility-energy-uses-modify-annual-data.component.css',
 })
 export class FacilityEnergyUsesModifyAnnualDataComponent {
+  private facilityDbService: FacilitydbService = inject(FacilitydbService);
+  private facilityEnergyUseEquipmentDbService: FacilityEnergyUseEquipmentDbService = inject(FacilityEnergyUseEquipmentDbService);
+  private facilityEnergyUseGroupsDbService: FacilityEnergyUseGroupsDbService = inject(FacilityEnergyUseGroupsDbService);
+  private activatedRoute: ActivatedRoute = inject(ActivatedRoute);
+  private facilityEnergyUsesSetupService: FacilityEnergyUsesSetupService = inject(FacilityEnergyUsesSetupService);
+  private router: Router = inject(Router);
+  private loadingService: LoadingService = inject(LoadingService);
+  private accountDbService: AccountdbService = inject(AccountdbService);
+  private dbChangesService: DbChangesService = inject(DbChangesService);
+  private toastNotificationsService: ToastNotificationsService = inject(ToastNotificationsService);
+  private routerGuardService: RouterGuardService = inject(RouterGuardService);
 
   selectedYear: number;
   facility: IdbFacility;
@@ -29,22 +41,11 @@ export class FacilityEnergyUsesModifyAnnualDataComponent {
 
   energyUseGroups: Array<IdbFacilityEnergyUseGroup & { equipment: Array<IdbFacilityEnergyUseEquipment> }>;
   groupSetupIndex: number = 0;
-
-  constructor(private facilityDbService: FacilitydbService,
-    private facilityEnergyUseEquipmentDbService: FacilityEnergyUseEquipmentDbService,
-    private facilityEnergyUseGroupsDbService: FacilityEnergyUseGroupsDbService,
-    private activatedRoute: ActivatedRoute,
-    private facilityEnergyUsesSetupService: FacilityEnergyUsesSetupService,
-    private router: Router,
-    private loadingService: LoadingService,
-    private accountDbService: AccountdbService,
-    private dbChangesService: DbChangesService,
-    private toastNotificationsService: ToastNotificationsService) { }
+  routingAfterSubmit: boolean = false;
 
   ngOnInit() {
     this.activatedRoute.params.subscribe(params => {
       this.selectedYear = parseInt(params['year']);
-      console.log('selected year: ', this.selectedYear);
     });
     this.facilitySub = this.facilityDbService.selectedFacility.subscribe(facility => {
       this.facility = facility;
@@ -70,19 +71,23 @@ export class FacilityEnergyUsesModifyAnnualDataComponent {
           let equipmentForGroupCopy: Array<IdbFacilityEnergyUseEquipment> = equipmentForGroup.map(equip => { return _.cloneDeep(equip); });
           //add year to equipment that doesn't have data for the year
           for (let equipment of equipmentForGroupCopy) {
-            let checkHasDataForYear: EnergyEquipmentOperatingConditionsData = equipment.operatingConditionsData.find(data => data.year == this.selectedYear);
-            if (!checkHasDataForYear) {
-              let mostRecentYearOfData: number = Math.max(...equipment.operatingConditionsData.map(data => data.year));
-              let mostRecentData: EnergyEquipmentOperatingConditionsData = equipment.operatingConditionsData.find(data => data.year == mostRecentYearOfData);
-              let newData: EnergyEquipmentOperatingConditionsData = {
-                ...mostRecentData,
-                year: this.selectedYear
+            if (equipment.utilityData.length > 0) {
+              let checkHasDataForYear: EnergyEquipmentOperatingConditionsData = equipment.operatingConditionsData.find(data => data.year == this.selectedYear);
+              if (!checkHasDataForYear) {
+                let mostRecentYearOfData: number = Math.max(...equipment.operatingConditionsData.map(data => data.year));
+                let mostRecentData: EnergyEquipmentOperatingConditionsData = equipment.operatingConditionsData.find(data => data.year == mostRecentYearOfData);
+                let newData: EnergyEquipmentOperatingConditionsData = {
+                  ...mostRecentData,
+                  year: this.selectedYear
+                }
+                equipment.operatingConditionsData.push(newData);
+                equipment.utilityData.forEach(utility => {
+                  let mostRecentYearOfUtilityData: EquipmentUtilityDataEnergyUse = utility.energyUse.find(data => data.year == mostRecentYearOfData);
+                  if (mostRecentYearOfUtilityData) {
+                    utility.energyUse.push({ year: this.selectedYear, energyUse: mostRecentYearOfUtilityData.energyUse, overrideEnergyUse: false, energyUseUnit: mostRecentYearOfUtilityData.energyUseUnit });
+                  }
+                })
               }
-              equipment.operatingConditionsData.push(newData);
-              equipment.utilityData.forEach(utility => {
-                let mostRecentYearOfUtilityData: EquipmentUtilityDataEnergyUse = utility.energyUse.find(data => data.year == mostRecentYearOfData);
-                utility.energyUse.push({ year: this.selectedYear, energyUse: mostRecentYearOfUtilityData.energyUse, overrideEnergyUse: false, energyUseUnit: mostRecentYearOfUtilityData.energyUseUnit });
-              })
             }
           }
           this.energyUseGroups.push({
@@ -145,11 +150,27 @@ export class FacilityEnergyUsesModifyAnnualDataComponent {
     await this.dbChangesService.setAccountFacilityEnergyUseEquipment(account, this.facility);
     this.loadingService.setLoadingStatus(false);
     this.toastNotificationsService.showToast("Energy Use Groups and Equipment Updated", undefined, undefined, false, "alert-success");
+    this.routingAfterSubmit = true;
     this.router.navigateByUrl('/data-management/' + this.facility.accountId + '/facilities/' + this.facility.guid + '/energy-uses');
   }
 
 
   leaveGroupSetup() {
     this.router.navigateByUrl('/data-management/' + this.facility.accountId + '/facilities/' + this.facility.guid + '/energy-uses');
+  }
+
+  canDeactivate(): Observable<boolean> {
+    if (!this.routingAfterSubmit) {
+      this.routerGuardService.setShowSave(false);
+      this.routerGuardService.setShowModal(true);
+      return this.routerGuardService.getModalAction().pipe(map(action => {
+        if (action == 'discard') {
+          return of(true);
+        }
+        return of(false);
+      }),
+        take(1), switchAll());
+    }
+    return of(true);
   }
 }

--- a/src/app/data-management/account-facilities/facility-data/facility-meters/facility-meter/facility-meter.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-meters/facility-meter/facility-meter.component.ts
@@ -158,6 +158,7 @@ export class FacilityMeterComponent {
 
   canDeactivate(): Observable<boolean> {
     if (this.meterForm && this.meterForm.dirty) {
+      this.routerGuardService.setShowSave(true);
       this.routerGuardService.setShowModal(true);
       return this.routerGuardService.getModalAction().pipe(map(action => {
         if (action == 'save') {

--- a/src/app/data-management/account-facilities/facility-data/facility-predictors/facility-predictor-data-entry/facility-predictor-data-entry.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-predictors/facility-predictor-data-entry/facility-predictor-data-entry.component.ts
@@ -108,6 +108,7 @@ export class FacilityPredictorDataEntryComponent {
 
   canDeactivate(): Observable<boolean> {
     if (!this.isSaved) {
+      this.routerGuardService.setShowSave(true);
       this.routerGuardService.setShowModal(true);
       return this.routerGuardService.getModalAction().pipe(map(action => {
         if (action == 'save') {

--- a/src/app/data-management/account-facilities/facility-data/facility-predictors/facility-predictor/facility-predictor.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-predictors/facility-predictor/facility-predictor.component.ts
@@ -191,6 +191,7 @@ export class FacilityPredictorComponent {
 
   canDeactivate(): Observable<boolean> {
     if (this.predictorForm && this.predictorForm.dirty) {
+      this.routerGuardService.setShowSave(true);
       this.routerGuardService.setShowModal(true);
       return this.routerGuardService.getModalAction().pipe(map(action => {
         if (action == 'save') {

--- a/src/app/routing/data-management.routes.ts
+++ b/src/app/routing/data-management.routes.ts
@@ -285,7 +285,8 @@ export const DataManagementRoutes: Route = {
                                 },
                                 {
                                     path: 'new-setup',
-                                    component: FacilityEnergyUsesGroupSetupComponent
+                                    component: FacilityEnergyUsesGroupSetupComponent,
+                                    canDeactivate: [canDeactivateGuard]
                                 },
                                 {
                                     path: 'modify-annual-data/:year',

--- a/src/app/routing/data-management.routes.ts
+++ b/src/app/routing/data-management.routes.ts
@@ -281,7 +281,8 @@ export const DataManagementRoutes: Route = {
                                 },
                                 {
                                     path: 'edit-existing',
-                                    component: FacilityEnergyUsesGroupSetupComponent
+                                    component: FacilityEnergyUsesGroupSetupComponent,
+                                    canDeactivate: [canDeactivateGuard]
                                 },
                                 {
                                     path: 'new-setup',
@@ -290,7 +291,8 @@ export const DataManagementRoutes: Route = {
                                 },
                                 {
                                     path: 'modify-annual-data/:year',
-                                    component: FacilityEnergyUsesModifyAnnualDataComponent
+                                    component: FacilityEnergyUsesModifyAnnualDataComponent,
+                                    canDeactivate: [canDeactivateGuard]
                                 },
                                 {
                                     path: 'summary',

--- a/src/app/shared/shared-meter-content/edit-bill/edit-bill.component.ts
+++ b/src/app/shared/shared-meter-content/edit-bill/edit-bill.component.ts
@@ -183,6 +183,7 @@ export class EditBillComponent implements OnInit {
 
   canDeactivate(): Observable<boolean> {
     if (this.meterDataForm && this.meterDataForm.dirty) {
+      this.routerGuardService.setShowSave(true);
       this.routerGuardService.setShowModal(true);
       return this.routerGuardService.getModalAction().pipe(map(action => {
         if (action == 'save') {

--- a/src/app/shared/shared-meter-content/edit-meter/edit-meter.component.ts
+++ b/src/app/shared/shared-meter-content/edit-meter/edit-meter.component.ts
@@ -135,6 +135,7 @@ export class EditMeterComponent implements OnInit {
 
   canDeactivate(): Observable<boolean> {
     if (this.meterForm && this.meterForm.dirty) {
+      this.routerGuardService.setShowSave(true);
       this.routerGuardService.setShowModal(true);
       return this.routerGuardService.getModalAction().pipe(map(action => {
         if (action == 'save') {

--- a/src/app/shared/shared-meter-content/set-meter-grouping/meter-group-form/meter-group-form.component.ts
+++ b/src/app/shared/shared-meter-content/set-meter-grouping/meter-group-form/meter-group-form.component.ts
@@ -189,6 +189,7 @@ export class MeterGroupFormComponent {
 
   canDeactivate(): Observable<boolean> {
     if (this.groupForm.dirty || this.selectionsChanged) {
+      this.routerGuardService.setShowSave(true);
       this.routerGuardService.setShowModal(true);
       return this.routerGuardService.getModalAction().pipe(map(action => {
         if (action == 'save') {

--- a/src/app/shared/shared-router-guard-modal/router-guard-service.ts
+++ b/src/app/shared/shared-router-guard-modal/router-guard-service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Subject } from 'rxjs';
 
-export type ModalAction = 'save' | 'discard';
+export type ModalAction = 'save' | 'discard' | 'cancel';
 
 @Injectable({
   providedIn: 'root',
@@ -10,10 +10,11 @@ export class RouterGuardService {
 
   actionSelected: Subject<ModalAction>;
   showModal: BehaviorSubject<boolean>;
-  
+  showSave: BehaviorSubject<boolean>;
   constructor() { 
     this.actionSelected = new Subject<ModalAction>();
     this.showModal = new BehaviorSubject<boolean>(false);
+    this.showSave = new BehaviorSubject<boolean>(true);
   }
 
   getModalAction() {
@@ -27,6 +28,10 @@ export class RouterGuardService {
 
   setShowModal(show: boolean) {
     this.showModal.next(show);
+  }
+
+  setShowSave(show: boolean) {
+    this.showSave.next(show);
   }
 
   getShowModal() {

--- a/src/app/shared/shared-router-guard-modal/shared-router-guard-modal.component.html
+++ b/src/app/shared/shared-router-guard-modal/shared-router-guard-modal.component.html
@@ -1,8 +1,12 @@
-<div [ngClass]="{'windowOverlay': showModal}"></div>
-<div class="popup" [ngClass]="{'open': showModal}">
+@let _showModal = showModal();
+@let _showSave = showSave();
+
+<div [ngClass]="{'windowOverlay': _showModal}"></div>
+<div class="popup" [ngClass]="{'open': _showModal}">
     <div class="popup-header">Unsaved Changes
         <button class="item-right" (click)="onClose()">x</button>
     </div>
+    @if(_showSave){
     <div class="popup-body">
         There are unsaved changes on this page. Would you like to save the changes?
     </div>
@@ -13,4 +17,15 @@
             Save
         </button>
     </div>
+    }@else {
+    <div class="popup-body">
+        There are unsaved changes on this page. Would you like to discard these changes?
+    </div>
+    <div class="popup-footer text-end">
+        <button class="btn btn-secondary" (click)="onClose()">
+            Cancel
+        </button>
+        <button class="btn btn-danger" (click)="onDiscard()">Discard</button>
+    </div>
+    }
 </div>

--- a/src/app/shared/shared-router-guard-modal/shared-router-guard-modal.component.ts
+++ b/src/app/shared/shared-router-guard-modal/shared-router-guard-modal.component.ts
@@ -1,6 +1,5 @@
 import { Component, inject, Signal } from '@angular/core';
 import { RouterGuardService } from './router-guard-service';
-import { Subscription } from 'rxjs';
 import { toSignal } from '@angular/core/rxjs-interop';
 
 

--- a/src/app/shared/shared-router-guard-modal/shared-router-guard-modal.component.ts
+++ b/src/app/shared/shared-router-guard-modal/shared-router-guard-modal.component.ts
@@ -1,6 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, inject, Signal } from '@angular/core';
 import { RouterGuardService } from './router-guard-service';
 import { Subscription } from 'rxjs';
+import { toSignal } from '@angular/core/rxjs-interop';
 
 
 @Component({
@@ -10,25 +11,10 @@ import { Subscription } from 'rxjs';
   styleUrl: './shared-router-guard-modal.component.css',
 })
 export class SharedRouterGuardModalComponent {
+  private routerGuardService: RouterGuardService = inject(RouterGuardService);
 
-  showModalSub: Subscription
-  showModal: boolean = false;
-
-  constructor(
-    private routerGuardService: RouterGuardService
-  ) { }
-
-  ngOnInit() {
-    this.showModalSub = this.routerGuardService.getShowModal().subscribe(show => {
-      this.showModal = show;
-    });
-  }
-
-  ngOnDestroy() {
-    if (this.showModalSub) {
-      this.showModalSub.unsubscribe();
-    }
-  }
+  showModal: Signal<boolean> = toSignal(this.routerGuardService.showModal, { initialValue: false });
+  showSave: Signal<boolean> = toSignal(this.routerGuardService.showSave, { initialValue: true });
 
   onSave() {
     this.routerGuardService.setShowModal(false);
@@ -42,5 +28,6 @@ export class SharedRouterGuardModalComponent {
 
   onClose() {
     this.routerGuardService.setShowModal(false);
+    this.routerGuardService.setModalAction('cancel');
   }
 }


### PR DESCRIPTION
connects #2394 

This pull request improves the navigation guard logic across several components to ensure users are prompted to save or discard changes before leaving forms with unsaved data. It also refactors two setup components to use Angular's `inject()` API for dependency management and implements custom `canDeactivate` logic for them. Additionally, the routing configuration is updated to enforce these guards on relevant routes.

**Navigation Guard Improvements:**

* In multiple components with forms or data entry (`EditPredictorComponent`, `PredictorsDataFormComponent`, `FacilityEnergyUseEquipmentComponent`, `FacilityEnergyUseGroupComponent`, `FacilityMeterComponent`, `FacilityPredictorDataEntryComponent`, `FacilityPredictorComponent`, `EditBillComponent`, `EditMeterComponent`, `MeterGroupFormComponent`), the `canDeactivate` method now sets the save prompt (`setShowSave(true)`) before showing the modal, ensuring users are clearly prompted to save changes before navigating away. [[1]](diffhunk://#diff-74380c87b48cfea03449a3565523f4d8cc47c513bda9579424be43c022b79feeR209) [[2]](diffhunk://#diff-1d042938d2314a8fdbfce4390a57327cf739dfda0cfe5fbef3176eb646ddf89fR114) [[3]](diffhunk://#diff-f57d4d919e16e4f9688c30652146924bd35a7c5c03cd2744e42312660b8c3dc3R127) [[4]](diffhunk://#diff-232a50ffd7f832da243d804769e662cb68f36ff64709a9fdf6da08399bdaae8bR135) [[5]](diffhunk://#diff-e71836099ae3cbb987636841b7ca13c8170339c0f753a69475e78eb09555239fR161) [[6]](diffhunk://#diff-bf04580f556c7165dc75164eef1b42f320501857f5ffa9c040db2171bfb3e7e9R111) [[7]](diffhunk://#diff-767df090e7fb8cdab0246927cd4a3030685f3650f6ea73937244553b4059c29bR194) [[8]](diffhunk://#diff-6a38beb4130526fe075094676c790fb50c297cd538d70c07f28386c7bc8207e1R186) [[9]](diffhunk://#diff-19cc8a3dae9db732e158914c129a4e08263a7870b67676d4d8826a57f7578564R138) [[10]](diffhunk://#diff-8ef3e877ff211c8c57c8501eda49a72572642dfbee780a0e80e5fd874d65a2c7R192)

**Setup Component Refactoring and Guard Implementation:**

* `FacilityEnergyUsesGroupSetupComponent` and `FacilityEnergyUsesModifyAnnualDataComponent` are refactored to use Angular's `inject()` API for dependency injection, improving code readability and maintainability. [[1]](diffhunk://#diff-9f42de161bf8fd46b94da2a347a092df284c23cc771e82873729fa8c3fe52401L1-R2) [[2]](diffhunk://#diff-9f42de161bf8fd46b94da2a347a092df284c23cc771e82873729fa8c3fe52401R18) [[3]](diffhunk://#diff-9f42de161bf8fd46b94da2a347a092df284c23cc771e82873729fa8c3fe52401R27-R38) [[4]](diffhunk://#diff-12c149134850a0d7b52b99b934304ac412ac504ec97b88fc698bb6a6422b21f4L1-R3) [[5]](diffhunk://#diff-12c149134850a0d7b52b99b934304ac412ac504ec97b88fc698bb6a6422b21f4R17) [[6]](diffhunk://#diff-12c149134850a0d7b52b99b934304ac412ac504ec97b88fc698bb6a6422b21f4R26-L47)
* Both components now implement a custom `canDeactivate` method that checks if navigation is occurring after a successful submit; if not, it prompts the user to confirm discarding unsaved changes. [[1]](diffhunk://#diff-9f42de161bf8fd46b94da2a347a092df284c23cc771e82873729fa8c3fe52401R231-R246) [[2]](diffhunk://#diff-12c149134850a0d7b52b99b934304ac412ac504ec97b88fc698bb6a6422b21f4R153-R175)
* The `routingAfterSubmit` flag is added to these components to track navigation state after successful form submission, preventing unnecessary prompts. [[1]](diffhunk://#diff-9f42de161bf8fd46b94da2a347a092df284c23cc771e82873729fa8c3fe52401L38-R51) [[2]](diffhunk://#diff-9f42de161bf8fd46b94da2a347a092df284c23cc771e82873729fa8c3fe52401R170) [[3]](diffhunk://#diff-12c149134850a0d7b52b99b934304ac412ac504ec97b88fc698bb6a6422b21f4R26-L47) [[4]](diffhunk://#diff-12c149134850a0d7b52b99b934304ac412ac504ec97b88fc698bb6a6422b21f4R153-R175)

**Routing Configuration:**

* The routes for `edit-existing`, `new-setup`, and `modify-annual-data/:year` in `data-management` are updated to use the `canDeactivate` guard, ensuring users are always prompted before leaving these forms with unsaved changes.

**Data Handling Fixes:**

* In `FacilityEnergyUsesModifyAnnualDataComponent`, additional checks are added to prevent errors when copying data for years where utility or operating conditions data may be missing. [[1]](diffhunk://#diff-12c149134850a0d7b52b99b934304ac412ac504ec97b88fc698bb6a6422b21f4R74) [[2]](diffhunk://#diff-12c149134850a0d7b52b99b934304ac412ac504ec97b88fc698bb6a6422b21f4R86-R92)