### PR TITLE
Issue 2400 - added modal to calculate hours of operation

### DIFF
--- a/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-use-equipment-form/annual-operating-conditions-form/annual-operating-conditions-form.component.css
+++ b/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-use-equipment-form/annual-operating-conditions-form/annual-operating-conditions-form.component.css
@@ -1,0 +1,4 @@
+.icon-style {
+    font-size: 1.2em;
+    cursor: pointer;
+}

--- a/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-use-equipment-form/annual-operating-conditions-form/annual-operating-conditions-form.component.html
+++ b/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-use-equipment-form/annual-operating-conditions-form/annual-operating-conditions-form.component.html
@@ -13,6 +13,10 @@
         </div>
         <div class="col">
             <div class="input-group">
+                <span class="input-group-text">
+                    <i class="fa fa-calculator text-primary icon-style"
+                        (click)="openCalculateHoursOfOperationModal()"></i>
+                </span>
                 <input class="form-control" type="number" formControlName="hoursOfOperation" min="0"
                     id="{{'hoursOfOperation_'+selectedYear}}">
                 <span class="input-group-text">hrs</span>
@@ -111,7 +115,7 @@
 }
 
 
-<div [ngClass]="{'windowOverlay': showRemoveOperatingConditionsModal}"></div>
+<div [ngClass]="{'windowOverlay': showRemoveOperatingConditionsModal || showCalculateHoursOfOperationModal }"></div>
 <div class="popup" [class.open]="showRemoveOperatingConditionsModal">
     <div class="popup-header">Remove Year of Operating Conditions Data
         <button class="item-right" (click)="closeRemoveOperatingConditionsModal()">x</button>
@@ -128,3 +132,10 @@
         <button class="btn btn-danger small" (click)="confirmRemoveOperatingConditionsData()">Remove</button>
     </div>
 </div>
+
+@if (showCalculateHoursOfOperationModal) {
+<app-operating-hours-modal [year]="annualOperatingConditionsDataForm.controls.year.value" [hoursPerDay]="annualOperatingConditionsDataForm.controls.hoursPerDay.value"
+    [daysPerWeek]="annualOperatingConditionsDataForm.controls.daysPerWeek.value" [weeksPerYear]="annualOperatingConditionsDataForm.controls.weeksPerYear.value"
+    (saveCalculatedHoursPerYear)="handleCalculatedValues($event)"
+    (closeModal)="closeCalculateHoursOfOperationModal()"></app-operating-hours-modal>
+}

--- a/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-use-equipment-form/annual-operating-conditions-form/annual-operating-conditions-form.component.html
+++ b/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-use-equipment-form/annual-operating-conditions-form/annual-operating-conditions-form.component.html
@@ -14,8 +14,10 @@
         <div class="col">
             <div class="input-group">
                 <span class="input-group-text">
-                    <i class="fa fa-calculator text-primary icon-style"
-                        (click)="openCalculateHoursOfOperationModal()"></i>
+                    <button type="button" class="btn p-0 border-0 bg-transparent"
+                        aria-label="Calculate hours of operation" (click)="openCalculateHoursOfOperationModal()">
+                        <i class="fa fa-calculator text-primary icon-style"></i>
+                    </button>
                 </span>
                 <input class="form-control" type="number" formControlName="hoursOfOperation" min="0"
                     id="{{'hoursOfOperation_'+selectedYear}}">
@@ -134,8 +136,10 @@
 </div>
 
 @if (showCalculateHoursOfOperationModal) {
-<app-operating-hours-modal [year]="annualOperatingConditionsDataForm.controls.year.value" [hoursPerDay]="annualOperatingConditionsDataForm.controls.hoursPerDay.value"
-    [daysPerWeek]="annualOperatingConditionsDataForm.controls.daysPerWeek.value" [weeksPerYear]="annualOperatingConditionsDataForm.controls.weeksPerYear.value"
+<app-operating-hours-modal [year]="annualOperatingConditionsDataForm.controls.year.value"
+    [hoursPerDay]="annualOperatingConditionsDataForm.controls.hoursPerDay.value"
+    [daysPerWeek]="annualOperatingConditionsDataForm.controls.daysPerWeek.value"
+    [weeksPerYear]="annualOperatingConditionsDataForm.controls.weeksPerYear.value"
     (saveCalculatedHoursPerYear)="handleCalculatedValues($event)"
     (closeModal)="closeCalculateHoursOfOperationModal()"></app-operating-hours-modal>
 }

