### PR TITLE
Issue 2403 - added column for heat capacity/ fuel efficiency in meter data table

### DIFF
--- a/src/app/models/meterDataFilter.ts
+++ b/src/app/models/meterDataFilter.ts
@@ -28,6 +28,7 @@ export interface GeneralUtilityDataFilters{
   stationaryCarbonEmissions: boolean,
   stationaryOtherEmissions: boolean,
   totalEmissions: boolean,
+  heatCapacity: boolean
 }
 
 
@@ -38,4 +39,5 @@ export interface VehicleDataFilters{
   mobileCarbonEmissions: boolean,
   mobileOtherEmissions: boolean,
   mobileTotalEmissions: boolean,
+  fuelEfficiency: boolean
 }

--- a/src/app/shared/shared-meter-content/meter-data/meter-data-table/general-utility-data-table/general-utility-data-table.component.html
+++ b/src/app/shared/shared-meter-content/meter-data/meter-data-table/general-utility-data-table/general-utility-data-table.component.html
@@ -7,6 +7,7 @@
 @let _showVolumeColumn = showVolumeColumn();
 @let _showEnergyColumn = showEnergyColumn();
 @let _showEmissions = showEmissions();
+@let _showHeatCapacity = showHeatCapacity();
 
 <table class="table utility-data table-sm table-bordered table-hover" #meterTable
   [ngClass]="{'copying-table': copyingTable}">
@@ -39,6 +40,12 @@
       @if (_showEnergyColumn) {
         <th (click)="setOrderDataField('totalEnergyUse')" [ngClass]="{'active': _orderDataField == 'totalEnergyUse'}">
           Total Energy<br>(<span [innerHTML]="_meter.energyUnit | settingsLabel"></span>)
+        </th>
+      }
+      @if (_showHeatCapacity && _filters.heatCapacity) {
+        <th (click)="setOrderDataField('heatCapacity')" [ngClass]="{'active': _orderDataField == 'heatCapacity'}">
+          Heat Capacity<br>(<span [innerHTML]="_meter.energyUnit | settingsLabel"></span>/<span
+            [innerHTML]="_meter.startingUnit | settingsLabel"></span>)
         </th>
       }
       @if (_filters.totalCost) {
@@ -124,6 +131,11 @@
               <span class="fa fa-asterisk"></span>
             }
             {{meterData.totalEnergyUse | customNumber}}
+          </td>
+        }
+        @if (_showHeatCapacity && _filters.heatCapacity) {
+          <td>
+            {{meterData.heatCapacity | customNumber}}
           </td>
         }
         @if (_filters.totalCost) {

--- a/src/app/shared/shared-meter-content/meter-data/meter-data-table/general-utility-data-table/general-utility-data-table.component.ts
+++ b/src/app/shared/shared-meter-content/meter-data/meter-data-table/general-utility-data-table/general-utility-data-table.component.ts
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { CopyTableService } from 'src/app/shared/helper-services/copy-table.service';
 import { GeneralUtilityDataFilters } from 'src/app/models/meterDataFilter';
-import { checkShowEmissionsOutputRate, getIsEnergyMeter, getIsEnergyUnit } from 'src/app/shared/sharedHelperFunctions';
+import { checkShowEmissionsOutputRate, checkShowHeatCapacity, getIsEnergyMeter, getIsEnergyUnit } from 'src/app/shared/sharedHelperFunctions';
 import { EmissionsResults } from 'src/app/models/eGridEmissions';
 import { EGridService } from 'src/app/shared/helper-services/e-grid.service';
 import { FacilitydbService } from 'src/app/indexedDB/facility-db.service';
@@ -93,6 +93,12 @@ export class GeneralUtilityDataTableComponent {
       : getIsEnergyMeter(meter.source);
   });
 
+  showHeatCapacity: Signal<boolean> = computed(() => {
+    const meter = this.selectedMeter();
+    if (!meter) return false;
+    return checkShowHeatCapacity(meter.source, meter.startingUnit, meter.scope);
+  });
+
   showEstimated: Signal<boolean> = computed(() => {
     return this.selectedMeterData().some(d => d.isEstimated === true);
   });
