### PR TITLE
Issue 2393: update report years dropdown options

### DIFF
--- a/src/app/calculations/shared-calculations/calculationsHelpers.ts
+++ b/src/app/calculations/shared-calculations/calculationsHelpers.ts
@@ -160,7 +160,7 @@ export function getYearsWithFullDataAccount(calanderizedMeters: Array<Calanderiz
         let uniqueMonths: Array<number> = _.uniq(months);
         return uniqueMonths.length == 12;
     });
-    return uniqueYears;
+    return _.sortBy(uniqueYears);
 }
 
 export function getYearsWithFullData(calanderizedMeters: Array<CalanderizedMeter>, facility: IdbFacility): Array<number> {
@@ -174,7 +174,7 @@ export function getYearsWithFullData(calanderizedMeters: Array<CalanderizedMeter
         let uniqueMonths: Array<number> = _.uniq(months);
         return uniqueMonths.length == 12;
     });
-    return uniqueYears;
+    return _.sortBy(uniqueYears);
 }
 
 export function getLatestYearWithData(calanderizedMeters: Array<CalanderizedMeter>, facilities: Array<IdbFacility>): number {
@@ -198,14 +198,14 @@ export function getAllYearsWithData(calanderizedMeters: Array<CalanderizedMeter>
     let monthlyData: Array<MonthlyData> = facilityMeters.flatMap(cMeter => { return cMeter.monthlyData });
     let years: Array<number> = monthlyData.map(mData => { return getFiscalYear(mData.date, facility) });
     let uniqueYears: Array<number> = _.uniq(years);
-    return uniqueYears;
+    return _.sortBy(uniqueYears);
 }
 
 export function getAllYearsWithDataAccount(calanderizedMeters: Array<CalanderizedMeter>, account: IdbAccount): Array<number> {
     let monthlyData: Array<MonthlyData> = calanderizedMeters.flatMap(cMeter => { return cMeter.monthlyData });
     let years: Array<number> = monthlyData.map(mData => { return getFiscalYear(mData.date, account) });
     let uniqueYears: Array<number> = _.uniq(years);
-    return uniqueYears;
+    return _.sortBy(uniqueYears);
 }
 
 export function getLatestDataDate(calanderizedMeters: Array<CalanderizedMeter>): Date {

--- a/src/app/calculations/shared-calculations/calculationsHelpers.ts
+++ b/src/app/calculations/shared-calculations/calculationsHelpers.ts
@@ -150,6 +150,19 @@ export function checkValueNaN(val: number): number {
     return val;
 }
 
+export function getYearsWithFullDataAccount(calanderizedMeters: Array<CalanderizedMeter>, account: IdbAccount): Array<number> {
+    let monthlyData: Array<MonthlyData> = calanderizedMeters.flatMap(cMeter => { return cMeter.monthlyData });
+    let years: Array<number> = monthlyData.map(mData => { return getFiscalYear(mData.date, account) });
+    let uniqueYears: Array<number> = _.uniq(years);
+    uniqueYears = uniqueYears.filter(year => {
+        let monthlyDataForYear: Array<MonthlyData> = monthlyData.filter(mData => { return getFiscalYear(mData.date, account) == year });
+        let months: Array<number> = monthlyDataForYear.map(mData => { return mData.date.getMonth() });
+        let uniqueMonths: Array<number> = _.uniq(months);
+        return uniqueMonths.length == 12;
+    });
+    return uniqueYears;
+}
+
 export function getYearsWithFullData(calanderizedMeters: Array<CalanderizedMeter>, facility: IdbFacility): Array<number> {
     let facilityMeters: Array<CalanderizedMeter> = calanderizedMeters.filter(cMeter => { return cMeter.meter.facilityId == facility.guid });
     let monthlyData: Array<MonthlyData> = facilityMeters.flatMap(cMeter => { return cMeter.monthlyData });
@@ -186,4 +199,17 @@ export function getAllYearsWithData(calanderizedMeters: Array<CalanderizedMeter>
     let years: Array<number> = monthlyData.map(mData => { return getFiscalYear(mData.date, facility) });
     let uniqueYears: Array<number> = _.uniq(years);
     return uniqueYears;
+}
+
+export function getAllYearsWithDataAccount(calanderizedMeters: Array<CalanderizedMeter>, account: IdbAccount): Array<number> {
+    let monthlyData: Array<MonthlyData> = calanderizedMeters.flatMap(cMeter => { return cMeter.monthlyData });
+    let years: Array<number> = monthlyData.map(mData => { return getFiscalYear(mData.date, account) });
+    let uniqueYears: Array<number> = _.uniq(years);
+    return uniqueYears;
+}
+
+export function getLatestDataDate(calanderizedMeters: Array<CalanderizedMeter>): Date {
+    let monthlyData: Array<MonthlyData> = calanderizedMeters.flatMap(cMeter => { return cMeter.monthlyData });
+    let dates: Array<Date> = monthlyData.map(mData => { return new Date(mData.year, mData.monthNumValue, 1) });
+    return _.max(dates);
 }

--- a/src/app/data-evaluation/account/account-reports/account-report-setup/account-report-setup.component.html
+++ b/src/app/data-evaluation/account/account-reports/account-report-setup/account-report-setup.component.html
@@ -4,6 +4,7 @@
 @let _setupForm = setupForm();
 @let _reportDateWarning = reportDateWarning();
 
+@if(_selectedReport && _setupForm){
 <div class="wrapper main-content p-0">
   <div class="content-padding">
     <h4>{{_selectedReport.reportType| accountReportType}} Report Setup</h4>
@@ -126,7 +127,7 @@
         </div>
       </div>
     </form>
-    @if (_selectedReport) {
+    @if (_selectedReport && _setupForm.valid) {
     @if (_selectedReport.reportType == 'betterPlants') {
     <app-better-plants-setup></app-better-plants-setup>
     }
@@ -153,3 +154,4 @@
     }
   </div>
 </div>
+}

--- a/src/app/data-evaluation/account/account-reports/account-report-setup/account-report-setup.component.html
+++ b/src/app/data-evaluation/account/account-reports/account-report-setup/account-report-setup.component.html
@@ -1,8 +1,14 @@
+@let _selectedReport = selectedReport();
+@let _account = account();
+@let _reportYears = reportYears();
+@let _setupForm = setupForm();
+@let _reportDateWarning = reportDateWarning();
+
 <div class="wrapper main-content p-0">
   <div class="content-padding">
-    <h4>{{selectedReport.reportType| accountReportType}} Report Setup</h4>
-    @let reportErrors = selectedReport.guid | invalidAccountReport;
-    <form [formGroup]="setupForm">
+    <h4>{{_selectedReport.reportType| accountReportType}} Report Setup</h4>
+    @let reportErrors = _selectedReport.guid | invalidAccountReport;
+    <form [formGroup]="_setupForm">
       <div class="row">
         <div class="col-6">
           <div class="row form-group">
@@ -13,20 +19,19 @@
             </div>
           </div>
         </div>
-        @if (setupForm.controls.reportType.value != 'dataOverview' && setupForm.controls.reportType.value !=
-        'accountEmissionFactors' && setupForm.controls.reportType.value != 'accountSavings') {
+        @if (_selectedReport.reportType != 'dataOverview' && _selectedReport.reportType !=
+        'accountEmissionFactors' && _selectedReport.reportType != 'accountSavings') {
         <div class="col-6">
-          @if (setupForm.controls.reportType.value != 'betterPlants' && setupForm.controls.reportType.value !=
-          'analysis' && setupForm.controls.reportType.value != 'accountSavings' && setupForm.controls.reportType.value
-          != 'performance') {
+          @if (_selectedReport.reportType != 'betterPlants' && _selectedReport.reportType !=
+          'analysis' && _selectedReport.reportType != 'performance') {
           <div class="row form-group">
             <label class="col-5 col-form-label semibold" for="baselineYear">Baseline Year</label>
             <div class="col-7">
               <select id="baselineYear" name="baselineYear" formControlName="baselineYear" class="form-select" required
                 (change)="save()">
-                @for (year of baselineYears; track year) {
+                @for (year of _reportYears; track year) {
                 <option [ngValue]="year">{{year | yearDisplay:
-                  account.fiscalYear}}</option>
+                  _account.fiscalYear}}</option>
                 }
               </select>
             </div>
@@ -37,18 +42,11 @@
             <div class="col-7">
               <select id="reportYear" name="reportYear" formControlName="reportYear" class="form-select" required
                 (change)="save()">
-                @for (year of reportYears; track year) {
+                @for (year of _reportYears; track year) {
                 <option [ngValue]="year">{{year | yearDisplay:
-                  account.fiscalYear}}</option>
+                  _account.fiscalYear}}</option>
                 }
               </select>
-              @if (showReportYearWarning) {
-              <div class="alert alert-warning mt-2">
-                Your final year does not include 12 months of data. Please update to a year with
-                complete data. To view mid-year progress, return to the reports dashboard and run a
-                "Savings Report".
-              </div>
-              }
             </div>
           </div>
           @if (reportErrors.baselineAfterReportYear) {
@@ -60,13 +58,13 @@
           }
         </div>
         }
-        @if (setupForm.controls.reportType.value == 'dataOverview' || setupForm.controls.reportType.value ==
-        'accountSavings' || setupForm.controls.reportType.value == 'accountEmissionFactors') {
+        @if (_selectedReport.reportType == 'dataOverview' || _selectedReport.reportType ==
+        'accountSavings' || _selectedReport.reportType == 'accountEmissionFactors') {
         <div class="col-6">
-          @if (setupForm.controls.reportType.value != 'accountSavings') {
+          @if (_selectedReport.reportType != 'accountSavings') {
           <div class="row form-group">
             <label class="col-5 col-form-label semibold" for="startDate">Start Date</label>
-            @if(setupForm.controls.reportType.value != 'accountEmissionFactors') {
+            @if(_selectedReport.reportType != 'accountEmissionFactors') {
             <div class="col-3">
               <select name="startMonth" formControlName="startMonth" class="form-select" (change)="save()">
                 @for (month of months; track month) {
@@ -78,7 +76,7 @@
             }
             <div class="col-3">
               <select name="startYear" formControlName="startYear" class="form-select" (change)="save()">
-                @for (year of baselineYears; track year) {
+                @for (year of _reportYears; track year) {
                 <option class="pe-2" [ngValue]="year">{{year}}
                 </option>
                 }
@@ -88,7 +86,7 @@
           }
           <div class="row form-group">
             <label class="col-5 col-form-label semibold" for="endMonth">End Date</label>
-            @if(setupForm.controls.reportType.value != 'accountEmissionFactors') {
+            @if(_selectedReport.reportType != 'accountEmissionFactors') {
             <div class="col-3">
               <select name="endMonth" formControlName="endMonth" class="form-select" (change)="save()">
                 @for (month of months; track month) {
@@ -100,7 +98,7 @@
             }
             <div class="col-3">
               <select name="endYear" formControlName="endYear" class="form-select" (change)="save()">
-                @for (year of reportYears; track year) {
+                @for (year of _reportYears; track year) {
                 <option class="pe-2" [ngValue]="year">{{year}}
                 </option>
                 }
@@ -112,6 +110,15 @@
             Start date cannot be later than the end date.
           </span>
           }
+          @if(_reportDateWarning){
+          <div class="row">
+            <div class="col-12 text-center">
+              <span class="alert alert-warning">
+                {{_reportDateWarning}}
+              </span>
+            </div>
+          </div>
+          }
         </div>
         }
         <div class="col-12">
@@ -119,27 +126,27 @@
         </div>
       </div>
     </form>
-    @if (setupForm.valid) {
-    @if (setupForm.controls.reportType.value == 'betterPlants') {
+    @if (_selectedReport) {
+    @if (_selectedReport.reportType == 'betterPlants') {
     <app-better-plants-setup></app-better-plants-setup>
     }
-    @if (setupForm.controls.reportType.value == 'dataOverview') { <app-data-overview-setup>
+    @if (_selectedReport.reportType == 'dataOverview') { <app-data-overview-setup>
     </app-data-overview-setup>
     }
-    @if (setupForm.controls.reportType.value == 'performance') {
+    @if (_selectedReport.reportType == 'performance') {
     <app-performance-setup></app-performance-setup>
     }
-    @if (setupForm.controls.reportType.value == 'betterClimate') {
+    @if (_selectedReport.reportType == 'betterClimate') {
     <app-better-climate-setup></app-better-climate-setup>
     }
-    @if (setupForm.controls.reportType.value == 'analysis') {
+    @if (_selectedReport.reportType == 'analysis') {
     <app-analysis-report-setup></app-analysis-report-setup>
     }
-    @if (setupForm.controls.reportType.value == 'accountSavings') {
+    @if (_selectedReport.reportType == 'accountSavings') {
     <app-account-savings-report-setup></app-account-savings-report-setup>
     }
     }
-    @if (setupForm.valid == false) {
+    @if (_setupForm.valid == false) {
     <div class="alert alert-warning text-center">
       Additional report detail options will appear once report dates are selected.
     </div>

--- a/src/app/data-evaluation/account/account-reports/account-report-setup/account-report-setup.component.ts
+++ b/src/app/data-evaluation/account/account-reports/account-report-setup/account-report-setup.component.ts
@@ -1,14 +1,17 @@
-import { Component } from '@angular/core';
+import { Component, computed, effect, inject, signal, Signal, WritableSignal } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { AccountReportDbService } from 'src/app/indexedDB/account-report-db.service';
 import { AccountReportsService } from '../account-reports.service';
 import { DbChangesService } from 'src/app/indexedDB/db-changes.service';
 import { AccountdbService } from 'src/app/indexedDB/account-db.service';
 import { Month, Months } from 'src/app/shared/form-data/months';
-import { firstValueFrom, Subscription } from 'rxjs';
+import { firstValueFrom } from 'rxjs';
 import { CalanderizationService } from 'src/app/shared/helper-services/calanderization.service';
 import { IdbAccount } from 'src/app/models/idbModels/account';
 import { IdbAccountReport } from 'src/app/models/idbModels/accountReport';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { CalanderizedMeter } from 'src/app/models/calanderization';
+import { getAllYearsWithDataAccount, getLatestDataDate, getYearsWithFullDataAccount } from 'src/app/calculations/shared-calculations/calculationsHelpers';
 
 @Component({
   selector: 'app-account-report-setup',
@@ -17,68 +20,66 @@ import { IdbAccountReport } from 'src/app/models/idbModels/accountReport';
   standalone: false
 })
 export class AccountReportSetupComponent {
+  private accountReportDbService: AccountReportDbService = inject(AccountReportDbService);
+  private accountReportsService: AccountReportsService = inject(AccountReportsService);
+  private dbChangesService: DbChangesService = inject(DbChangesService);
+  private accountDbService: AccountdbService = inject(AccountdbService);
+  private calanderizationService: CalanderizationService = inject(CalanderizationService);
 
-  setupForm: FormGroup;
-  account: IdbAccount;
-  reportYears: Array<number>;
-  baselineYears: Array<number>;
+  calanderizedMeters: Signal<Array<CalanderizedMeter>> = toSignal(this.calanderizationService.calanderizedMeters);
+  account: Signal<IdbAccount> = toSignal(this.accountDbService.selectedAccount);
+  selectedReport: Signal<IdbAccountReport> = toSignal(this.accountReportDbService.selectedReport);
+
+  setupForm: WritableSignal<FormGroup> = signal(undefined);
+  reportYears: Signal<Array<number>> = computed(() => {
+    const calanderizedMeters = this.calanderizedMeters();
+    const selectedReport = this.selectedReport();
+    const account = this.account();
+    if (calanderizedMeters && selectedReport && account) {
+      if (selectedReport.reportType == 'accountSavings' || selectedReport.reportType == 'dataOverview') {
+        return getAllYearsWithDataAccount(calanderizedMeters, account);
+      } else {
+        return getYearsWithFullDataAccount(calanderizedMeters, account);
+      }
+    }
+    return [];
+  });
+
+  reportDateWarning: Signal<string> = computed(() => {
+    const selectedReport = this.selectedReport();
+    if (selectedReport) {
+      if (selectedReport.reportType == 'accountSavings' || selectedReport.reportType == 'dataOverview') {
+        const calanderizedMeters = this.calanderizedMeters();
+        if (calanderizedMeters && calanderizedMeters.length > 0) {
+          const latestDataDate = getLatestDataDate(calanderizedMeters);
+          const reportDate = new Date(selectedReport.endYear, selectedReport.endMonth, 1);
+          if (reportDate > latestDataDate) {
+            return `Latest data for account is from ${latestDataDate.toLocaleString('default', { month: 'long' })} ${latestDataDate.getFullYear()}.`;
+          }
+        }
+      }
+    }
+    return null;
+  });
+
   months: Array<Month> = Months;
-  selectedReportSub: Subscription;
-  isFormChange: boolean = false;
-  showReportYearWarning: boolean = false;
-  selectedReport: IdbAccountReport;
-
-  calanderizedMeterSub: Subscription;
-  constructor(private accountReportDbService: AccountReportDbService,
-    private accountReportsService: AccountReportsService,
-    private dbChangesService: DbChangesService,
-    private accountDbService: AccountdbService,
-    private calanderizationService: CalanderizationService
-  ) {
-
-  }
-
-  ngOnInit() {
-    this.account = this.accountDbService.selectedAccount.getValue();
-    this.selectedReportSub = this.accountReportDbService.selectedReport.subscribe(val => {
-      this.selectedReport = val;
-      if (!this.isFormChange) {
-        this.setupForm = this.accountReportsService.getSetupFormFromReport(this.selectedReport);
-      }
-      else {
-        this.isFormChange = false;
+  currentReportId: string;
+  constructor() {
+    effect(() => {
+      const selectedReport = this.selectedReport();
+      if (selectedReport && this.currentReportId !== selectedReport.guid) {
+        this.currentReportId = selectedReport.guid;
+        const form = this.accountReportsService.getSetupFormFromReport(selectedReport);
+        this.setupForm.set(form);
       }
     });
-
-    this.calanderizedMeterSub = this.calanderizationService.calanderizedMeters.subscribe(val => {
-      this.setYearOptions();
-      this.checkReportYear();
-    });
-  }
-
-  ngOnDestroy() {
-    this.selectedReportSub.unsubscribe();
-    this.calanderizedMeterSub.unsubscribe();
   }
 
   async save() {
-    this.isFormChange = true;
-    this.selectedReport = this.accountReportsService.updateReportFromSetupForm(this.selectedReport, this.setupForm);
-    this.selectedReport = await firstValueFrom(this.accountReportDbService.updateWithObservable(this.selectedReport));
-    await this.dbChangesService.setAccountReports(this.account);
-    this.accountReportDbService.selectedReport.next(this.selectedReport);
-    this.checkReportYear();
-  }
-
-  setYearOptions() {
-    let yearOptions: Array<number> = this.calanderizationService.getYearOptions('all', true);
-    this.reportYears = yearOptions;
-    this.baselineYears = yearOptions;
-  }
-
-  checkReportYear() {
-    if (this.selectedReport.reportType == 'analysis' && this.setupForm.controls.reportYear.value != undefined) {
-      this.showReportYearWarning = this.calanderizationService.checkReportYearSelection('all', this.setupForm.controls.reportYear.value, true);
-    }
+    let selectedReport = this.selectedReport();
+    selectedReport = this.accountReportsService.updateReportFromSetupForm(selectedReport, this.setupForm());
+    const updatedReport = await firstValueFrom(this.accountReportDbService.updateWithObservable(selectedReport));
+    await this.dbChangesService.setAccountReports(this.account());
+    this.accountReportDbService.selectedReport.next(updatedReport);
   }
 }

--- a/src/app/data-evaluation/account/account-reports/account-report-setup/account-savings-report-setup/account-savings-report-setup.component.html
+++ b/src/app/data-evaluation/account/account-reports/account-report-setup/account-savings-report-setup/account-savings-report-setup.component.html
@@ -1,7 +1,11 @@
-<app-account-report-analysis-selection [reportForm]="accountSavingsReportForm"></app-account-report-analysis-selection>
+@let _accountSavingsReportForm = accountSavingsReportForm();
+@let _reportSetup = reportSetup();
+@let _selectedAnalysisItem = selectedAnalysisItem();
 
-@if (selectedAnalysisItem) {
-<form [formGroup]="accountSavingsReportForm">
+<app-account-report-analysis-selection [reportForm]="_accountSavingsReportForm"></app-account-report-analysis-selection>
+
+@if (_selectedAnalysisItem) {
+<form [formGroup]="_accountSavingsReportForm">
   <div>
     <hr>
     <div>
@@ -16,7 +20,7 @@
             <label class="bold form-check-label" for="includeAnnualResults">Company Results
             </label>
           </div>
-          @if (reportSetup.includeAnnualResults) {
+          @if (_reportSetup.includeAnnualResults) {
           <div class="form-check ms-2">
             <input class="form-check-input" type="checkbox" name="includeAnnualResultsTable"
               id="includeAnnualResultsTable" formControlName="includeAnnualResultsTable" (change)="save()">
@@ -54,7 +58,7 @@
             <label class="bold form-check-label" for="includeFacilityResults">Facility Results
             </label>
           </div>
-          @if (reportSetup.includeFacilityResults) {
+          @if (_reportSetup.includeFacilityResults) {
           <div class="form-check ms-2">
             <input class="form-check-input" type="checkbox" name="includeFacilityResultsTable"
               id="includeFacilityResultsTable" formControlName="includeFacilityResultsTable" (change)="save()">
@@ -87,7 +91,7 @@
             <label class="bold form-check-label" for="includePerformanceResults">Performance Results
             </label>
           </div>
-          @if (reportSetup.includePerformanceResults) {
+          @if (_reportSetup.includePerformanceResults) {
           <div class="form-check ms-2">
             <input class="form-check-input" type="checkbox" name="includePerformanceResultsTable"
               id="includePerformanceResultsTable" formControlName="includePerformanceResultsTable" (change)="save()">
@@ -95,7 +99,7 @@
               Table
             </label>
           </div>
-          @if (reportSetup.includePerformanceResultsTable) {
+          @if (_reportSetup.includePerformanceResultsTable) {
           <div class="form-check ms-4">
             <input class="form-check-input" type="checkbox" name="includePerformanceActual"
               id="includePerformanceActual" formControlName="includePerformanceActual" (change)="save()">
@@ -158,13 +162,13 @@
           <div class="form-check">
             <input class="form-check-input" type="checkbox" name="energy" formControlName="energy"
               (change)="toggleEnergyColumns()" id="energy">
-            <label class="bold form-check-label" for="energy">{{energyColumnLabel}}
+            <label class="bold form-check-label" for="energy">{{energyColumnLabel()}}
             </label>
           </div>
           <div class="form-check">
             <input class="form-check-input" type="checkbox" name="actualEnergy" formControlName="actualEnergy"
               (change)="save()" id="actualEnergy">
-            <label class="form-check-label" for="actualEnergy">{{actualUseLabel}}</label>
+            <label class="form-check-label" for="actualEnergy">{{actualUseLabel()}}</label>
           </div>
           <div class="form-check">
             <input class="form-check-input" type="checkbox" name="adjusted" formControlName="adjusted" (change)="save()"

--- a/src/app/data-evaluation/account/account-reports/account-report-setup/account-savings-report-setup/account-savings-report-setup.component.html
+++ b/src/app/data-evaluation/account/account-reports/account-report-setup/account-savings-report-setup/account-savings-report-setup.component.html
@@ -2,6 +2,7 @@
 @let _reportSetup = reportSetup();
 @let _selectedAnalysisItem = selectedAnalysisItem();
 
+@if(_accountSavingsReportForm){
 <app-account-report-analysis-selection [reportForm]="_accountSavingsReportForm"></app-account-report-analysis-selection>
 
 @if (_selectedAnalysisItem) {
@@ -268,4 +269,5 @@
     </div>
   </div>
 </form>
+}
 }

--- a/src/app/data-evaluation/account/account-reports/account-report-setup/account-savings-report-setup/account-savings-report-setup.component.ts
+++ b/src/app/data-evaluation/account/account-reports/account-report-setup/account-savings-report-setup/account-savings-report-setup.component.ts
@@ -1,6 +1,6 @@
 import { Component, computed, effect, inject, Signal, signal, WritableSignal } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { EMPTY, firstValueFrom, map, skip, startWith, switchMap, tap } from 'rxjs';
+import { EMPTY, firstValueFrom, map, startWith, switchMap, tap } from 'rxjs';
 import { AccountdbService } from 'src/app/indexedDB/account-db.service';
 import { AccountReportDbService } from 'src/app/indexedDB/account-report-db.service';
 import { DbChangesService } from 'src/app/indexedDB/db-changes.service';

--- a/src/app/data-evaluation/account/account-reports/account-report-setup/account-savings-report-setup/account-savings-report-setup.component.ts
+++ b/src/app/data-evaluation/account/account-reports/account-report-setup/account-savings-report-setup/account-savings-report-setup.component.ts
@@ -1,6 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, computed, effect, inject, Signal, signal, WritableSignal } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { Subscription, firstValueFrom } from 'rxjs';
+import { EMPTY, firstValueFrom, map, skip, startWith, switchMap, tap } from 'rxjs';
 import { AccountdbService } from 'src/app/indexedDB/account-db.service';
 import { AccountReportDbService } from 'src/app/indexedDB/account-report-db.service';
 import { DbChangesService } from 'src/app/indexedDB/db-changes.service';
@@ -12,6 +12,7 @@ import { AccountSavingsReportSetup } from 'src/app/models/overview-report';
 import { AnalysisTableColumns } from 'src/app/models/analysis';
 import { AnalysisService } from 'src/app/data-evaluation/facility/analysis/analysis.service';
 import { AccountAnalysisDbService } from 'src/app/indexedDB/account-analysis-db.service';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-account-savings-report-setup',
@@ -21,95 +22,92 @@ import { AccountAnalysisDbService } from 'src/app/indexedDB/account-analysis-db.
   styleUrl: './account-savings-report-setup.component.css'
 })
 export class AccountSavingsReportSetupComponent {
-  accountSavingsReportForm: FormGroup;
-  account: IdbAccount;
+  private accountReportDbService: AccountReportDbService = inject(AccountReportDbService);
+  private accountReportsService: AccountReportsService = inject(AccountReportsService);
+  private dbChangesService: DbChangesService = inject(DbChangesService);
+  private accountDbService: AccountdbService = inject(AccountdbService);
+  private analysisService: AnalysisService = inject(AnalysisService);
+  private accountAnalysisDbService: AccountAnalysisDbService = inject(AccountAnalysisDbService);
 
-  selectedReportSub: Subscription;
-  isFormChange: boolean = false;
-  selectedAnalysisItem: IdbAccountAnalysisItem;
-  reportSetup: AccountSavingsReportSetup;
+
+  account: Signal<IdbAccount> = toSignal(this.accountDbService.selectedAccount);
+  analysisTableColumns: Signal<AnalysisTableColumns> = toSignal(this.analysisService.analysisTableColumns);
+  selectedReport: Signal<IdbAccountReport> = toSignal(this.accountReportDbService.selectedReport);
+
+  accountSavingsReportForm: WritableSignal<FormGroup> = signal(undefined);
+
+  selectedAnalysisItem: Signal<IdbAccountAnalysisItem> = toSignal(
+    toObservable(this.accountSavingsReportForm).pipe(
+      switchMap(form => form
+        ? form.get('analysisItemId').valueChanges.pipe(
+            tap(() => this.save()),
+            startWith(form.get('analysisItemId').value)
+          )
+        : EMPTY
+      ),
+      map(id => this.accountAnalysisDbService.getByGuid(id))
+    )
+  );
+
+  reportSetup: Signal<AccountSavingsReportSetup> = computed(() => {
+    const selectedReport = this.selectedReport();
+    if (selectedReport) {
+      return selectedReport.accountSavingsReportSetup;
+    }
+  });
+  energyColumnLabel: Signal<string> = computed(() => {
+    const selectedAnalysisItem = this.selectedAnalysisItem();
+    if (selectedAnalysisItem) {
+      if (selectedAnalysisItem.analysisCategory == 'water') {
+        return 'Consumption Columns';
+      } else if (selectedAnalysisItem.analysisCategory == 'energy') {
+        return 'Energy Columns';
+      }
+    }
+    return '';
+  });
+  actualUseLabel: Signal<string> = computed(() => {
+    const selectedAnalysisItem = this.selectedAnalysisItem();
+    if (selectedAnalysisItem) {
+      if (selectedAnalysisItem.analysisCategory == 'water') {
+        return 'Actual Consumption';
+      } else if (selectedAnalysisItem.analysisCategory == 'energy') {
+        return 'Actual Energy Use';
+      }
+    }
+    return '';
+  });
+
   numberOfPerformerOptions: Array<number> = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-  analysisTableColumns: AnalysisTableColumns;
-  energyColumnLabel: string;
-  actualUseLabel: string;
-  analysisItemIdSub: Subscription;
+  currentReportId: string;
 
-  constructor(private accountReportDbService: AccountReportDbService,
-    private accountReportsService: AccountReportsService,
-    private dbChangesService: DbChangesService,
-    private accountDbService: AccountdbService,
-    private analysisService: AnalysisService,
-    private accountAnalysisDbService: AccountAnalysisDbService) {
-  }
-
-
-  ngOnInit() {
-    this.account = this.accountDbService.selectedAccount.getValue();
-    this.analysisTableColumns = this.analysisService.analysisTableColumns.getValue();
-    this.selectedReportSub = this.accountReportDbService.selectedReport.subscribe(val => {
-      if (!this.isFormChange) {
-        this.accountSavingsReportForm = this.accountReportsService.getAccountSavingsFormFromReport(val.accountSavingsReportSetup);
-        this.reportSetup = val.accountSavingsReportSetup;
-        this.subscribeAnalysisItemChanges();
-        this.setSelectedAnalysisItem();
-      } else {
-        this.isFormChange = false;
+  constructor() {
+    effect(() => {
+      const selectedReport = this.selectedReport();
+      if (selectedReport && this.currentReportId !== selectedReport.guid) {
+        this.currentReportId = selectedReport.guid;
+        const form = this.accountReportsService.getAccountSavingsFormFromReport(selectedReport.accountSavingsReportSetup);
+        this.accountSavingsReportForm.set(form);
       }
     });
   }
 
-  ngOnDestroy() {
-    this.selectedReportSub.unsubscribe();
-    this.analysisItemIdSub.unsubscribe();
-  }
-
-  subscribeAnalysisItemChanges() {
-    if (this.analysisItemIdSub) {
-      this.analysisItemIdSub.unsubscribe();
-    }
-    //skip(1) to avoid triggering on init when we set the form value
-    this.analysisItemIdSub = this.accountSavingsReportForm.controls.analysisItemId.valueChanges.subscribe(async val => {
-      this.setSelectedAnalysisItem();
-      await this.save();
-    })
-  }
-
-  setLabels() {
-    if (this.selectedAnalysisItem) {
-      if (this.selectedAnalysisItem.analysisCategory == 'water') {
-        this.actualUseLabel = 'Actual Consumption';
-        this.energyColumnLabel = 'Consumption Columns';
-      } else if (this.selectedAnalysisItem.analysisCategory == 'energy') {
-        this.actualUseLabel = 'Actual Energy Use';
-        this.energyColumnLabel = 'Energy Columns';
-      }
-    }
-  }
-
   async save() {
-    this.isFormChange = true;
+    // this.isFormChange = true;
     this.setEnergyColumns();
     this.setMonthIncrementalImprovement();
 
-    let selectedReport: IdbAccountReport = this.accountReportDbService.selectedReport.getValue();
-    selectedReport.accountSavingsReportSetup = this.accountReportsService.updateAccountSavingsReportFromForm(selectedReport.accountSavingsReportSetup, this.accountSavingsReportForm);
+    let selectedReport: IdbAccountReport = this.selectedReport();
+    selectedReport.accountSavingsReportSetup = this.accountReportsService.updateAccountSavingsReportFromForm(selectedReport.accountSavingsReportSetup, this.accountSavingsReportForm());
     await firstValueFrom(this.accountReportDbService.updateWithObservable(selectedReport));
-    await this.dbChangesService.setAccountReports(this.account);
+    await this.dbChangesService.setAccountReports(this.account());
     this.accountReportDbService.selectedReport.next({ ...selectedReport });
   }
 
-  setSelectedAnalysisItem() {
-    this.selectedAnalysisItem = this.accountAnalysisDbService.getByGuid(this.accountSavingsReportForm.controls.analysisItemId.value);
-    this.setPredictorVariables();
-    this.setLabels();
-  }
-
-  setPredictorVariables() {
-    this.analysisTableColumns.predictors = [];
-  }
 
   async setDefault() {
-    const columnsGroup = this.accountSavingsReportForm.get('analysisTableColumns');
+    const accountSavingsReportForm = this.accountSavingsReportForm();
+    const columnsGroup = accountSavingsReportForm.get('analysisTableColumns');
     if (columnsGroup) {
       columnsGroup.patchValue({
         incrementalImprovement: true,
@@ -141,7 +139,8 @@ export class AccountSavingsReportSetupComponent {
   }
 
   toggleEnergyColumns() {
-    const columnsGroup = this.accountSavingsReportForm.get('analysisTableColumns');
+    const accountSavingsReportForm = this.accountSavingsReportForm();
+    const columnsGroup = accountSavingsReportForm.get('analysisTableColumns');
     if (columnsGroup) {
       const energy = columnsGroup.get('energy')?.value;
       columnsGroup.patchValue({
@@ -157,7 +156,8 @@ export class AccountSavingsReportSetupComponent {
   }
 
   toggleIncrementalImprovement() {
-    const columnsGroup = this.accountSavingsReportForm.get('analysisTableColumns');
+    const accountSavingsReportForm = this.accountSavingsReportForm();
+    const columnsGroup = accountSavingsReportForm.get('analysisTableColumns');
     if (columnsGroup) {
       const incremental = columnsGroup.get('incrementalImprovement')?.value;
       columnsGroup.patchValue({
@@ -177,31 +177,33 @@ export class AccountSavingsReportSetupComponent {
   }
 
   setEnergyColumns() {
-    this.analysisTableColumns.energy = (this.analysisTableColumns.actualEnergy
-      || this.analysisTableColumns.modeledEnergy
-      || this.analysisTableColumns.adjusted
-      || this.analysisTableColumns.baselineAdjustmentForNormalization
-      || this.analysisTableColumns.baselineAdjustmentForOther
-      || this.analysisTableColumns.baselineAdjustment);
+    const analysisTableColumns = this.analysisTableColumns();
+    analysisTableColumns.energy = (analysisTableColumns.actualEnergy
+      || analysisTableColumns.modeledEnergy
+      || analysisTableColumns.adjusted
+      || analysisTableColumns.baselineAdjustmentForNormalization
+      || analysisTableColumns.baselineAdjustmentForOther
+      || analysisTableColumns.baselineAdjustment);
   }
 
   setMonthIncrementalImprovement() {
-    this.analysisTableColumns.incrementalImprovement = (
-      this.analysisTableColumns.SEnPI ||
-      this.analysisTableColumns.savings ||
+    const analysisTableColumns = this.analysisTableColumns();
+    analysisTableColumns.incrementalImprovement = (
+      analysisTableColumns.SEnPI ||
+      analysisTableColumns.savings ||
       // this.analysisTableColumns.percentSavingsComparedToBaseline ||
       // this.analysisTableColumns.yearToDateSavings ||
       // this.analysisTableColumns.yearToDatePercentSavings ||
-      this.analysisTableColumns.rollingSavings ||
-      this.analysisTableColumns.rolling12MonthImprovement ||
-      this.analysisTableColumns.SEnPI ||
-      this.analysisTableColumns.savings ||
-      this.analysisTableColumns.totalSavingsPercentImprovement ||
-      this.analysisTableColumns.annualSavingsPercentImprovement ||
-      this.analysisTableColumns.cummulativeSavings ||
-      this.analysisTableColumns.newSavings ||
-      this.analysisTableColumns.bankedSavings ||
-      this.analysisTableColumns.savingsUnbanked
+      analysisTableColumns.rollingSavings ||
+      analysisTableColumns.rolling12MonthImprovement ||
+      analysisTableColumns.SEnPI ||
+      analysisTableColumns.savings ||
+      analysisTableColumns.totalSavingsPercentImprovement ||
+      analysisTableColumns.annualSavingsPercentImprovement ||
+      analysisTableColumns.cummulativeSavings ||
+      analysisTableColumns.newSavings ||
+      analysisTableColumns.bankedSavings ||
+      analysisTableColumns.savingsUnbanked
     )
   }
 }

--- a/src/app/data-evaluation/account/account-reports/account-reports.service.ts
+++ b/src/app/data-evaluation/account/account-reports/account-reports.service.ts
@@ -31,7 +31,6 @@ export class AccountReportsService {
     if (report.reportType == 'betterClimate' || report.reportType == 'dataOverview' || report.reportType == 'accountSavings') {
       let form: FormGroup = this.formBuilder.group({
         reportName: [report.name, Validators.required],
-        reportType: [report.reportType, Validators.required],
         reportYear: [report.reportYear, yearValidators],
         baselineYear: [report.baselineYear, yearValidators],
         startMonth: [report.startMonth, startDateValidators],
@@ -44,7 +43,6 @@ export class AccountReportsService {
     else if (report.reportType == 'betterPlants' || report.reportType == 'analysis' || report.reportType == 'performance') {
       let form: FormGroup = this.formBuilder.group({
         reportName: [report.name, Validators.required],
-        reportType: [report.reportType, Validators.required],
         reportYear: [report.reportYear, yearValidators],
         baselineYear: [report.baselineYear, ''],
         startMonth: [report.startMonth, startDateValidators],
@@ -57,7 +55,6 @@ export class AccountReportsService {
     else if (report.reportType == 'accountEmissionFactors') {
       let form: FormGroup = this.formBuilder.group({
         reportName: [report.name, Validators.required],
-        reportType: [report.reportType, Validators.required],
         reportYear: [report.reportYear, ''],
         baselineYear: [report.baselineYear, ''],
         startMonth: [report.startMonth, ''],
@@ -71,7 +68,6 @@ export class AccountReportsService {
 
   updateReportFromSetupForm(report: IdbAccountReport, form: FormGroup): IdbAccountReport {
     report.name = form.controls.reportName.value;
-    report.reportType = form.controls.reportType.value;
     report.reportYear = form.controls.reportYear.value;
     report.baselineYear = form.controls.baselineYear.value;
     report.startMonth = form.controls.startMonth.value;
@@ -278,83 +274,6 @@ export class AccountReportsService {
   }
 
   getAccountSavingsFormFromReport(accountSavingsReportSetup: AccountSavingsReportSetup): FormGroup {
-    if (!accountSavingsReportSetup) {
-      accountSavingsReportSetup = {
-        analysisItemId: undefined,
-        includeAnnualResults: true,
-        includeAnnualResultsTable: true,
-        includeAnnualResultsGraph: true,
-        includeAccountMonthlyTable: true,
-        includeAccountMonthlyResults: true,
-        includeFacilityResults: true,
-        includeFacilityResultsTable: true,
-        includeFacilityResultsGraph: true,
-        includeFacilityMonthlyResultsGraph: true,
-        includePerformanceResults: true,
-        includePerformanceResultsTable: true,
-        includePerformanceResultsGraph: true,
-        includePerformanceActual: true,
-        includePerformanceAdjusted: true,
-        includePerformanceContribution: true,
-        includePerformanceSavings: true,
-        numberOfTopPerformers: 5,
-        analysisTableColumns: {
-          incrementalImprovement: false,
-          SEnPI: false,
-          savings: false,
-          percentSavingsComparedToBaseline: false,
-          yearToDateSavings: false,
-          yearToDatePercentSavings: false,
-          rollingSavings: false,
-          rolling12MonthImprovement: false,
-          productionVariables: false,
-          energy: true,
-          actualEnergy: true,
-          modeledEnergy: true,
-          adjusted: true,
-          baselineAdjustmentForNormalization: true,
-          baselineAdjustmentForOther: true,
-          baselineAdjustment: true,
-          totalSavingsPercentImprovement: true,
-          annualSavingsPercentImprovement: true,
-          cummulativeSavings: true,
-          newSavings: true,
-          predictors: [],
-          predictorGroupId: undefined,
-          bankedSavings: false,
-          savingsUnbanked: false
-        }
-      };
-    }
-
-    if (!accountSavingsReportSetup.analysisTableColumns) {
-      accountSavingsReportSetup.analysisTableColumns = {
-        incrementalImprovement: false,
-        SEnPI: false,
-        savings: false,
-        percentSavingsComparedToBaseline: false,
-        yearToDateSavings: false,
-        yearToDatePercentSavings: false,
-        rollingSavings: false,
-        rolling12MonthImprovement: false,
-        productionVariables: false,
-        energy: true,
-        actualEnergy: true,
-        modeledEnergy: true,
-        adjusted: true,
-        baselineAdjustmentForNormalization: true,
-        baselineAdjustmentForOther: true,
-        baselineAdjustment: true,
-        totalSavingsPercentImprovement: true,
-        annualSavingsPercentImprovement: true,
-        cummulativeSavings: true,
-        newSavings: true,
-        predictors: [],
-        predictorGroupId: undefined,
-        bankedSavings: false,
-        savingsUnbanked: false
-      };
-    }
     let form: FormGroup = this.formBuilder.group({
       analysisItemId: [accountSavingsReportSetup.analysisItemId, Validators.required],
       includeAnnualResults: [accountSavingsReportSetup.includeAnnualResults],

--- a/src/app/indexedDB/update-db-entry.service.ts
+++ b/src/app/indexedDB/update-db-entry.service.ts
@@ -381,6 +381,56 @@ export class UpdateDbEntryService {
         }
       });
     }
+
+    if (report.reportType == 'accountSavings' && !report.accountSavingsReportSetup) {
+      report.accountSavingsReportSetup = {
+        analysisItemId: undefined,
+        includeAnnualResults: true,
+        includeAnnualResultsTable: true,
+        includeAnnualResultsGraph: true,
+        includeAccountMonthlyTable: true,
+        includeAccountMonthlyResults: true,
+        includeFacilityResults: true,
+        includeFacilityResultsTable: true,
+        includeFacilityResultsGraph: true,
+        includeFacilityMonthlyResultsGraph: true,
+        includePerformanceResults: true,
+        includePerformanceResultsTable: true,
+        includePerformanceResultsGraph: true,
+        includePerformanceActual: true,
+        includePerformanceAdjusted: true,
+        includePerformanceContribution: true,
+        includePerformanceSavings: true,
+        numberOfTopPerformers: 5,
+        analysisTableColumns: {
+          incrementalImprovement: false,
+          SEnPI: false,
+          savings: false,
+          percentSavingsComparedToBaseline: false,
+          yearToDateSavings: false,
+          yearToDatePercentSavings: false,
+          rollingSavings: false,
+          rolling12MonthImprovement: false,
+          productionVariables: false,
+          energy: true,
+          actualEnergy: true,
+          modeledEnergy: true,
+          adjusted: true,
+          baselineAdjustmentForNormalization: true,
+          baselineAdjustmentForOther: true,
+          baselineAdjustment: true,
+          totalSavingsPercentImprovement: true,
+          annualSavingsPercentImprovement: true,
+          cummulativeSavings: true,
+          newSavings: true,
+          predictors: [],
+          predictorGroupId: undefined,
+          bankedSavings: false,
+          savingsUnbanked: false
+        }
+      };
+      isChanged = true;
+    }
     return {
       report: report,
       isChanged: isChanged

--- a/src/app/models/idbModels/accountReport.ts
+++ b/src/app/models/idbModels/accountReport.ts
@@ -24,7 +24,7 @@ export interface IdbAccountReport extends IdbEntry {
     performanceReportSetup: PerformanceReportSetup,
     betterClimateReportSetup: BetterClimateReportSetup,
     analysisReportSetup: AnalysisReportSetup,
-    accountSavingsReportSetup?: AccountSavingsReportSetup
+    accountSavingsReportSetup: AccountSavingsReportSetup
 }
 
 export function getNewIdbAccountReport(account: IdbAccount, facilities: Array<IdbFacility>, groups: Array<IdbUtilityMeterGroup>): IdbAccountReport {
@@ -120,6 +120,52 @@ export function getNewIdbAccountReport(account: IdbAccount, facilities: Array<Id
             includeProblemsInformation: true,
             includeExecutiveSummary: true,
             includeDataValidationTables: true
+        },
+        accountSavingsReportSetup: {
+            analysisItemId: undefined,
+            includeAnnualResults: true,
+            includeAnnualResultsTable: true,
+            includeAnnualResultsGraph: true,
+            includeAccountMonthlyTable: true,
+            includeAccountMonthlyResults: true,
+            includeFacilityResults: true,
+            includeFacilityResultsTable: true,
+            includeFacilityResultsGraph: true,
+            includeFacilityMonthlyResultsGraph: true,
+            includePerformanceResults: true,
+            includePerformanceResultsTable: true,
+            includePerformanceResultsGraph: true,
+            includePerformanceActual: true,
+            includePerformanceAdjusted: true,
+            includePerformanceContribution: true,
+            includePerformanceSavings: true,
+            numberOfTopPerformers: 5,
+            analysisTableColumns: {
+                incrementalImprovement: false,
+                SEnPI: false,
+                savings: false,
+                percentSavingsComparedToBaseline: false,
+                yearToDateSavings: false,
+                yearToDatePercentSavings: false,
+                rollingSavings: false,
+                rolling12MonthImprovement: false,
+                productionVariables: false,
+                energy: true,
+                actualEnergy: true,
+                modeledEnergy: true,
+                adjusted: true,
+                baselineAdjustmentForNormalization: true,
+                baselineAdjustmentForOther: true,
+                baselineAdjustment: true,
+                totalSavingsPercentImprovement: true,
+                annualSavingsPercentImprovement: true,
+                cummulativeSavings: true,
+                newSavings: true,
+                predictors: [],
+                predictorGroupId: undefined,
+                bankedSavings: false,
+                savingsUnbanked: false
+            }
         }
     }
 }


### PR DESCRIPTION
connects #2393 
connects #2383 

migrates setup report for account savings report to use of signals.
Updates how reports are initialized which should address bugs causing weird behavior in printing/display
update reports years dropdown to be set based on report type. Either all years with data or complete years.