--- a/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-use-equipment-form/annual-operating-conditions-form/annual-operating-conditions-form.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-use-equipment-form/annual-operating-conditions-form/annual-operating-conditions-form.component.ts
@@ -1,7 +1,6 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { UtilityMeterDatadbService } from 'src/app/indexedDB/utilityMeterData-db.service';
-import { IdbUtilityMeterData } from 'src/app/models/idbModels/utilityMeterData';
 import * as _ from 'lodash';
 
 @Component({
@@ -19,6 +18,8 @@ export class AnnualOperatingConditionsFormComponent {
   inSetup: boolean = false;
 
   showRemoveOperatingConditionsModal: boolean = false;
+  showCalculateHoursOfOperationModal: boolean = false;
+
   constructor(private utilityMeterDataDbService: UtilityMeterDatadbService) { }
 
   ngOnInit() {
@@ -35,5 +36,20 @@ export class AnnualOperatingConditionsFormComponent {
   confirmRemoveOperatingConditionsData() {
     this.closeRemoveOperatingConditionsModal();
     this.emitRemoveOperatingConditionsData.emit();
+  }
+
+  openCalculateHoursOfOperationModal() {
+    this.showCalculateHoursOfOperationModal = true;
+  }
+
+  closeCalculateHoursOfOperationModal() {
+    this.showCalculateHoursOfOperationModal = false;
+  }
+
+  handleCalculatedValues({ calculatedHoursPerYear, hoursPerDay, daysPerWeek, weeksPerYear }: { calculatedHoursPerYear: number, hoursPerDay: number, daysPerWeek: number, weeksPerYear: number }) {
+    this.annualOperatingConditionsDataForm.controls.hoursOfOperation.setValue(calculatedHoursPerYear);
+    this.annualOperatingConditionsDataForm.controls.hoursPerDay.setValue(hoursPerDay);
+    this.annualOperatingConditionsDataForm.controls.daysPerWeek.setValue(daysPerWeek);
+    this.annualOperatingConditionsDataForm.controls.weeksPerYear.setValue(weeksPerYear);
   }
 }

--- a/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-use-equipment-form/facility-energy-use-equipment-form.service.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-energy-uses/setup/facility-energy-use-equipment-form/facility-energy-use-equipment-form.service.ts
@@ -135,7 +135,10 @@ export class FacilityEnergyUseEquipmentFormService {
       dutyFactor: [operatingConditionsData.dutyFactor, [Validators.required, Validators.min(0), Validators.max(100)]],
       efficiency: [operatingConditionsData.efficiency, [Validators.required, Validators.min(0), Validators.max(100)]],
       hoursOfOperation: [operatingConditionsData.hoursOfOperation, [Validators.required, Validators.min(0)]],
-      loadFactor: [operatingConditionsData.loadFactor, [Validators.required, Validators.min(0), Validators.max(100)]]
+      loadFactor: [operatingConditionsData.loadFactor, [Validators.required, Validators.min(0), Validators.max(100)]],
+      hoursPerDay: [operatingConditionsData.hoursPerDay],
+      daysPerWeek: [operatingConditionsData.daysPerWeek],
+      weeksPerYear: [operatingConditionsData.weeksPerYear]
     });
     operatingConditionsForm.controls['year'].disable();
     return operatingConditionsForm;
@@ -150,7 +153,10 @@ export class FacilityEnergyUseEquipmentFormService {
         dutyFactor: operatingConditionsForm.controls.dutyFactor.value,
         efficiency: operatingConditionsForm.controls.efficiency.value,
         hoursOfOperation: operatingConditionsForm.controls.hoursOfOperation.value,
-        loadFactor: operatingConditionsForm.controls.loadFactor.value
+        loadFactor: operatingConditionsForm.controls.loadFactor.value,
+        hoursPerDay: operatingConditionsForm.controls.hoursPerDay.value,
+        daysPerWeek: operatingConditionsForm.controls.daysPerWeek.value,
+        weeksPerYear: operatingConditionsForm.controls.weeksPerYear.value
       });
     }
     return equipment;

--- a/src/app/data-management/data-management.module.ts
+++ b/src/app/data-management/data-management.module.ts
@@ -104,6 +104,7 @@ import { MapMeterGroupsToEquipmentComponent } from './data-management-import/pro
 import { ConfirmEnergyUsesUploadComponent } from './data-management-import/process-footprint-tool-file/confirm-energy-uses-upload/confirm-energy-uses-upload.component';
 import { FacilityEnergyUsesSankeyComponent } from './account-facilities/facility-data/facility-energy-uses/results/facility-energy-uses-footprint/facility-energy-uses-sankey/facility-energy-uses-sankey.component';
 import { FacilityEnergyUsesGroupSankeyComponent } from './account-facilities/facility-data/facility-energy-uses/results/facility-energy-uses-group-footprint/facility-energy-uses-group-sankey/facility-energy-uses-group-sankey.component';
+import { OperatingHoursModalModule } from '../shared/operating-hours-modal/operating-hours.module';
 
 
 @NgModule({
@@ -216,7 +217,8 @@ import { FacilityEnergyUsesGroupSankeyComponent } from './account-facilities/fac
     CustomDatabaseModule,
     DataManagementSidePanelModule,
     SharedDataQualityReportMetersModule,
-    SharedDataQualityReportPredictorsModule
+    SharedDataQualityReportPredictorsModule,
+    OperatingHoursModalModule
 ]
 })
 export class DataManagementModule { }