@@ -115,6 +121,7 @@ export class GeneralUtilityDataTableComponent {
     if (filters.totalVolume && this.showVolumeColumn()) count++;
     if (!this.showEnergyColumn()) count--;
     if (filters.totalCost) count++;
+    if (filters.heatCapacity && this.showHeatCapacity()) count++;
     return count;
   });
 

--- a/src/app/shared/shared-meter-content/meter-data/meter-data-table/vehicle-data-table/vehicle-data-table.component.html
+++ b/src/app/shared/shared-meter-content/meter-data/meter-data-table/vehicle-data-table/vehicle-data-table.component.html
@@ -38,8 +38,8 @@
       </th>
       }
       @if (_meter && _meter.scope == 2 && _meter.vehicleCategory == 2 && _filters.fuelEfficiency) {
-      <th (click)="setOrderDataField('displayFuelEfficiency')"
-        [ngClass]="{'active': _orderDataField == 'displayFuelEfficiency'}">
+      <th (click)="setOrderDataField('vehicleFuelEfficiency')"
+        [ngClass]="{'active': _orderDataField == 'vehicleFuelEfficiency'}">
         Fuel Efficiency<br>(<span [innerHTML]="_meter.vehicleDistanceUnit | settingsLabel"></span>/<span
           [innerHTML]="_meter.vehicleCollectionUnit | settingsLabel"></span>)
       </th>

--- a/src/app/shared/shared-meter-content/meter-data/meter-data-table/vehicle-data-table/vehicle-data-table.component.html
+++ b/src/app/shared/shared-meter-content/meter-data/meter-data-table/vehicle-data-table/vehicle-data-table.component.html
@@ -12,127 +12,139 @@
       <th></th>
       <th [attr.colspan]="numGeneralInformation()">General Information</th>
       @if (showEmissionsSection()) {
-        <th [attr.colspan]="numEmissions()">Emissions</th>
+      <th [attr.colspan]="numEmissions()">Emissions</th>
       }
       @if (numDetailedCharges() > 0) {
-        <th [attr.colspan]="numDetailedCharges()">Detailed Charges</th>
+      <th [attr.colspan]="numDetailedCharges()">Detailed Charges</th>
       }
       <th></th>
     </tr>
     <tr>
       @if (!copyingTable) {
-        <th class="input">
-          <input #masterCheckbox type="checkbox" (change)="checkAll()" [(ngModel)]="allChecked">
-        </th>
+      <th class="input">
+        <input #masterCheckbox type="checkbox" (change)="checkAll()" [(ngModel)]="allChecked">
+      </th>
       }
-      <th (click)="setOrderDataField('readDate')" [ngClass]="{'active': _orderDataField == 'readDate'}" class="row-year">
+      <th (click)="setOrderDataField('readDate')" [ngClass]="{'active': _orderDataField == 'readDate'}"
+        class="row-year">
         Meter Read Date
       </th>
       <th (click)="setOrderDataField('totalVolume')" [ngClass]="{'active': _orderDataField == 'totalVolume'}">
         Total {{consumptionLabel()}}<br>(<span [innerHTML]="volumeUnit() | settingsLabel"></span>)
       </th>
       @if (_filters.totalEnergy) {
-        <th (click)="setOrderDataField('totalEnergyUse')" [ngClass]="{'active': _orderDataField == 'totalEnergyUse'}">
-          Total Energy<br>(<span [innerHTML]="_meter.energyUnit | settingsLabel"></span>)
-        </th>
+      <th (click)="setOrderDataField('totalEnergyUse')" [ngClass]="{'active': _orderDataField == 'totalEnergyUse'}">
+        Total Energy<br>(<span [innerHTML]="_meter.energyUnit | settingsLabel"></span>)
+      </th>
+      }
+      @if (_meter && _meter.scope == 2 && _meter.vehicleCategory == 2 && _filters.fuelEfficiency) {
+      <th (click)="setOrderDataField('displayFuelEfficiency')"
+        [ngClass]="{'active': _orderDataField == 'displayFuelEfficiency'}">
+        Fuel Efficiency<br>(<span [innerHTML]="_meter.vehicleDistanceUnit | settingsLabel"></span>/<span
+          [innerHTML]="_meter.vehicleCollectionUnit | settingsLabel"></span>)
+      </th>
       }
       @if (_filters.totalCost) {
-        <th (click)="setOrderDataField('totalCost')" [ngClass]="{'active': _orderDataField == 'totalCost'}">
-          Total Cost
-        </th>
+      <th (click)="setOrderDataField('totalCost')" [ngClass]="{'active': _orderDataField == 'totalCost'}">
+        Total Cost
+      </th>
       }
       @if (_filters.mobileBiogenicEmissions) {
-        <th (click)="setOrderDataField('mobileBiogenicEmissions')"
-          [ngClass]="{'active': _orderDataField == 'mobileBiogenicEmissions'}">
-          Total Biogenic<br>Emissions (tonne CO<sub>2</sub>e)
-        </th>
+      <th (click)="setOrderDataField('mobileBiogenicEmissions')"
+        [ngClass]="{'active': _orderDataField == 'mobileBiogenicEmissions'}">
+        Total Biogenic<br>Emissions (tonne CO<sub>2</sub>e)
+      </th>
       }
       @if (_filters.mobileCarbonEmissions) {
-        <th (click)="setOrderDataField('mobileCarbonEmissions')"
-          [ngClass]="{'active': _orderDataField == 'mobileCarbonEmissions'}">
-          Total Carbon<br>Emissions (tonne CO<sub>2</sub>e)
-        </th>
+      <th (click)="setOrderDataField('mobileCarbonEmissions')"
+        [ngClass]="{'active': _orderDataField == 'mobileCarbonEmissions'}">
+        Total Carbon<br>Emissions (tonne CO<sub>2</sub>e)
+      </th>
       }
       @if (_filters.mobileOtherEmissions) {
-        <th (click)="setOrderDataField('mobileOtherEmissions')"
-          [ngClass]="{'active': _orderDataField == 'mobileOtherEmissions'}">
-          Total Other<br>Emissions (tonne CO<sub>2</sub>e)
-        </th>
+      <th (click)="setOrderDataField('mobileOtherEmissions')"
+        [ngClass]="{'active': _orderDataField == 'mobileOtherEmissions'}">
+        Total Other<br>Emissions (tonne CO<sub>2</sub>e)
+      </th>
       }
       @if (_filters.mobileTotalEmissions) {
-        <th (click)="setOrderDataField('mobileTotalEmissions')"
-          [ngClass]="{'active': _orderDataField == 'mobileTotalEmissions'}">
-          Total<br>Emissions (tonne CO<sub>2</sub>e)
-        </th>
+      <th (click)="setOrderDataField('mobileTotalEmissions')"
+        [ngClass]="{'active': _orderDataField == 'mobileTotalEmissions'}">
+        Total<br>Emissions (tonne CO<sub>2</sub>e)
+      </th>
       }
       @for (charge of _meter.charges; track charge.guid) {
-        @if (charge.displayChargeInTable) {
-          <th (click)="setOrderDataField(charge.guid, 'amount')"
-            [ngClass]="{'active': _orderDataField == charge.guid && _orderByCharge == 'amount'}">
-            {{charge.name}}<br>(&dollar;)
-          </th>
-        }
+      @if (charge.displayChargeInTable) {
+      <th (click)="setOrderDataField(charge.guid, 'amount')"
+        [ngClass]="{'active': _orderDataField == charge.guid && _orderByCharge == 'amount'}">
+        {{charge.name}}<br>(&dollar;)
+      </th>
+      }
       }
       @if (!copyingTable) {
-        <th>Actions</th>
+      <th>Actions</th>
       }
     </tr>
   </thead>
   <tbody class="table-group-divider">
-    @for (meterData of _orderedMeterData | slice: ((currentPageNumber - 1) * _itemsPerPage): currentPageNumber * _itemsPerPage; track meterData.guid) {
-      <tr>
-        @if (!copyingTable) {
-          <td class="input">
-            <input type="checkbox" name="metersSelected"
-              [checked]="isChecked(meterData.guid)" (change)="toggleChecked(meterData.guid)">
-          </td>
+    @for (meterData of _orderedMeterData | slice: ((currentPageNumber - 1) * _itemsPerPage): currentPageNumber *
+    _itemsPerPage; track meterData.guid) {
+    <tr>
+      @if (!copyingTable) {
+      <td class="input">
+        <input type="checkbox" name="metersSelected" [checked]="isChecked(meterData.guid)"
+          (change)="toggleChecked(meterData.guid)">
+      </td>
+      }
+      <td class="read-date">{{meterData | displayMeterDataDate}}</td>
+      <td>
+        @if (meterData.isEstimated) {
+        <span class="fa fa-asterisk"></span>
         }
-        <td class="read-date">{{meterData | displayMeterDataDate}}</td>
-        <td>
-          @if (meterData.isEstimated) {
-            <span class="fa fa-asterisk"></span>
+        {{meterData.totalVolume | customNumber}}
+      </td>
+      @if (_filters.totalEnergy) {
+      <td>{{meterData.totalEnergyUse | customNumber}}</td>
+      }
+      @if (_meter && _meter.scope == 2 && _meter.vehicleCategory == 2 && _filters.fuelEfficiency) {
+      <td>{{meterData.vehicleFuelEfficiency | customNumber}}</td>
+      }
+      @if (_filters.totalCost) {
+      <td>{{meterData.totalCost | customNumber:true}}</td>
+      }
+      @if (_filters.mobileBiogenicEmissions) {
+      <td>{{meterData.mobileBiogenicEmissions | customNumber}}</td>
+      }
+      @if (_filters.mobileCarbonEmissions) {
+      <td>{{meterData.mobileCarbonEmissions | customNumber}}</td>
+      }
+      @if (_filters.mobileOtherEmissions) {
+      <td>{{meterData.mobileOtherEmissions | customNumber}}</td>
+      }
+      @if (_filters.mobileTotalEmissions) {
+      <td>{{meterData.mobileTotalEmissions | customNumber}}</td>
+      }
+      @for (meterCharge of _meter.charges; track meterCharge.guid) {
+      @if (meterCharge.displayChargeInTable) {
+      <td>{{meterData.charges | meterChargeValue: meterCharge.guid: 'amount' | customNumber:true}}</td>
+      }
+      }
+      @if (!copyingTable) {
+      <td class="actions">
+        <div class="btn-group">
+          <button class="btn btn-sm btn-outline" (click)="setEditMeterData(meterData)" title="Edit">
+            <i class="fa fa-pencil"></i>
+          </button>
+          @if (isElectron) {
+          <app-view-connect-bill [meterData]="meterData" [selectedMeter]="_meter"></app-view-connect-bill>
           }
-          {{meterData.totalVolume | customNumber}}
-        </td>
-        @if (_filters.totalEnergy) {
-          <td>{{meterData.totalEnergyUse | customNumber}}</td>
-        }
-        @if (_filters.totalCost) {
-          <td>{{meterData.totalCost | customNumber:true}}</td>
-        }
-        @if (_filters.mobileBiogenicEmissions) {
-          <td>{{meterData.mobileBiogenicEmissions | customNumber}}</td>
-        }
-        @if (_filters.mobileCarbonEmissions) {
-          <td>{{meterData.mobileCarbonEmissions | customNumber}}</td>
-        }
-        @if (_filters.mobileOtherEmissions) {
-          <td>{{meterData.mobileOtherEmissions | customNumber}}</td>
-        }
-        @if (_filters.mobileTotalEmissions) {
-          <td>{{meterData.mobileTotalEmissions | customNumber}}</td>
-        }
-        @for (meterCharge of _meter.charges; track meterCharge.guid) {
-          @if (meterCharge.displayChargeInTable) {
-            <td>{{meterData.charges | meterChargeValue: meterCharge.guid: 'amount' | customNumber:true}}</td>
-          }
-        }
-        @if (!copyingTable) {
-          <td class="actions">
-            <div class="btn-group">
-              <button class="btn btn-sm btn-outline" (click)="setEditMeterData(meterData)" title="Edit">
-                <i class="fa fa-pencil"></i>
-              </button>
-              @if (isElectron) {
-                <app-view-connect-bill [meterData]="meterData" [selectedMeter]="_meter"></app-view-connect-bill>
-              }
-              <button class="btn btn-sm btn-outline" (click)="setDeleteMeterData(meterData)" title="Delete">
-                <i class="fa fa-trash"></i>
-              </button>
-            </div>
-          </td>
-        }
-      </tr>
+          <button class="btn btn-sm btn-outline" (click)="setDeleteMeterData(meterData)" title="Delete">
+            <i class="fa fa-trash"></i>
+          </button>
+        </div>
+      </td>
+      }
+    </tr>
     }
   </tbody>
 </table>
@@ -145,9 +157,9 @@
       </button>
     </div>
     @if (showEstimated()) {
-      <div class="ps-2">
-        <span class="fa fa-asterisk"></span> Indicates Estimated Reading
-      </div>
+    <div class="ps-2">
+      <span class="fa fa-asterisk"></span> Indicates Estimated Reading
+    </div>
     }
   </div>
   <ngb-pagination [collectionSize]="_orderedMeterData.length" [(page)]="currentPageNumber" [pageSize]="_itemsPerPage"

--- a/src/app/shared/shared-meter-content/meter-data/meter-data-table/vehicle-data-table/vehicle-data-table.component.ts
+++ b/src/app/shared/shared-meter-content/meter-data/meter-data-table/vehicle-data-table/vehicle-data-table.component.ts
@@ -101,6 +101,7 @@ export class VehicleDataTableComponent {
     let count = 3;
     if (!f.totalEnergy) count--;
     if (f.totalCost) count++;
+    if (f.fuelEfficiency && this.selectedMeter()?.scope === 2 &&  this.selectedMeter()?.vehicleCategory == 2) count++;
     return count;
   });
 

--- a/src/app/shared/shared-meter-content/utility-meter-data-filter/utility-meter-data-filter.component.html
+++ b/src/app/shared/shared-meter-content/utility-meter-data-filter/utility-meter-data-filter.component.html
@@ -78,6 +78,13 @@
           <label for="totalVolume" class="form-check-label">Total Volume</label>
         </div>
         }
+        @if (showHeatCapacity) {
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" name="heatCapacity" id="heatCapacity"
+            [(ngModel)]="generalUtilityDataFilters.heatCapacity" (change)="save()">
+          <label for="heatCapacity" class="form-check-label">Heat Capacity</label>
+        </div>
+        }
         <div class="form-check">
           <input class="form-check-input" type="checkbox" name="totalCost" id="totalCost"
             [(ngModel)]="generalUtilityDataFilters.totalCost" (change)="save()">
@@ -124,6 +131,13 @@
             [(ngModel)]="vehicleDataFilters.totalEnergy" (change)="save()">
           <label for="totalEnergy" class="form-check-label">Total Energy</label>
         </div>
+        @if (showFuelEfficiency) {
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" name="fuelEfficiency" id="fuelEfficiency"
+            [(ngModel)]="vehicleDataFilters.fuelEfficiency" (change)="save()">
+          <label for="fuelEfficiency" class="form-check-label">Fuel Efficiency</label>
+        </div>
+        }
         <div class="form-check">
           <input class="form-check-input" type="checkbox" name="totalCost" id="totalCost"
             [(ngModel)]="vehicleDataFilters.totalCost" (change)="save()">

--- a/src/app/shared/shared-meter-content/utility-meter-data-filter/utility-meter-data-filter.component.ts
+++ b/src/app/shared/shared-meter-content/utility-meter-data-filter/utility-meter-data-filter.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, Input, OnInit, Signal } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { DbChangesService } from 'src/app/indexedDB/db-changes.service';
 import { FacilitydbService } from 'src/app/indexedDB/facility-db.service';
 import { ElectricityDataFilters, EmissionsFilters, GeneralInformationFilters, GeneralUtilityDataFilters, VehicleDataFilters } from 'src/app/models/meterDataFilter';

--- a/src/app/shared/shared-meter-content/utility-meter-data-filter/utility-meter-data-filter.component.ts
+++ b/src/app/shared/shared-meter-content/utility-meter-data-filter/utility-meter-data-filter.component.ts
@@ -1,8 +1,8 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, computed, Input, OnInit, Signal } from '@angular/core';
 import { DbChangesService } from 'src/app/indexedDB/db-changes.service';
 import { FacilitydbService } from 'src/app/indexedDB/facility-db.service';
 import { ElectricityDataFilters, EmissionsFilters, GeneralInformationFilters, GeneralUtilityDataFilters, VehicleDataFilters } from 'src/app/models/meterDataFilter';
