### PR TITLE
Issue 2414: updating facility analysis items when adding/modifying meter groups

### DIFF
--- a/src/app/indexedDB/analysis-db.service.ts
+++ b/src/app/indexedDB/analysis-db.service.ts
@@ -36,7 +36,7 @@ export class AnalysisDbService {
         this.localStorageService.store('analysisItemId', analysisItem.id);
       }
     });
-    
+
     this.generatedModelsPerGroup = new BehaviorSubject<{ [groupId: string]: Array<JStatRegressionModel> }>({});
   }
 
@@ -214,7 +214,7 @@ export class AnalysisDbService {
             pVariable.unit = predictor.unit;
           }
         })
-        if(group.models){
+        if (group.models) {
           group.models.forEach(model => {
             model.predictorVariables.forEach(pVariable => {
               if (pVariable.id == predictor.guid) {
@@ -240,7 +240,7 @@ export class AnalysisDbService {
     }
   }
 
-  async addGroup(groupId: string) {
+  async addGroup(groupId: string, groupType: 'Energy' | 'Water' | 'Other') {
     let predictors: Array<IdbPredictor> = this.predictorDbService.facilityPredictors.getValue();
     let predictorVariables: Array<AnalysisGroupPredictorVariable> = predictors.map(predictor => {
       return {
@@ -253,11 +253,15 @@ export class AnalysisDbService {
       }
     });
     let facilityAnalysisItems: Array<IdbAnalysisItem> = this.facilityAnalysisItems.getValue();
+    //TODO: I think we only want to add groups to analysis that are the same type..
+    // water -> water, energy -> energy
     for (let index = 0; index < facilityAnalysisItems.length; index++) {
       let item: IdbAnalysisItem = facilityAnalysisItems[index];
-      let analysisGroup: AnalysisGroup = getNewAnalysisGroup(groupId, predictorVariables);
-      item.groups.push(analysisGroup);
-      await firstValueFrom(this.updateWithObservable(item));
+      if (item.analysisCategory == 'energy' && groupType == 'Energy' || item.analysisCategory == 'water' && groupType == 'Water') {
+        let analysisGroup: AnalysisGroup = getNewAnalysisGroup(groupId, predictorVariables);
+        item.groups.push(analysisGroup);
+        await firstValueFrom(this.updateWithObservable(item));
+      }
     };
   }
 
@@ -305,4 +309,34 @@ export class AnalysisDbService {
   //   }
   //   return values;
   // }
+
+  async changeGroupType(groupId: string, newGroupType: 'Energy' | 'Water' | 'Other', oldGroupType: 'Energy' | 'Water' | 'Other') {
+    let predictors: Array<IdbPredictor> = this.predictorDbService.facilityPredictors.getValue();
+    let predictorVariables: Array<AnalysisGroupPredictorVariable> = predictors.map(predictor => {
+      return {
+        id: predictor.guid,
+        name: predictor.name,
+        production: predictor.production,
+        productionInAnalysis: true,
+        regressionCoefficient: undefined,
+        unit: predictor.unit
+      }
+    });
+    let facilityAnalysisItems: Array<IdbAnalysisItem> = this.facilityAnalysisItems.getValue();
+    for (let index = 0; index < facilityAnalysisItems.length; index++) {
+      let item: IdbAnalysisItem = facilityAnalysisItems[index];
+      if (item.analysisCategory == 'energy' && newGroupType == 'Energy' || item.analysisCategory == 'water' && newGroupType == 'Water') {
+        //add group to energy analysis that didn't have it before
+        let analysisGroup: AnalysisGroup = getNewAnalysisGroup(groupId, predictorVariables);
+        item.groups.push(analysisGroup);
+        await firstValueFrom(this.updateWithObservable(item));
+      }
+
+      if (item.analysisCategory == 'energy' && oldGroupType == 'Energy' || item.analysisCategory == 'water' && oldGroupType == 'Water') {
+        //remove group from energy analysis that shouldn't have it anymore
+        item.groups = item.groups.filter(group => { return group.idbGroupId != groupId });
+      }
+      await firstValueFrom(this.updateWithObservable(item));
+    };
+  }
 }

--- a/src/app/indexedDB/analysis-db.service.ts
+++ b/src/app/indexedDB/analysis-db.service.ts
@@ -253,7 +253,7 @@ export class AnalysisDbService {
       }
     });
     let facilityAnalysisItems: Array<IdbAnalysisItem> = this.facilityAnalysisItems.getValue();
-    //TODO: I think we only want to add groups to analysis that are the same type..
+    // add groups to analysis that are the same type..
     // water -> water, energy -> energy
     for (let index = 0; index < facilityAnalysisItems.length; index++) {
       let item: IdbAnalysisItem = facilityAnalysisItems[index];

--- a/src/app/indexedDB/analysis-db.service.ts
+++ b/src/app/indexedDB/analysis-db.service.ts
@@ -327,16 +327,20 @@ export class AnalysisDbService {
       let item: IdbAnalysisItem = facilityAnalysisItems[index];
       if (item.analysisCategory == 'energy' && newGroupType == 'Energy' || item.analysisCategory == 'water' && newGroupType == 'Water') {
         //add group to energy analysis that didn't have it before
-        let analysisGroup: AnalysisGroup = getNewAnalysisGroup(groupId, predictorVariables);
-        item.groups.push(analysisGroup);
-        await firstValueFrom(this.updateWithObservable(item));
+        //check if group already exists in analysis item groups (if changing from other to energy/water) and only add if it doesn't already exist
+        let existingGroup: AnalysisGroup = item.groups.find(group => { return group.idbGroupId == groupId });
+        if (!existingGroup) {
+          let analysisGroup: AnalysisGroup = getNewAnalysisGroup(groupId, predictorVariables);
+          item.groups.push(analysisGroup);
+          await firstValueFrom(this.updateWithObservable(item));
+        }
       }
 
       if (item.analysisCategory == 'energy' && oldGroupType == 'Energy' || item.analysisCategory == 'water' && oldGroupType == 'Water') {
         //remove group from energy analysis that shouldn't have it anymore
         item.groups = item.groups.filter(group => { return group.idbGroupId != groupId });
+        await firstValueFrom(this.updateWithObservable(item));
       }
-      await firstValueFrom(this.updateWithObservable(item));
     };
   }
 }

--- a/src/app/shared/shared-meter-content/set-meter-grouping/manage-meter-grouping/manage-meter-grouping.component.ts
+++ b/src/app/shared/shared-meter-content/set-meter-grouping/manage-meter-grouping/manage-meter-grouping.component.ts
@@ -88,6 +88,7 @@ export class ManageMeterGroupingComponent {
     await firstValueFrom(this.utilityMeterGroupDbService.addWithObservable(newGroup));
     let account: IdbAccount = this.accountDbService.selectedAccount.getValue();
     await this.analysisDbService.addGroup(newGroup.guid, newGroup.groupType);
+    await this.dbChangesService.setAnalysisItems(account, true, this.facility);
     await this.dbChangesService.setMeterGroups(account, this.facility);
     this.toastNoticationService.showToast("Meter Group Added!", undefined, undefined, false, "alert-success");
     this.editGroup(newGroup);

--- a/src/app/shared/shared-meter-content/set-meter-grouping/manage-meter-grouping/manage-meter-grouping.component.ts
+++ b/src/app/shared/shared-meter-content/set-meter-grouping/manage-meter-grouping/manage-meter-grouping.component.ts
@@ -87,6 +87,7 @@ export class ManageMeterGroupingComponent {
     let newGroup: IdbUtilityMeterGroup = getNewIdbUtilityMeterGroup(newGroupType, "New Group", this.facility.guid, this.facility.accountId);
     await firstValueFrom(this.utilityMeterGroupDbService.addWithObservable(newGroup));
     let account: IdbAccount = this.accountDbService.selectedAccount.getValue();
+    await this.analysisDbService.addGroup(newGroup.guid, newGroup.groupType);
     await this.dbChangesService.setMeterGroups(account, this.facility);
     this.toastNoticationService.showToast("Meter Group Added!", undefined, undefined, false, "alert-success");
     this.editGroup(newGroup);

--- a/src/app/shared/shared-meter-content/set-meter-grouping/meter-group-form/meter-group-form.component.ts
+++ b/src/app/shared/shared-meter-content/set-meter-grouping/meter-group-form/meter-group-form.component.ts
@@ -110,6 +110,10 @@ export class MeterGroupFormComponent {
 
   async saveChanges() {
     this.meterGroup.name = this.groupForm.controls['name'].value;
+    if (this.meterGroup.groupType != this.groupForm.controls['groupType'].value) {
+      //need to update analysis items if groupType changes
+      await this.analysisDbService.changeGroupType(this.meterGroup.guid, this.groupForm.controls['groupType'].value, this.meterGroup.groupType);
+    }
     this.meterGroup.groupType = this.groupForm.controls['groupType'].value;
     this.meterGroup.description = this.groupForm.controls['description'].value;
     await firstValueFrom(this.utilityMeterGroupDbService.updateWithObservable(this.meterGroup));
@@ -127,10 +131,13 @@ export class MeterGroupFormComponent {
         await firstValueFrom(this.utilityMeterDbService.updateWithObservable(meter));
       }
     }
+
+
     let account: IdbAccount = this.accountDbService.selectedAccount.getValue();
     let facility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
     await this.dbChangesService.setMeterGroups(account, facility);
     await this.dbChangesService.setMeters(account, facility);
+    this.toastNoticationService.showToast("Meter Group Changes Saved!", undefined, undefined, false, "alert-success");
     this.selectionsChanged = false;
     this.groupForm.markAsPristine();
   }

--- a/src/app/shared/shared-meter-content/set-meter-grouping/meter-group-form/meter-group-form.component.ts
+++ b/src/app/shared/shared-meter-content/set-meter-grouping/meter-group-form/meter-group-form.component.ts
@@ -109,10 +109,14 @@ export class MeterGroupFormComponent {
   }
 
   async saveChanges() {
+    let account: IdbAccount = this.accountDbService.selectedAccount.getValue();
+    let facility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
+
     this.meterGroup.name = this.groupForm.controls['name'].value;
     if (this.meterGroup.groupType != this.groupForm.controls['groupType'].value) {
       //need to update analysis items if groupType changes
       await this.analysisDbService.changeGroupType(this.meterGroup.guid, this.groupForm.controls['groupType'].value, this.meterGroup.groupType);
+      await this.dbChangesService.setAnalysisItems(account, true, facility)
     }
     this.meterGroup.groupType = this.groupForm.controls['groupType'].value;
     this.meterGroup.description = this.groupForm.controls['description'].value;
@@ -131,10 +135,6 @@ export class MeterGroupFormComponent {
         await firstValueFrom(this.utilityMeterDbService.updateWithObservable(meter));
       }
     }
-
-
-    let account: IdbAccount = this.accountDbService.selectedAccount.getValue();
-    let facility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
     await this.dbChangesService.setMeterGroups(account, facility);
     await this.dbChangesService.setMeters(account, facility);
     this.toastNoticationService.showToast("Meter Group Changes Saved!", undefined, undefined, false, "alert-success");


### PR DESCRIPTION
connects #2414 
This pull request introduces improvements to how meter groups are added and managed, ensuring that analysis groups are only added or updated in analyses of matching types (e.g., Energy or Water). It also adds logic to handle changes in a group's type, updating related analysis items accordingly, and provides better user feedback when changes are saved.

**Analysis group management improvements:**

* The `addGroup` method in `AnalysisDbService` now takes a `groupType` parameter and only adds the group to analysis items of the matching type (e.g., Energy groups are only added to energy analyses). [[1]](diffhunk://#diff-dc5956fe61e6e2951c878cc950a05da698db341610adba94423e077c95711989L243-R243) [[2]](diffhunk://#diff-dc5956fe61e6e2951c878cc950a05da698db341610adba94423e077c95711989R256-R264)
* A new `changeGroupType` method is added to `AnalysisDbService`, which updates analysis items by adding or removing groups as necessary when a group's type changes.

**Component updates for group addition and editing:**

* When a new meter group is created in `ManageMeterGroupingComponent`, it now calls `addGroup` with the correct `groupType` to ensure analysis items are updated.
* In `MeterGroupFormComponent`, if the group type is changed, it calls the new `changeGroupType` method to synchronize analysis items.

**User feedback improvements:**

* After saving meter group changes, a success toast notification is now shown to the user.