--- a/src/app/models/idbModels/facilityEnergyUseEquipment.ts
+++ b/src/app/models/idbModels/facilityEnergyUseEquipment.ts
@@ -55,6 +55,9 @@ export interface EnergyEquipmentOperatingConditionsData {
     loadFactor: number,
     dutyFactor: number,
     efficiency: number,
+    hoursPerDay?: number,
+    daysPerWeek?: number,
+    weeksPerYear?: number
 }
 
 export interface EquipmentUtilityData {

--- a/src/app/shared/operating-hours-modal/operating-hours-modal.component.html
+++ b/src/app/shared/operating-hours-modal/operating-hours-modal.component.html
@@ -24,12 +24,9 @@
         <div class="row mb-2">
             <label class="col-5 col-form-label" for="weeksPerYear">Weeks / Year</label>
             <div class="col-7">
-                <input class="form-control" type="number" id="weeksPerYear" min="0" [max]="isLeapYear ? 52.28 : 52.14" [(ngModel)]="weeksPerYear">
-                @if (!isLeapYear && weeksPerYear > 52.14) {
-                <div class="text-danger">Weeks per year cannot exceed 52.14</div>
-                }
-                @if (isLeapYear && weeksPerYear > 52.28) {
-                <div class="text-danger">Weeks per year cannot exceed 52.28</div>
+                <input class="form-control" type="number" id="weeksPerYear" min="0" max="52" [(ngModel)]="weeksPerYear">
+                @if (weeksPerYear > 52) {
+                <div class="text-danger">Weeks per year cannot exceed 52</div>
                 }
             </div>
         </div>

--- a/src/app/shared/operating-hours-modal/operating-hours-modal.component.html
+++ b/src/app/shared/operating-hours-modal/operating-hours-modal.component.html
@@ -1,0 +1,45 @@
+<div class="popup" [class.open]="showCalculateHoursOfOperationModal">
+    <div class="popup-header">Hours of Operation
+        <button class="item-right" (click)="closeCalculateHoursOfOperationModal()">x</button>
+    </div>
+    <div class="popup-body">
+        <div class="row mb-2">
+            <label class="col-5 col-form-label" for="hoursPerDay">Hours / Day</label>
+            <div class="col-7">
+                <input class="form-control" type="number" id="hoursPerDay" min="0" max="24" [(ngModel)]="hoursPerDay">
+                @if (hoursPerDay > 24) {
+                <div class="text-danger">Hours per day cannot exceed 24</div>
+                }
+            </div>
+        </div>
+        <div class="row mb-2">
+            <label class="col-5 col-form-label" for="daysPerWeek">Days / Week</label>
+            <div class="col-7">
+                <input class="form-control" type="number" id="daysPerWeek" min="0" max="7" [(ngModel)]="daysPerWeek">
+                @if (daysPerWeek > 7) {
+                <div class="text-danger">Days per week cannot exceed 7</div>
+                }
+            </div>
+        </div>
+        <div class="row mb-2">
+            <label class="col-5 col-form-label" for="weeksPerYear">Weeks / Year</label>
+            <div class="col-7">
+                <input class="form-control" type="number" id="weeksPerYear" min="0" [max]="isLeapYear ? 52.28 : 52.14" [(ngModel)]="weeksPerYear">
+                @if (!isLeapYear && weeksPerYear > 52.14) {
+                <div class="text-danger">Weeks per year cannot exceed 52.14</div>
+                }
+                @if (isLeapYear && weeksPerYear > 52.28) {
+                <div class="text-danger">Weeks per year cannot exceed 52.28</div>
+                }
+            </div>
+        </div>
+        <div class="alert alert-info d-flex align-items-center justify-content-center mt-3">
+            <span class="fs-6">Hours of Operation: <strong class="fs-6">{{calculatedHoursPerYear}}</strong>
+                hrs/yr</span>
+        </div>
+    </div>
+    <div class="popup-footer text-end">
+        <button class="btn btn-secondary small me-2" (click)="closeCalculateHoursOfOperationModal()">Cancel</button>
+        <button class="btn btn-success small" [disabled]="isDisabled" (click)="save()">Save</button>
+    </div>
+</div>

--- a/src/app/shared/operating-hours-modal/operating-hours-modal.component.spec.ts
+++ b/src/app/shared/operating-hours-modal/operating-hours-modal.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OperatingHoursModalComponent } from './operating-hours-modal.component';
+
+describe('OperatingHoursModalComponent', () => {
+  let component: OperatingHoursModalComponent;
+  let fixture: ComponentFixture<OperatingHoursModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [OperatingHoursModalComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(OperatingHoursModalComponent);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/operating-hours-modal/operating-hours-modal.component.spec.ts
+++ b/src/app/shared/operating-hours-modal/operating-hours-modal.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { OperatingHoursModalComponent } from './operating-hours-modal.component';
+import { FormsModule } from '@angular/forms';
 
 describe('OperatingHoursModalComponent', () => {
   let component: OperatingHoursModalComponent;
@@ -8,7 +9,8 @@ describe('OperatingHoursModalComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [OperatingHoursModalComponent]
+      declarations: [OperatingHoursModalComponent],
+      imports: [FormsModule]
     })
     .compileComponents();
 

--- a/src/app/shared/operating-hours-modal/operating-hours-modal.component.ts
+++ b/src/app/shared/operating-hours-modal/operating-hours-modal.component.ts
@@ -32,12 +32,8 @@ export class OperatingHoursModalComponent {
       this.daysPerWeek = 7;
     }
     if (this.weeksPerYear == null) {
-      this.weeksPerYear = this.isLeapYear ? 52.28 : 52.14;
+      this.weeksPerYear = 52;
     }
-  }
-
-  get isLeapYear(): boolean {
-    return (this.year % 4 === 0 && this.year % 100 !== 0) || (this.year % 400 === 0);
   }
 
   get calculatedHoursPerYear(): number {
@@ -52,7 +48,7 @@ export class OperatingHoursModalComponent {
       return true;
     }
 
-    if (this.hoursPerDay < 0 || this.hoursPerDay > 24 || this.daysPerWeek < 0 || this.daysPerWeek > 7 || this.weeksPerYear < 0 || (!this.isLeapYear && this.weeksPerYear > 52.14) || (this.isLeapYear && this.weeksPerYear > 52.28)) {
+    if (this.hoursPerDay < 0 || this.hoursPerDay > 24 || this.daysPerWeek < 0 || this.daysPerWeek > 7 || this.weeksPerYear < 0 || this.weeksPerYear > 52) {
       return true;
     }
     return false;

--- a/src/app/shared/operating-hours-modal/operating-hours-modal.component.ts
+++ b/src/app/shared/operating-hours-modal/operating-hours-modal.component.ts
@@ -1,0 +1,72 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-operating-hours-modal',
+  standalone: false,
+  templateUrl: './operating-hours-modal.component.html',
+  styleUrl: './operating-hours-modal.component.css',
+})
+export class OperatingHoursModalComponent {
+
+  @Input()
+  year: number;
+  @Input()
+  hoursPerDay: number;
+  @Input()
+  daysPerWeek: number;
+  @Input()
+  weeksPerYear: number;
+
+  showCalculateHoursOfOperationModal: boolean = true;
+
+  @Output()
+  saveCalculatedHoursPerYear: EventEmitter<{ calculatedHoursPerYear: number, hoursPerDay: number, daysPerWeek: number, weeksPerYear: number }> = new EventEmitter<{ calculatedHoursPerYear: number, hoursPerDay: number, daysPerWeek: number, weeksPerYear: number }>();
+  @Output()
+  closeModal: EventEmitter<undefined> = new EventEmitter<undefined>();
+
+  ngOnInit() {
+    if (this.hoursPerDay == null) {
+      this.hoursPerDay = 24;
+    }
+    if (this.daysPerWeek == null) {
+      this.daysPerWeek = 7;
+    }
+    if (this.weeksPerYear == null) {
+      this.weeksPerYear = this.isLeapYear ? 52.28 : 52.14;
+    }
+  }
+
+  get isLeapYear(): boolean {
+    return (this.year % 4 === 0 && this.year % 100 !== 0) || (this.year % 400 === 0);
+  }
+
+  get calculatedHoursPerYear(): number {
+    if (this.hoursPerDay > 0 && this.daysPerWeek > 0 && this.weeksPerYear > 0) {
+      return Math.ceil(this.hoursPerDay * this.daysPerWeek * this.weeksPerYear);
+    }
+    return 0;
+  }
+
+  get isDisabled(): boolean {
+    if (this.hoursPerDay == null || this.daysPerWeek == null || this.weeksPerYear == null) {
+      return true;
+    }
+
+    if (this.hoursPerDay < 0 || this.hoursPerDay > 24 || this.daysPerWeek < 0 || this.daysPerWeek > 7 || this.weeksPerYear < 0 || (!this.isLeapYear && this.weeksPerYear > 52.14) || (this.isLeapYear && this.weeksPerYear > 52.28)) {
+      return true;
+    }
+    return false;
+  }
+
+  closeCalculateHoursOfOperationModal() {
+    this.closeModal.emit(undefined);
+  }
+
+  save() {
+    this.saveCalculatedHoursPerYear.emit({
+      calculatedHoursPerYear: this.calculatedHoursPerYear,
+      hoursPerDay: this.hoursPerDay, daysPerWeek: this.daysPerWeek, weeksPerYear: this.weeksPerYear
+    });
+    this.closeCalculateHoursOfOperationModal();
+  }
+}

--- a/src/app/shared/operating-hours-modal/operating-hours.module.ts
+++ b/src/app/shared/operating-hours-modal/operating-hours.module.ts
@@ -1,5 +1,4 @@
 import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
 import { OperatingHoursModalComponent } from './operating-hours-modal.component';
 import { FormsModule } from '@angular/forms';
 

--- a/src/app/shared/operating-hours-modal/operating-hours.module.ts
+++ b/src/app/shared/operating-hours-modal/operating-hours.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { OperatingHoursModalComponent } from './operating-hours-modal.component';
+import { FormsModule } from '@angular/forms';
+
+@NgModule({
+  declarations: [
+    OperatingHoursModalComponent
+  ],
+  imports: [
+    FormsModule
+  ],
+  exports: [
+    OperatingHoursModalComponent
+  ]
+})
+export class OperatingHoursModalModule { }


### PR DESCRIPTION
connects #2400 

This pull request adds a new modal component to help users calculate annual hours of operation based on hours per day, days per week, and weeks per year, and integrates this modal into the facility energy use equipment form. It also updates the data model and form logic to support these new fields and values.

**Feature: Hours of Operation Calculation Modal**
- Added a reusable `OperatingHoursModalComponent` with a UI for users to input hours per day, days per week, and weeks per year, and see the calculated annual hours. The modal includes validation and emits calculated values to the parent component. 
- Integrated the modal into the annual operating conditions form: added a calculator icon next to the "hours of operation" input, which opens the modal. The form overlays and modal state are managed accordingly. 
- Registered the modal module in the main data management module to make it available application-wide. 

**Data Model and Form Enhancements**
- Extended the `EnergyEquipmentOperatingConditionsData` interface and related form logic to include `hoursPerDay`, `daysPerWeek`, and `weeksPerYear` fields, ensuring these values are saved and loaded with the rest of the operating conditions data. 

These changes improve user experience by making it easier to calculate and input accurate hours of operation, and ensure that supporting data is properly handled throughout the application.