-import { checkShowEmissionsOutputRate, getIsEnergyUnit } from 'src/app/shared/sharedHelperFunctions';
+import { checkShowEmissionsOutputRate, checkShowHeatCapacity, getIsEnergyUnit } from 'src/app/shared/sharedHelperFunctions';
 import { IdbFacility } from 'src/app/models/idbModels/facility';
 import { IdbUtilityMeter } from 'src/app/models/idbModels/utilityMeter';
 import { UtilityMeterDataService } from 'src/app/shared/shared-meter-content/utility-meter-data.service';
@@ -29,6 +29,10 @@ export class UtilityMeterDataFilterComponent implements OnInit {
   vehicleDataFilters: VehicleDataFilters;
   isRECs: boolean;
   account: IdbAccount;
+  showHeatCapacity: boolean;
+  showFuelEfficiency: boolean;
+  private lastMeterId: string;
+
   constructor(private utilityMeterDataService: UtilityMeterDataService, private facilityDbService: FacilitydbService,
     private dbChangesService: DbChangesService,
     private utilityMeterDbService: UtilityMeterdbService,
@@ -39,28 +43,35 @@ export class UtilityMeterDataFilterComponent implements OnInit {
   }
 
   ngOnChanges() {
-    if (this.meter.source == 'Electricity') {
-      this.isRECs = (this.meter.agreementType == 4 || this.meter.agreementType == 6);
-      let electricityDataFilters: ElectricityDataFilters;
-      electricityDataFilters = this.utilityMeterDataService.tableElectricityFilters.getValue();
-      this.emissionsFilters = electricityDataFilters.emissionsFilters;
-      this.generalInformationFilters = electricityDataFilters.generalInformationFilters;
-    } else if (this.meter.scope != 2) {
-      this.generalUtilityDataFilters = this.utilityMeterDataService.tableGeneralUtilityFilters.getValue();
+    if (!this.meter) {
+      return;
     }
+    if (this.meter.guid != this.lastMeterId) {
+      if (this.meter.source == 'Electricity') {
+        this.isRECs = (this.meter.agreementType == 4 || this.meter.agreementType == 6);
+        let electricityDataFilters: ElectricityDataFilters;
+        electricityDataFilters = this.utilityMeterDataService.tableElectricityFilters.getValue();
+        this.emissionsFilters = electricityDataFilters.emissionsFilters;
+        this.generalInformationFilters = electricityDataFilters.generalInformationFilters;
+      } else if (this.meter.scope != 2) {
+        this.generalUtilityDataFilters = this.utilityMeterDataService.tableGeneralUtilityFilters.getValue();
+      }
 
-    if (this.meter.source != 'Electricity') {
-      this.isRECs = false;
-    }
+      if (this.meter.source != 'Electricity') {
+        this.isRECs = false;
+      }
 
-    if (this.meter.scope == 2) {
-      this.vehicleDataFilters = this.utilityMeterDataService.tableVehicleDataFilters.getValue();
-      this.showEmissions = true;
-      this.displayVolumeInput = true;
-
-    } else {
-      this.showEmissions = checkShowEmissionsOutputRate(this.meter);
-      this.displayVolumeInput = (getIsEnergyUnit(this.meter.startingUnit) == false);
+      if (this.meter.scope == 2) {
+        this.vehicleDataFilters = this.utilityMeterDataService.tableVehicleDataFilters.getValue();
+        this.showEmissions = true;
+        this.displayVolumeInput = true;
+        this.showFuelEfficiency = (this.meter.vehicleCategory == 2);
+      } else {
+        this.showEmissions = checkShowEmissionsOutputRate(this.meter);
+        this.displayVolumeInput = (getIsEnergyUnit(this.meter.startingUnit) == false);
+        this.showHeatCapacity = checkShowHeatCapacity(this.meter.source, this.meter.startingUnit, this.meter.scope);
+      }
+      this.lastMeterId = this.meter.guid;
     }
   }
 
@@ -111,6 +122,7 @@ export class UtilityMeterDataFilterComponent implements OnInit {
         stationaryCarbonEmissions: this.account.displayEmissions ? true : false,
         stationaryOtherEmissions: this.account.displayEmissions ? true : false,
         totalEmissions: this.account.displayEmissions ? true : false,
+        heatCapacity: checkShowHeatCapacity(this.meter.source, this.meter.startingUnit, this.meter.scope)
       }
     } else if (this.meter.scope == 2) {
       this.vehicleDataFilters = {
@@ -120,6 +132,7 @@ export class UtilityMeterDataFilterComponent implements OnInit {
         mobileCarbonEmissions: this.account.displayEmissions ? true : false,
         mobileOtherEmissions: this.account.displayEmissions ? true : false,
         mobileTotalEmissions: this.account.displayEmissions ? true : false,
+        fuelEfficiency: (this.meter.vehicleCategory == 2) ? true : false
       }
     }
 
@@ -157,6 +170,7 @@ export class UtilityMeterDataFilterComponent implements OnInit {
         stationaryCarbonEmissions: false,
         stationaryOtherEmissions: false,
         totalEmissions: false,
+        heatCapacity: false
       }
     } else if (this.meter.scope == 2) {
       this.vehicleDataFilters = {
@@ -166,6 +180,7 @@ export class UtilityMeterDataFilterComponent implements OnInit {
         mobileCarbonEmissions: false,
         mobileOtherEmissions: false,
         mobileTotalEmissions: false,
+        fuelEfficiency: false
       }
     }
     this.meter.charges.forEach(charge => {

--- a/src/app/shared/shared-meter-content/utility-meter-data.service.ts
+++ b/src/app/shared/shared-meter-content/utility-meter-data.service.ts
@@ -107,6 +107,7 @@ export class UtilityMeterDataService {
       stationaryCarbonEmissions: account && account.displayEmissions ? true : false,
       stationaryOtherEmissions: account && account.displayEmissions ? true : false,
       totalEmissions: account && account.displayEmissions ? true : false,
+      heatCapacity: true
     }
   }
 
@@ -118,7 +119,8 @@ export class UtilityMeterDataService {
       mobileBiogenicEmissions: account && account.displayEmissions ? true : false,
       mobileCarbonEmissions: account && account.displayEmissions ? true : false,
       mobileOtherEmissions: account && account.displayEmissions ? true : false,
-      mobileTotalEmissions: account && account.displayEmissions ? true : false
+      mobileTotalEmissions: account && account.displayEmissions ? true : false,
+      fuelEfficiency: true
     }
   }
 


### PR DESCRIPTION
connects #2403 

This pull request adds support for displaying and filtering new calculated columns—Heat Capacity for general utility meters and Fuel Efficiency for vehicle meters—across the meter data table and filter components. These enhancements improve the flexibility and detail of meter data analysis for users.

**General Utility Data Table Enhancements:**

- Added a new `heatCapacity` filter to the `GeneralUtilityDataFilters` interface and included logic to show/hide the Heat Capacity column in the utility data table and its filter UI, based on meter properties. 

**Vehicle Data Table Enhancements:**

- Added a new `fuelEfficiency` filter to the `VehicleDataFilters` interface and included logic to show/hide the Fuel Efficiency column in the vehicle data table and its filter UI, specifically for scope 2, category 2 vehicles. 

**UI and Logic Improvements:**

- Updated the filter components and logic to dynamically determine when to display the new columns and ensure filter state is properly initialized and reset.

**Table Markup and Formatting:**

- Adjusted table markup for improved readability and consistency, including minor formatting changes for alignment and code clarity. 