### PR TITLE
Issue 2174: Status checks updates for account analysis

### DIFF
--- a/src/app/calculations/analysis-calculations/annualAccountAnalysisSummaryClass.ts
+++ b/src/app/calculations/analysis-calculations/annualAccountAnalysisSummaryClass.ts
@@ -1,8 +1,8 @@
-import { MonthlyAnalysisSummaryData } from "src/app/models/analysis";
+import { AnalysisGroup, JStatRegressionModel, MonthlyAnalysisSummaryData } from "src/app/models/analysis";
 import { AnnualAnalysisSummaryDataClass } from "./annualAnalysisSummaryDataClass";
 import { AnnualAnalysisSummary } from 'src/app/models/analysis';
 import { MonthlyAccountAnalysisClass } from "./monthlyAccountAnalysisClass";
-import { checkAnalysisValue, getLatestYearWithData } from "../shared-calculations/calculationsHelpers";
+import { checkAnalysisValue, getLatestYearWithData, getYearsWithFullData } from "../shared-calculations/calculationsHelpers";
 import { IdbAccount } from "src/app/models/idbModels/account";
 import { IdbFacility } from "src/app/models/idbModels/facility";
 import { IdbUtilityMeter } from "src/app/models/idbModels/utilityMeter";
@@ -14,6 +14,7 @@ import { IdbAnalysisItem } from "src/app/models/idbModels/analysisItem";
 import { CalanderizedMeter } from "src/app/models/calanderization";
 import { getCalanderizedMeterData } from "../calanderization/calanderizeMeters";
 import { getNeededUnits } from "../shared-calculations/calanderizationFunctions";
+import * as _ from 'lodash';
 
 export class AnnualAccountAnalysisSummaryClass {
 
@@ -32,7 +33,7 @@ export class AnnualAccountAnalysisSummaryClass {
         meters: Array<IdbUtilityMeter>,
         meterData: Array<IdbUtilityMeterData>,
         accountPredictors: Array<IdbPredictor>) {
-        this.setReportYear(accountAnalysisItem, meters, meterData, account, accountFacilities);
+        this.setReportYear(accountAnalysisItem, meters, meterData, account, accountFacilities, allAccountAnalysisItems, accountPredictorEntries);
         this.setMonthlyAnalysisSummaryData(accountAnalysisItem, account, accountFacilities, accountPredictorEntries, allAccountAnalysisItems, calculateAllMonthlyData, meters, meterData, accountPredictors);
         this.setBaselineYear(accountAnalysisItem);
         this.setAnnualAnalysisSummaryDataClasses(accountPredictorEntries, accountPredictors);
@@ -51,24 +52,128 @@ export class AnnualAccountAnalysisSummaryClass {
         this.baselineYear = analysisItem.baselineYear;
     }
 
-    setReportYear(analysisItem: IdbAccountAnalysisItem, meters: Array<IdbUtilityMeter>, meterData: Array<IdbUtilityMeterData>, account: IdbAccount, accountFacilities: Array<IdbFacility>) {
+    setReportYear(analysisItem: IdbAccountAnalysisItem,
+        meters: Array<IdbUtilityMeter>,
+        meterData: Array<IdbUtilityMeterData>,
+        account: IdbAccount,
+        accountFacilities: Array<IdbFacility>,
+        facilityAnalysisItems: Array<IdbAnalysisItem>,
+        predictorData: Array<IdbPredictorData>) {
         if (analysisItem.calculatedReportYear) {
             this.reportYear = analysisItem.calculatedReportYear;
         } else {
             let calanderizedMeters: Array<CalanderizedMeter> = getCalanderizedMeterData(meters, meterData, account, false, { energyIsSource: analysisItem.energyIsSource, neededUnits: getNeededUnits(analysisItem) }, [], [], accountFacilities, account.assessmentReportVersion, []);
-            let includedFacilities: Array<IdbFacility> = new Array();
+            let includedFacilityAnalysis: Array<IdbAnalysisItem> = new Array();
             analysisItem.facilityAnalysisItems.forEach(facilityItem => {
                 if (facilityItem.analysisItemId) {
-                    let facility: IdbFacility = accountFacilities.find(fac => fac.guid == facilityItem.facilityId);
-                    includedFacilities.push(facility);
+                    const facilityAnalysis: IdbAnalysisItem = facilityAnalysisItems.find(item => item.guid === facilityItem.analysisItemId);
+                    // let facility: IdbFacility = accountFacilities.find(fac => fac.guid == facilityItem.facilityId);
+                    includedFacilityAnalysis.push(facilityAnalysis);
                 }
             });
             //TODO need to update this to only look at meters that are included in the analysis item 
             // need full year
-            this.reportYear = getLatestYearWithData(calanderizedMeters, includedFacilities);
+            // this.reportYear = getLatestYearWithData(calanderizedMeters, includedFacilityAnalysis);
+
+            const { includedMeterIds, includedPredictorIds } = this.collectRegressionGroupInputIds(meters, includedFacilityAnalysis);
+            let latestYears: Array<Date> = [];
+            for (const meterId of includedMeterIds) {
+                const cMeter: CalanderizedMeter = calanderizedMeters.find(cMeter => cMeter.meter.guid === meterId);
+                const facility: IdbFacility = accountFacilities.find(fac => {
+                    return fac.guid == cMeter.meter.facilityId
+                });
+                const fullYearsWithData: Array<number> = getYearsWithFullData([cMeter], facility)
+                const latestYearWithData = _.max(fullYearsWithData);
+                if (latestYearWithData) {
+                    latestYears.push(latestYearWithData);
+                }
+            }
+            for (const predictorId of includedPredictorIds) {
+                const predictorDataForPredictor = predictorData.filter(predictorEntry => predictorEntry.predictorId === predictorId);
+                //years with 12 months of data
+                const years: Array<number> = predictorDataForPredictor.map(entry => { return entry.year });
+                //get counts of years to find full years of data
+                const yearCounts = _.countBy(years);
+                const fullYears = Object.keys(yearCounts).filter(year => yearCounts[year] >= 12).map(year => parseInt(year));
+                const latestYearWithData = _.max(fullYears);
+                if (latestYearWithData) {
+                    latestYears.push(latestYearWithData);
+                }
+            }
+            //minimum date of all meters and predictors included in the analysis groups will determine the 
+            //report year to ensure full year of data for all inputs
+            const minYear: number = _.min(latestYears);
+            this.reportYear = minYear;
             analysisItem.calculatedReportYear = this.reportYear;
+
+
+            // let includedFacility: Array<IdbFacility> = new Array();
+            // analysisItem.facilityAnalysisItems.forEach(facilityItem => {
+            //     if (facilityItem.analysisItemId) {
+            //         let facility: IdbFacility = accountFacilities.find(fac => fac.guid == facilityItem.facilityId);
+            //         includedFacility.push(facility);
+            //     }
+            // });
+            // //TODO need to update this to only look at meters that are included in the analysis item 
+            // // need full year
+            // this.reportYear = getLatestYearWithData(calanderizedMeters, includedFacility);
+            // analysisItem.calculatedReportYear = this.reportYear;
         }
     }
+
+    collectRegressionGroupInputIds(
+        meters: Array<IdbUtilityMeter>,
+        facilityAnalysisItems: Array<IdbAnalysisItem>
+    ): { includedMeterIds: Array<string>; includedPredictorIds: Array<string> } {
+        const includedMeterIds: Array<string> = [];
+        const includedPredictorIds: Array<string> = [];
+        for (const analysisItem of facilityAnalysisItems) {
+            for (const group of analysisItem.groups) {
+                if (group.analysisType == 'skip' || group.analysisType == 'skipAnalysis') {
+                    continue;
+                }
+                if (group.analysisType == 'energyIntensity' || group.analysisType == 'modifiedEnergyIntensity') {
+                    group.predictorVariables.forEach(pv => {
+                        if (pv.productionInAnalysis && !includedPredictorIds.includes(pv.id) && pv.id) {
+                            includedPredictorIds.push(pv.id);
+                        }
+                    });
+                }
+
+                // Collect predictor IDs from the group's selected regression model.
+                if (group.analysisType == 'regression') {
+                    if (group.isGeneratedModel) {
+                        const selectedModel: JStatRegressionModel = group.models?.find(m => m.modelId === group.selectedModelId);
+                        if (selectedModel) {
+                            for (const pv of selectedModel.predictorVariables) {
+                                if (!includedPredictorIds.includes(pv.id) && pv.id) {
+                                    includedPredictorIds.push(pv.id);
+                                }
+                            }
+                        }
+                    } else {
+                        //user defined model
+                        group.predictorVariables.forEach(pv => {
+                            if (pv.productionInAnalysis && !includedPredictorIds.includes(pv.id) && pv.id) {
+                                includedPredictorIds.push(pv.id);
+                            }
+                        });
+                    }
+                }
+
+                // Collect unique meter IDs for all calanderized meters belonging to this group.
+                const groupMeters: Array<IdbUtilityMeter> = meters.filter(meter => meter.groupId === group.idbGroupId);
+                for (const meter of groupMeters) {
+                    if (!includedMeterIds.includes(meter.guid)) {
+                        includedMeterIds.push(meter.guid);
+                    }
+                }
+            }
+        }
+
+        return { includedMeterIds, includedPredictorIds };
+    }
+
 
 
     setAnnualAnalysisSummaryDataClasses(accountPredictorEntries: Array<IdbPredictorData>, accountPredictors: Array<IdbPredictor>) {

--- a/src/app/calculations/analysis-calculations/annualAccountAnalysisSummaryClass.ts
+++ b/src/app/calculations/analysis-calculations/annualAccountAnalysisSummaryClass.ts
@@ -13,7 +13,7 @@ import { IdbAccountAnalysisItem } from "src/app/models/idbModels/accountAnalysis
 import { IdbAnalysisItem } from "src/app/models/idbModels/analysisItem";
 import { CalanderizedMeter } from "src/app/models/calanderization";
 import { getCalanderizedMeterData } from "../calanderization/calanderizeMeters";
-import { getNeededUnits } from "../shared-calculations/calanderizationFunctions";
+import { getNeededUnits, getFiscalYear } from "../shared-calculations/calanderizationFunctions";
 import * as _ from 'lodash';
 
 export class AnnualAccountAnalysisSummaryClass {
@@ -67,16 +67,13 @@ export class AnnualAccountAnalysisSummaryClass {
             analysisItem.facilityAnalysisItems.forEach(facilityItem => {
                 if (facilityItem.analysisItemId) {
                     const facilityAnalysis: IdbAnalysisItem = facilityAnalysisItems.find(item => item.guid === facilityItem.analysisItemId);
-                    // let facility: IdbFacility = accountFacilities.find(fac => fac.guid == facilityItem.facilityId);
-                    includedFacilityAnalysis.push(facilityAnalysis);
+                    if (facilityAnalysis) {
+                        includedFacilityAnalysis.push(facilityAnalysis);
+                    }
                 }
             });
-            //TODO need to update this to only look at meters that are included in the analysis item 
-            // need full year
-            // this.reportYear = getLatestYearWithData(calanderizedMeters, includedFacilityAnalysis);
-
             const { includedMeterIds, includedPredictorIds } = this.collectRegressionGroupInputIds(meters, includedFacilityAnalysis);
-            let latestYears: Array<Date> = [];
+            let latestYears: Array<number> = [];
             for (const meterId of includedMeterIds) {
                 const cMeter: CalanderizedMeter = calanderizedMeters.find(cMeter => cMeter.meter.guid === meterId);
                 const facility: IdbFacility = accountFacilities.find(fac => {
@@ -90,14 +87,23 @@ export class AnnualAccountAnalysisSummaryClass {
             }
             for (const predictorId of includedPredictorIds) {
                 const predictorDataForPredictor = predictorData.filter(predictorEntry => predictorEntry.predictorId === predictorId);
-                //years with 12 months of data
-                const years: Array<number> = predictorDataForPredictor.map(entry => { return entry.year });
-                //get counts of years to find full years of data
-                const yearCounts = _.countBy(years);
-                const fullYears = Object.keys(yearCounts).filter(year => yearCounts[year] >= 12).map(year => parseInt(year));
-                const latestYearWithData = _.max(fullYears);
-                if (latestYearWithData) {
-                    latestYears.push(latestYearWithData);
+                if (predictorDataForPredictor.length != 0) {
+                    const facility: IdbFacility = accountFacilities.find(fac => {
+                        return fac.guid == predictorDataForPredictor[0].facilityId
+                    });
+                    //years with 12 months of data
+                    const years: Array<number> = predictorDataForPredictor.map(entry => {
+                        const date: Date = new Date(entry.year, entry.month - 1, 1);
+                        const fiscalYear: number = getFiscalYear(date, facility)
+                        return fiscalYear;
+                    });
+                    //get counts of years to find full years of data
+                    const yearCounts = _.countBy(years);
+                    const fullYears = Object.keys(yearCounts).filter(year => yearCounts[year] >= 12).map(year => parseInt(year));
+                    const latestYearWithData = _.max(fullYears);
+                    if (latestYearWithData) {
+                        latestYears.push(latestYearWithData);
+                    }
                 }
             }
             //minimum date of all meters and predictors included in the analysis groups will determine the 
@@ -105,19 +111,6 @@ export class AnnualAccountAnalysisSummaryClass {
             const minYear: number = _.min(latestYears);
             this.reportYear = minYear;
             analysisItem.calculatedReportYear = this.reportYear;
-
-
-            // let includedFacility: Array<IdbFacility> = new Array();
-            // analysisItem.facilityAnalysisItems.forEach(facilityItem => {
-            //     if (facilityItem.analysisItemId) {
-            //         let facility: IdbFacility = accountFacilities.find(fac => fac.guid == facilityItem.facilityId);
-            //         includedFacility.push(facility);
-            //     }
-            // });
-            // //TODO need to update this to only look at meters that are included in the analysis item 
-            // // need full year
-            // this.reportYear = getLatestYearWithData(calanderizedMeters, includedFacility);
-            // analysisItem.calculatedReportYear = this.reportYear;
         }
     }
 

--- a/src/app/calculations/analysis-calculations/annualAccountAnalysisSummaryClass.ts
+++ b/src/app/calculations/analysis-calculations/annualAccountAnalysisSummaryClass.ts
@@ -32,7 +32,7 @@ export class AnnualAccountAnalysisSummaryClass {
         meters: Array<IdbUtilityMeter>,
         meterData: Array<IdbUtilityMeterData>,
         accountPredictors: Array<IdbPredictor>) {
-        this.setReportYear(accountAnalysisItem, meters, meterData, account, accountAnalysisItem, accountFacilities);
+        this.setReportYear(accountAnalysisItem, meters, meterData, account, accountFacilities);
         this.setMonthlyAnalysisSummaryData(accountAnalysisItem, account, accountFacilities, accountPredictorEntries, allAccountAnalysisItems, calculateAllMonthlyData, meters, meterData, accountPredictors);
         this.setBaselineYear(accountAnalysisItem);
         this.setAnnualAnalysisSummaryDataClasses(accountPredictorEntries, accountPredictors);
@@ -51,11 +51,11 @@ export class AnnualAccountAnalysisSummaryClass {
         this.baselineYear = analysisItem.baselineYear;
     }
 
-    setReportYear(analysisItem: IdbAccountAnalysisItem, meters: Array<IdbUtilityMeter>, meterData: Array<IdbUtilityMeterData>, account: IdbAccount, accountAnalysisItem: IdbAccountAnalysisItem, accountFacilities: Array<IdbFacility>) {
+    setReportYear(analysisItem: IdbAccountAnalysisItem, meters: Array<IdbUtilityMeter>, meterData: Array<IdbUtilityMeterData>, account: IdbAccount, accountFacilities: Array<IdbFacility>) {
         if (analysisItem.calculatedReportYear) {
             this.reportYear = analysisItem.calculatedReportYear;
         } else {
-            let calanderizedMeters: Array<CalanderizedMeter> = getCalanderizedMeterData(meters, meterData, account, false, { energyIsSource: accountAnalysisItem.energyIsSource, neededUnits: getNeededUnits(accountAnalysisItem) }, [], [], accountFacilities, account.assessmentReportVersion, []);
+            let calanderizedMeters: Array<CalanderizedMeter> = getCalanderizedMeterData(meters, meterData, account, false, { energyIsSource: analysisItem.energyIsSource, neededUnits: getNeededUnits(analysisItem) }, [], [], accountFacilities, account.assessmentReportVersion, []);
             let includedFacilities: Array<IdbFacility> = new Array();
             analysisItem.facilityAnalysisItems.forEach(facilityItem => {
                 if (facilityItem.analysisItemId) {
@@ -63,6 +63,8 @@ export class AnnualAccountAnalysisSummaryClass {
                     includedFacilities.push(facility);
                 }
             });
+            //TODO need to update this to only look at meters that are included in the analysis item 
+            // need full year
             this.reportYear = getLatestYearWithData(calanderizedMeters, includedFacilities);
             analysisItem.calculatedReportYear = this.reportYear;
         }

--- a/src/app/calculations/shared-calculations/calculationsHelpers.ts
+++ b/src/app/calculations/shared-calculations/calculationsHelpers.ts
@@ -222,6 +222,13 @@ export function getYearsWithFullDataAnalysis(calanderizedMeters: Array<Calanderi
     return getYearsWithFullData(filteredMeters, facility);
 }
 
+export function getYearsWithFullDataAccountAnalysis(calanderizedMeters: Array<CalanderizedMeter>, analysisItem: IdbAccountAnalysisItem, account: IdbAccount): Array<number> {
+    const filteredMeters: Array<CalanderizedMeter> = calanderizedMeters.filter(calanderizedMeter => {
+        return isCategoryMeter(calanderizedMeter.meter, analysisItem.analysisCategory);
+    });
+    return getYearsWithFullDataAccount(filteredMeters, account);
+}
+
 export function isCategoryMeter(meter: IdbUtilityMeter, meterCategory: 'water' | 'energy' | 'all'): boolean {
     if (meterCategory == 'water') {
         if (meter.source == 'Water Intake') {

--- a/src/app/calculations/status-check-calculations/accountAnalysisStatusCheck.ts
+++ b/src/app/calculations/status-check-calculations/accountAnalysisStatusCheck.ts
@@ -13,16 +13,19 @@ export class AccountAnalysisStatusCheck {
     analysisItemId: string;
     accountAnalysisSetupErrors: AccountAnalysisSetupErrors;
     status: STATUS_CHECK_OPTIONS;
-    
+
     /** The most recent data date across all meters and predictors used in the analysis. */
     latestDataDate: Date;
     /** The most recent same day/month across all meters and predictors used in the analysis */
     latestDataAllEntries: Date;
+    /** latest complete year of data */
+    latestCompleteYear: number;
+
     /** True when every meter and predictor has data up to the same month/year as latestDataDate. */
     allDatesCurrent: boolean;
+    facilityAnalysisHasWarnings: boolean;
 
-
-    constructor(analysisItem: IdbAccountAnalysisItem, facilityStatusChecks: Array<FacilityStatusCheck>) {
+    constructor(analysisItem: IdbAccountAnalysisItem, facilityStatusChecks: Array<FacilityStatusCheck>, account: IdbAccount) {
         this.analysisItemId = analysisItem.guid;
         const facilityAnalysisItemIds: Set<string> = new Set(
             analysisItem.facilityAnalysisItems
@@ -32,8 +35,8 @@ export class AccountAnalysisStatusCheck {
         const facilityAnalysisStatusChecks: Array<AnalysisStatusCheck> = facilityStatusChecks.flatMap(fc => fc.analysisStatusChecks)
         const includedFacilityAnalysisStatusChecks: Array<AnalysisStatusCheck> = facilityAnalysisStatusChecks.filter(fc => facilityAnalysisItemIds.has(fc.analysisItem.guid));
         this.setAnalysisSetupErrors(includedFacilityAnalysisStatusChecks, analysisItem);
-        this.setDates(includedFacilityAnalysisStatusChecks);
-        this.setStatus();
+        this.setDates(includedFacilityAnalysisStatusChecks, account);
+        this.setStatus(includedFacilityAnalysisStatusChecks);
     }
 
     private setAnalysisSetupErrors(facilityAnalysisStatusChecks: Array<AnalysisStatusCheck>, analysisItem: IdbAccountAnalysisItem) {
@@ -42,21 +45,50 @@ export class AccountAnalysisStatusCheck {
         this.accountAnalysisSetupErrors = errors;
     }
 
-    private setDates(facilityAnalysisStatusChecks: Array<AnalysisStatusCheck>) {
+    private setDates(facilityAnalysisStatusChecks: Array<AnalysisStatusCheck>, account: IdbAccount) {
         const latestDataDates: Array<Date> = facilityAnalysisStatusChecks.map(fc => fc.latestDataDate).filter((date): date is Date => date !== undefined);
         this.latestDataDate = latestDataDates.length > 0 ? new Date(Math.max(...latestDataDates.map(date => date.getTime()))) : undefined;
 
         const latestDataAllEntriesDates: Array<Date> = facilityAnalysisStatusChecks.map(fc => fc.latestDataAllEntries).filter((date): date is Date => date !== undefined);
         this.latestDataAllEntries = latestDataAllEntriesDates.length > 0 ? new Date(Math.min(...latestDataAllEntriesDates.map(date => date.getTime()))) : undefined;
 
-        //year/month equal
-        this.allDatesCurrent = this.latestDataDate !== undefined && this.latestDataAllEntries !== undefined && this.latestDataDate.getFullYear() === this.latestDataAllEntries.getFullYear() && this.latestDataDate.getMonth() === this.latestDataAllEntries.getMonth();
+        if (this.latestDataAllEntries) {
+            if (account.fiscalYear === 'calendarYear') {
+                if(this.latestDataAllEntries.getMonth() === 11) {
+                    this.latestCompleteYear = this.latestDataAllEntries.getFullYear();
+                } else {
+                    this.latestCompleteYear = this.latestDataAllEntries.getFullYear() - 1;
+                }
+            } else if(account.fiscalYearCalendarEnd) {
+                //fiscal year ends in the fiscalYearMonth
+                if(account.fiscalYearMonth){
+                    if(this.latestDataAllEntries.getMonth() === (account.fiscalYearMonth - 1 + 12) % 12) {
+                        this.latestCompleteYear = this.latestDataAllEntries.getFullYear();
+                    } else {
+                        this.latestCompleteYear = this.latestDataAllEntries.getFullYear() - 1;
+                    }
+                }
+            } else if(!account.fiscalYearCalendarEnd){
+                //fiscal year starts in the fiscalYearMonth
+                if(account.fiscalYearMonth){
+                    if(this.latestDataAllEntries.getMonth() === (account.fiscalYearMonth - 2 + 12) % 12) {
+                        this.latestCompleteYear = this.latestDataAllEntries.getFullYear();
+                    } else {
+                        this.latestCompleteYear = this.latestDataAllEntries.getFullYear() - 1;
+                    }
+                }
+            }
+            //year/month equal
+            this.allDatesCurrent = this.latestDataDate !== undefined && this.latestDataDate.getFullYear() === this.latestDataAllEntries.getFullYear() && this.latestDataDate.getMonth() === this.latestDataAllEntries.getMonth();
+        }
     }
 
-    private setStatus() {
+    private setStatus(includedFacilityAnalysisStatusChecks: Array<AnalysisStatusCheck>) {
+        this.facilityAnalysisHasWarnings = includedFacilityAnalysisStatusChecks.some(fc => fc.status === 'warning');
+
         if (this.accountAnalysisSetupErrors.hasError) {
             this.status = 'error';
-        } else if (!this.allDatesCurrent) {
+        } else if (this.facilityAnalysisHasWarnings) {
             this.status = 'warning';
         } else {
             this.status = 'good';

--- a/src/app/calculations/status-check-calculations/accountAnalysisStatusCheck.ts
+++ b/src/app/calculations/status-check-calculations/accountAnalysisStatusCheck.ts
@@ -1,0 +1,65 @@
+import { AccountAnalysisSetupErrors } from "src/app/models/accountAnalysis";
+import { IdbAccount } from "src/app/models/idbModels/account";
+import { IdbAccountAnalysisItem } from "src/app/models/idbModels/accountAnalysisItem";
+import { AnalysisSetupErrors } from "src/app/models/validation";
+import { FacilityStatusCheck } from "./facilityStatusCheck";
+import { getAccountAnalysisSetupErrors } from "./validation/accountAnalysisValidation";
+import { STATUS_CHECK_OPTIONS } from "./statusCheckModels";
+import { AnalysisStatusCheck } from "./analysisStatusCheck";
+
+
+export class AccountAnalysisStatusCheck {
+
+    analysisItemId: string;
+    accountAnalysisSetupErrors: AccountAnalysisSetupErrors;
+    status: STATUS_CHECK_OPTIONS;
+    
+    /** The most recent data date across all meters and predictors used in the analysis. */
+    latestDataDate: Date;
+    /** The most recent same day/month across all meters and predictors used in the analysis */
+    latestDataAllEntries: Date;
+    /** True when every meter and predictor has data up to the same month/year as latestDataDate. */
+    allDatesCurrent: boolean;
+
+
+    constructor(analysisItem: IdbAccountAnalysisItem, facilityStatusChecks: Array<FacilityStatusCheck>) {
+        this.analysisItemId = analysisItem.guid;
+        const facilityAnalysisItemIds: Set<string> = new Set(
+            analysisItem.facilityAnalysisItems
+                .map(facilityAnalysisItem => facilityAnalysisItem.analysisItemId)
+                .filter((analysisItemId): analysisItemId is string => analysisItemId !== undefined && analysisItemId !== null)
+        );
+        const facilityAnalysisStatusChecks: Array<AnalysisStatusCheck> = facilityStatusChecks.flatMap(fc => fc.analysisStatusChecks)
+        const includedFacilityAnalysisStatusChecks: Array<AnalysisStatusCheck> = facilityAnalysisStatusChecks.filter(fc => facilityAnalysisItemIds.has(fc.analysisItem.guid));
+        this.setAnalysisSetupErrors(includedFacilityAnalysisStatusChecks, analysisItem);
+        this.setDates(includedFacilityAnalysisStatusChecks);
+        this.setStatus();
+    }
+
+    private setAnalysisSetupErrors(facilityAnalysisStatusChecks: Array<AnalysisStatusCheck>, analysisItem: IdbAccountAnalysisItem) {
+        const analysisSetupErrors: Array<AnalysisSetupErrors> = facilityAnalysisStatusChecks.map(fc => fc.analysisSetupErrors);
+        const errors = getAccountAnalysisSetupErrors(analysisItem, analysisSetupErrors);
+        this.accountAnalysisSetupErrors = errors;
+    }
+
+    private setDates(facilityAnalysisStatusChecks: Array<AnalysisStatusCheck>) {
+        const latestDataDates: Array<Date> = facilityAnalysisStatusChecks.map(fc => fc.latestDataDate).filter((date): date is Date => date !== undefined);
+        this.latestDataDate = latestDataDates.length > 0 ? new Date(Math.max(...latestDataDates.map(date => date.getTime()))) : undefined;
+
+        const latestDataAllEntriesDates: Array<Date> = facilityAnalysisStatusChecks.map(fc => fc.latestDataAllEntries).filter((date): date is Date => date !== undefined);
+        this.latestDataAllEntries = latestDataAllEntriesDates.length > 0 ? new Date(Math.min(...latestDataAllEntriesDates.map(date => date.getTime()))) : undefined;
+
+        //year/month equal
+        this.allDatesCurrent = this.latestDataDate !== undefined && this.latestDataAllEntries !== undefined && this.latestDataDate.getFullYear() === this.latestDataAllEntries.getFullYear() && this.latestDataDate.getMonth() === this.latestDataAllEntries.getMonth();
+    }
+
+    private setStatus() {
+        if (this.accountAnalysisSetupErrors.hasError) {
+            this.status = 'error';
+        } else if (!this.allDatesCurrent) {
+            this.status = 'warning';
+        } else {
+            this.status = 'good';
+        }
+    }
+}

--- a/src/app/calculations/status-check-calculations/accountStatusCheck.ts
+++ b/src/app/calculations/status-check-calculations/accountStatusCheck.ts
@@ -13,7 +13,7 @@ import { FacilityStatusCheck } from "./facilityStatusCheck";
 import { STATUS_CHECK_OPTIONS, StatusCheckAction } from "./statusCheckModels";
 import { emptyGroupAnalysisErrors } from "src/app/calculations/status-check-calculations/validation/groupAnalysisValidation";
 import { emptyAnalysisSetupErrors } from "src/app/calculations/status-check-calculations/validation/analysisValidation";
-import { getAccountAnalysisSetupErrors, emptyAccountAnalysisSetupErrors } from "src/app/calculations/status-check-calculations/validation/accountAnalysisValidation";
+import { emptyAccountAnalysisSetupErrors } from "src/app/calculations/status-check-calculations/validation/accountAnalysisValidation";
 import { getAccountReportErrors, emptyAccountReportErrors } from "src/app/calculations/status-check-calculations/validation/accountReportValidation";
 import { IdbFacilityReport } from "src/app/models/idbModels/facilityReport";
 import { IdbAccountAnalysisItem } from "src/app/models/idbModels/accountAnalysisItem";
@@ -21,6 +21,7 @@ import { IdbAccountReport } from "src/app/models/idbModels/accountReport";
 import { AccountAnalysisSetupErrors } from "src/app/models/accountAnalysis";
 import { AnalysisStatusCheck } from './analysisStatusCheck';
 import { AnalysisGroupStatusCheck } from './analysisGroupStatusCheck';
+import { AccountAnalysisStatusCheck } from './accountAnalysisStatusCheck';
 
 export class AccountStatusCheck {
 
@@ -28,8 +29,10 @@ export class AccountStatusCheck {
     status: STATUS_CHECK_OPTIONS;
     actions: Array<StatusCheckAction>;
 
-    accountAnalysisSetupErrors: Array<AccountAnalysisSetupErrors>;
     accountReportErrors: Array<AccountReportErrors>;
+    accountAnalysisStatusChecks: Array<AccountAnalysisStatusCheck>;
+    energyAnalysisStatusCheck: AccountAnalysisStatusCheck;
+    waterAnalysisStatusCheck: AccountAnalysisStatusCheck;
 
     constructor(
         account: IdbAccount,
@@ -88,7 +91,7 @@ export class AccountStatusCheck {
     }
 
     getAccountAnalysisErrorsByAnalysisId(analysisId: string): AccountAnalysisSetupErrors {
-        const errors = this.accountAnalysisSetupErrors.find(e => e.analysisId === analysisId);
+        const errors = this.accountAnalysisStatusChecks.find(e => e.analysisItemId === analysisId)?.accountAnalysisSetupErrors;
         return errors ?? emptyAccountAnalysisSetupErrors();
     }
 
@@ -98,27 +101,36 @@ export class AccountStatusCheck {
     }
 
     private computeAccountAnalysisSetupErrors(account: IdbAccount, accountAnalysisItems: Array<IdbAccountAnalysisItem>) {
-        this.accountAnalysisSetupErrors = [];
-        const analysisStatusChecks: Array<AnalysisStatusCheck> = this.facilityStatusChecks.flatMap(fc => fc.analysisStatusChecks)
-        const allAnalysisSetupErrors: Array<AnalysisSetupErrors> = analysisStatusChecks.map(asc => asc.analysisSetupErrors);
+        this.accountAnalysisStatusChecks = [];
         const accountAnalysisItemsForAccount: Array<IdbAccountAnalysisItem> = accountAnalysisItems.filter(accountAnalysisItem => accountAnalysisItem.accountId === account.guid);
         for (const item of accountAnalysisItemsForAccount) {
-            const itemAnalysisIds: Set<string> = new Set(
-                item.facilityAnalysisItems
-                    .map(facilityAnalysisItem => facilityAnalysisItem.analysisItemId)
-                    .filter((analysisItemId): analysisItemId is string => analysisItemId !== undefined && analysisItemId !== null)
-            );
-            const analysisSetupErrors: Array<AnalysisSetupErrors> = allAnalysisSetupErrors
-                .filter(errors => itemAnalysisIds.has(errors.analysisId));
-            const errors = getAccountAnalysisSetupErrors(item, analysisSetupErrors);
-            this.accountAnalysisSetupErrors.push(errors);
+            const accountAnalysisStatusCheck = new AccountAnalysisStatusCheck(item, this.facilityStatusChecks);
+            this.accountAnalysisStatusChecks.push(accountAnalysisStatusCheck);
         }
+        const energyAnalysisItem = this.getLatestAnalysisItem(account, accountAnalysisItemsForAccount, 'energy');
+        if (energyAnalysisItem) {
+            this.energyAnalysisStatusCheck = this.accountAnalysisStatusChecks.find(check => check.analysisItemId === energyAnalysisItem.guid);
+        }
+        const waterAnalysisItem = this.getLatestAnalysisItem(account, accountAnalysisItemsForAccount, 'water');
+        if (waterAnalysisItem) {
+            this.waterAnalysisStatusCheck = this.accountAnalysisStatusChecks.find(check => check.analysisItemId === waterAnalysisItem.guid);
+        }
+    }
+
+    private getLatestAnalysisItem(account: IdbAccount, accountAnalysisItems: Array<IdbAccountAnalysisItem>, category: 'energy' | 'water'): IdbAccountAnalysisItem | undefined {
+        const selectedId = category === 'energy' ? account.selectedEnergyAnalysisId : account.selectedWaterAnalysisId;
+        if (selectedId) {
+            return accountAnalysisItems.find(item => item.guid === selectedId);
+        }
+        const items = accountAnalysisItems.filter(item => item.accountId === account.guid && item.analysisCategory === category);
+        return items.length > 0 ? _.maxBy(items, 'modifiedDate') : undefined;
     }
 
     private computeAccountReportErrors(account: IdbAccount, accountReports: Array<IdbAccountReport>) {
         this.accountReportErrors = [];
         for (const report of accountReports.filter(accountReport => accountReport.accountId === account.guid)) {
-            const errors = getAccountReportErrors(report, this.accountAnalysisSetupErrors);
+            const accountAnalysisSetupErrors: Array<AccountAnalysisSetupErrors> = this.accountAnalysisStatusChecks.flatMap(aasc => aasc.accountAnalysisSetupErrors);
+            const errors = getAccountReportErrors(report, accountAnalysisSetupErrors);
             this.accountReportErrors.push(errors);
         }
     }

--- a/src/app/calculations/status-check-calculations/accountStatusCheck.ts
+++ b/src/app/calculations/status-check-calculations/accountStatusCheck.ts
@@ -112,7 +112,7 @@ export class AccountStatusCheck {
         this.accountAnalysisStatusChecks = [];
         const accountAnalysisItemsForAccount: Array<IdbAccountAnalysisItem> = accountAnalysisItems.filter(accountAnalysisItem => accountAnalysisItem.accountId === account.guid);
         for (const item of accountAnalysisItemsForAccount) {
-            const accountAnalysisStatusCheck = new AccountAnalysisStatusCheck(item, this.facilityStatusChecks);
+            const accountAnalysisStatusCheck = new AccountAnalysisStatusCheck(item, this.facilityStatusChecks, account);
             this.accountAnalysisStatusChecks.push(accountAnalysisStatusCheck);
         }
         const energyAnalysisItem = this.getLatestAnalysisItem(account, accountAnalysisItemsForAccount, 'energy');

--- a/src/app/calculations/status-check-calculations/accountStatusCheck.ts
+++ b/src/app/calculations/status-check-calculations/accountStatusCheck.ts
@@ -90,8 +90,12 @@ export class AccountStatusCheck {
         return facilityReportStatusChecks.find(fr => fr.reportId === reportId);
     }
 
+    getAccountAnalysisStatusCheckById(analysisId: string): AccountAnalysisStatusCheck | undefined {
+        return this.accountAnalysisStatusChecks.find(aasc => aasc.analysisItemId === analysisId);
+    }
+
     getAccountAnalysisErrorsByAnalysisId(analysisId: string): AccountAnalysisSetupErrors {
-        const errors = this.accountAnalysisStatusChecks.find(e => e.analysisItemId === analysisId)?.accountAnalysisSetupErrors;
+        const errors = this.getAccountAnalysisStatusCheckById(analysisId)?.accountAnalysisSetupErrors;
         return errors ?? emptyAccountAnalysisSetupErrors();
     }
 

--- a/src/app/calculations/status-check-calculations/accountStatusCheck.ts
+++ b/src/app/calculations/status-check-calculations/accountStatusCheck.ts
@@ -104,6 +104,10 @@ export class AccountStatusCheck {
         return errors ?? emptyAccountReportErrors();
     }
 
+    getFacilityStatusCheckByFacilityId(facilityId: string): FacilityStatusCheck | undefined {
+        return this.facilityStatusChecks.find(fc => fc.facility.guid === facilityId);
+    }
+
     private computeAccountAnalysisSetupErrors(account: IdbAccount, accountAnalysisItems: Array<IdbAccountAnalysisItem>) {
         this.accountAnalysisStatusChecks = [];
         const accountAnalysisItemsForAccount: Array<IdbAccountAnalysisItem> = accountAnalysisItems.filter(accountAnalysisItem => accountAnalysisItem.accountId === account.guid);

--- a/src/app/calculations/status-check-calculations/analysisStatusCheck.ts
+++ b/src/app/calculations/status-check-calculations/analysisStatusCheck.ts
@@ -218,17 +218,4 @@ export class AnalysisStatusCheck {
     getGroupStatusChecksByGroupId(groupId: string): AnalysisGroupStatusCheck | undefined {
         return this.groupStatusChecks.find(gsc => gsc.group.idbGroupId === groupId);
     }
-
-    setIsDateCurrentWithAccountAnalysis(accountLatestDataDate: Date) {
-        if (!this.latestDataAllEntries) {
-            this.isDateCurrentWithAccountAnalysis = false;
-        } else {
-            //check month/year of latest facility entry against month/year of latest data date for account analysis
-            this.isDateCurrentWithAccountAnalysis = this.latestDataAllEntries.getFullYear() === accountLatestDataDate.getFullYear() &&
-                this.latestDataAllEntries.getMonth() === accountLatestDataDate.getMonth();
-        }
-        if(!this.isDateCurrentWithAccountAnalysis && this.status == 'good'){
-            this.status = 'warning';
-        }
-    }
 }

--- a/src/app/calculations/status-check-calculations/analysisStatusCheck.ts
+++ b/src/app/calculations/status-check-calculations/analysisStatusCheck.ts
@@ -33,6 +33,7 @@ export class AnalysisStatusCheck {
     status: 'good' | 'warning' | 'error';
     groupsHaveWarnings: boolean;
     groupsHaveErrors: boolean;
+    isDateCurrentWithAccountAnalysis: boolean;
     constructor(analysisItem: IdbAnalysisItem,
         meterStatusChecks: Array<MeterStatusCheck>,
         predictorStatusChecks: Array<PredictorStatusCheck>,
@@ -216,5 +217,18 @@ export class AnalysisStatusCheck {
 
     getGroupStatusChecksByGroupId(groupId: string): AnalysisGroupStatusCheck | undefined {
         return this.groupStatusChecks.find(gsc => gsc.group.idbGroupId === groupId);
+    }
+
+    setIsDateCurrentWithAccountAnalysis(accountLatestDataDate: Date) {
+        if (!this.latestDataAllEntries) {
+            this.isDateCurrentWithAccountAnalysis = false;
+        } else {
+            //check month/year of latest facility entry against month/year of latest data date for account analysis
+            this.isDateCurrentWithAccountAnalysis = this.latestDataAllEntries.getFullYear() === accountLatestDataDate.getFullYear() &&
+                this.latestDataAllEntries.getMonth() === accountLatestDataDate.getMonth();
+        }
+        if(!this.isDateCurrentWithAccountAnalysis && this.status == 'good'){
+            this.status = 'warning';
+        }
     }
 }

--- a/src/app/calculations/status-check-calculations/analysisStatusCheck.ts
+++ b/src/app/calculations/status-check-calculations/analysisStatusCheck.ts
@@ -19,6 +19,8 @@ export class AnalysisStatusCheck {
     latestDataAllEntries: Date;
     /** True when every meter and predictor has data up to the same month/year as latestDataDate. */
     allDatesCurrent: boolean;
+    /// latest complete year of data
+    latestCompleteYear: number;
 
     analysisSetupErrors: AnalysisSetupErrors;
     groupStatusChecks: Array<AnalysisGroupStatusCheck>;
@@ -48,6 +50,7 @@ export class AnalysisStatusCheck {
         this.setPredictorSetupErrors();
         this.setMeterSetupErrors();
         this.setStatus();
+        this.setLatestCompleteYear(facility);
     }
 
     private setAnalysisGroupErrors(
@@ -111,6 +114,38 @@ export class AnalysisStatusCheck {
 
         //latest data entry date for which all meters and predictors have data entered
         this.latestDataAllEntries = _.min(allDates);
+    }
+
+    private setLatestCompleteYear(facility: IdbFacility) {
+        if (this.latestDataAllEntries) {
+            if (facility.fiscalYear === 'calendarYear') {
+                if(this.latestDataAllEntries.getMonth() === 11) {
+                    this.latestCompleteYear = this.latestDataAllEntries.getFullYear();
+                } else {
+                    this.latestCompleteYear = this.latestDataAllEntries.getFullYear() - 1;
+                }
+            } else if(facility.fiscalYearCalendarEnd) {
+                //fiscal year ends in the fiscalYearMonth
+                if(facility.fiscalYearMonth){
+                    if(this.latestDataAllEntries.getMonth() === (facility.fiscalYearMonth - 1 + 12) % 12) {
+                        this.latestCompleteYear = this.latestDataAllEntries.getFullYear();
+                    } else {
+                        this.latestCompleteYear = this.latestDataAllEntries.getFullYear() - 1;
+                    }
+                }
+            } else if(!facility.fiscalYearCalendarEnd){
+                //fiscal year starts in the fiscalYearMonth
+                if(facility.fiscalYearMonth){
+                    if(this.latestDataAllEntries.getMonth() === (facility.fiscalYearMonth - 2 + 12) % 12) {
+                        this.latestCompleteYear = this.latestDataAllEntries.getFullYear();
+                    } else {
+                        this.latestCompleteYear = this.latestDataAllEntries.getFullYear() - 1;
+                    }
+                }
+            }
+        } else {
+            this.latestCompleteYear = undefined;
+        }
     }
 
     /**

--- a/src/app/calculations/status-check-calculations/facilityStatusCheck.ts
+++ b/src/app/calculations/status-check-calculations/facilityStatusCheck.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { CalanderizedMeter } from "src/app/models/calanderization";
+import { CalanderizedMeter, MonthlyData } from "src/app/models/calanderization";
 import { IdbAnalysisItem } from "src/app/models/idbModels/analysisItem";
 import { IdbFacility } from "src/app/models/idbModels/facility";
 import { IdbPredictor } from "src/app/models/idbModels/predictor";
@@ -68,7 +68,7 @@ export class FacilityStatusCheck {
         this.hasNoMeterData = facilityMeterData.length === 0;
         this.hasNoMeterGroups = !this.hasNoMeters && facilityMeterGroups.length === 0;
         this.hasNoPredictors = facilityPredictors.length === 0;
-        this.facilityLatestEntry = this.computeFacilityLatestEntry(facilityMeterData);
+        this.facilityLatestEntry = this.computeFacilityLatestEntry(facilityCalanderizedMeters);
 
         this.setMetersStatusChecks(facilityMeters, facilityCalanderizedMeters, facilityMeterData);
         this.setMetersStatus();
@@ -91,10 +91,11 @@ export class FacilityStatusCheck {
         return actions;
     }
 
-    private computeFacilityLatestEntry(utilityMeterData: Array<IdbUtilityMeterData>): { month: number; year: number, date: Date } | undefined {
-        if (!utilityMeterData || utilityMeterData.length === 0) return undefined;
-        const latest = _.maxBy(utilityMeterData, d => d.year * 12 + d.month);
-        return latest ? { month: latest.month, year: latest.year, date: new Date(latest.year, latest.month - 1) } : undefined;
+    private computeFacilityLatestEntry(calanderizedMeters: Array<CalanderizedMeter>): { month: number; year: number, date: Date } | undefined {
+        if (!calanderizedMeters || calanderizedMeters.length === 0) return undefined;
+        const allMonthlyData: Array<MonthlyData> = calanderizedMeters.flatMap(cm => cm.monthlyData);
+        const latest = _.maxBy(allMonthlyData, d => d.year * 12 + d.monthNumValue);
+        return latest ? { month: latest.monthNumValue, year: latest.year, date: new Date(latest.year, latest.monthNumValue) } : undefined;
     }
 
     private setMetersStatusChecks(meters: Array<IdbUtilityMeter>, calanderizedMeters: Array<CalanderizedMeter>, utilityMeterData: Array<IdbUtilityMeterData>) {
@@ -226,11 +227,8 @@ export class FacilityStatusCheck {
         return errors ?? emptyFacilityReportErrors();
     }
 
-    getAnalysisStatusById(analysisId: string, accountLatestDataDate?: Date): AnalysisStatusCheck | undefined {
+    getAnalysisStatusById(analysisId: string): AnalysisStatusCheck | undefined {
         const analysisStatusCheck: AnalysisStatusCheck = this.analysisStatusChecks.find(asc => asc.analysisItem.guid === analysisId);
-        if (analysisStatusCheck && accountLatestDataDate) {
-            analysisStatusCheck.setIsDateCurrentWithAccountAnalysis(accountLatestDataDate);
-        }
         return analysisStatusCheck;
     }
 

--- a/src/app/calculations/status-check-calculations/facilityStatusCheck.ts
+++ b/src/app/calculations/status-check-calculations/facilityStatusCheck.ts
@@ -95,7 +95,7 @@ export class FacilityStatusCheck {
         if (!calanderizedMeters || calanderizedMeters.length === 0) return undefined;
         const allMonthlyData: Array<MonthlyData> = calanderizedMeters.flatMap(cm => cm.monthlyData);
         const latest = _.maxBy(allMonthlyData, d => d.year * 12 + d.monthNumValue);
-        return latest ? { month: latest.monthNumValue, year: latest.year, date: new Date(latest.year, latest.monthNumValue) } : undefined;
+        return latest ? { month: latest.monthNumValue + 1, year: latest.year, date: new Date(latest.year, latest.monthNumValue) } : undefined;
     }
 
     private setMetersStatusChecks(meters: Array<IdbUtilityMeter>, calanderizedMeters: Array<CalanderizedMeter>, utilityMeterData: Array<IdbUtilityMeterData>) {

--- a/src/app/calculations/status-check-calculations/facilityStatusCheck.ts
+++ b/src/app/calculations/status-check-calculations/facilityStatusCheck.ts
@@ -43,7 +43,6 @@ export class FacilityStatusCheck {
 
     facilityLatestEntry: { month: number; year: number, date: Date } | undefined;
     facilityReportErrors: Array<FacilityReportErrors>;
-
     constructor(
         facility: IdbFacility,
         calanderizedMeters: Array<CalanderizedMeter>,
@@ -227,8 +226,12 @@ export class FacilityStatusCheck {
         return errors ?? emptyFacilityReportErrors();
     }
 
-    getAnalysisStatusById(analysisId: string): AnalysisStatusCheck | undefined {
-        return this.analysisStatusChecks.find(asc => asc.analysisItem.guid === analysisId);
+    getAnalysisStatusById(analysisId: string, accountLatestDataDate?: Date): AnalysisStatusCheck | undefined {
+        const analysisStatusCheck: AnalysisStatusCheck = this.analysisStatusChecks.find(asc => asc.analysisItem.guid === analysisId);
+        if (analysisStatusCheck && accountLatestDataDate) {
+            analysisStatusCheck.setIsDateCurrentWithAccountAnalysis(accountLatestDataDate);
+        }
+        return analysisStatusCheck;
     }
 
     getGroupStatusChecksByGroupId(groupId: string, analysisId: string): AnalysisGroupStatusCheck | undefined {

--- a/src/app/calculations/status-check-calculations/facilityStatusCheck.ts
+++ b/src/app/calculations/status-check-calculations/facilityStatusCheck.ts
@@ -41,8 +41,7 @@ export class FacilityStatusCheck {
     hasPredictorWeatherWarnings: boolean;
     hasInvalidMeters: boolean;
 
-    facilityLatestEntry: { month: number; year: number } | undefined;
-
+    facilityLatestEntry: { month: number; year: number, date: Date } | undefined;
     facilityReportErrors: Array<FacilityReportErrors>;
 
     constructor(
@@ -93,10 +92,10 @@ export class FacilityStatusCheck {
         return actions;
     }
 
-    private computeFacilityLatestEntry(utilityMeterData: Array<IdbUtilityMeterData>): { month: number; year: number } | undefined {
+    private computeFacilityLatestEntry(utilityMeterData: Array<IdbUtilityMeterData>): { month: number; year: number, date: Date } | undefined {
         if (!utilityMeterData || utilityMeterData.length === 0) return undefined;
         const latest = _.maxBy(utilityMeterData, d => d.year * 12 + d.month);
-        return latest ? { month: latest.month, year: latest.year } : undefined;
+        return latest ? { month: latest.month, year: latest.year, date: new Date(latest.year, latest.month - 1) } : undefined;
     }
 
     private setMetersStatusChecks(meters: Array<IdbUtilityMeter>, calanderizedMeters: Array<CalanderizedMeter>, utilityMeterData: Array<IdbUtilityMeterData>) {

--- a/src/app/calculations/status-check-calculations/meterStatusCheck.ts
+++ b/src/app/calculations/status-check-calculations/meterStatusCheck.ts
@@ -34,7 +34,7 @@ export class MeterStatusCheck {
         this.hasNoData = meterReadings.length === 0;
         this.hasNoCalendarizationMethod = !meter.meterReadingDataApplication;
         this.setHasNegativeReadings(meterReadings);
-        this.latestFacilityEntryDate = facilityLatestEntry ? new Date(facilityLatestEntry.year, facilityLatestEntry.month - 1) : undefined;
+        this.latestFacilityEntryDate = facilityLatestEntry ? new Date(facilityLatestEntry.year, facilityLatestEntry.month - 1, 1) : undefined;
         if (calanderizedMeter) {
             this.isMeterValid = isMeterInvalid(calanderizedMeter.meter) == false;
             this.setLastDateEntry(calanderizedMeter.monthlyData);

--- a/src/app/calculations/status-check-calculations/meterStatusCheck.ts
+++ b/src/app/calculations/status-check-calculations/meterStatusCheck.ts
@@ -1,4 +1,4 @@
-import { CalanderizedMeter } from "src/app/models/calanderization";
+import { CalanderizedMeter, MonthlyData } from "src/app/models/calanderization";
 import { IdbUtilityMeter } from "src/app/models/idbModels/utilityMeter";
 import * as _ from 'lodash';
 import { IdbUtilityMeterData } from "src/app/models/idbModels/utilityMeterData";
@@ -37,7 +37,7 @@ export class MeterStatusCheck {
         this.latestFacilityEntryDate = facilityLatestEntry ? new Date(facilityLatestEntry.year, facilityLatestEntry.month - 1) : undefined;
         if (calanderizedMeter) {
             this.isMeterValid = isMeterInvalid(calanderizedMeter.meter) == false;
-            this.setLastDateEntry(meterReadings);
+            this.setLastDateEntry(calanderizedMeter.monthlyData);
             this.setHasDuplicateEntries(meterReadings);
         } else {
             this.isMeterValid = true;
@@ -49,10 +49,10 @@ export class MeterStatusCheck {
         this.setActions(meter, facilityLatestEntry);
     }
 
-    private setLastDateEntry(meterReadings: Array<IdbUtilityMeterData>) {
-        if (meterReadings && meterReadings.length > 0) {
-            let lastEntry: IdbUtilityMeterData = _.maxBy(meterReadings, (data: IdbUtilityMeterData) => new Date(data.year, data.month - 1, data.day));
-            this.lastDateEntry = new Date(lastEntry.year, lastEntry.month - 1, lastEntry.day);
+    private setLastDateEntry(calanderizedMeterData: Array<MonthlyData>) {
+        if (calanderizedMeterData && calanderizedMeterData.length > 0) {
+            let lastEntry: MonthlyData = _.maxBy(calanderizedMeterData, (data: MonthlyData) => new Date(data.year, data.monthNumValue, 1));
+            this.lastDateEntry = new Date(lastEntry.year, lastEntry.monthNumValue, 1);
         }
     }
 

--- a/src/app/data-evaluation/account/account-analysis/account-analysis-banner/account-analysis-banner.component.html
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-banner/account-analysis-banner.component.html
@@ -18,7 +18,9 @@
         <a class="nav-link" routerLink="select-items" [routerLinkActive]="['active']">
           <i class="fa fa-list-check"></i>
           Select Facility Items
-          @if (_analysisStatusCheck.accountAnalysisSetupErrors.facilitiesSelectionsInvalid || !_analysisStatusCheck.allDatesCurrent) {
+          <!--'warning' = warnings in facilities-->
+          @if (_analysisStatusCheck.accountAnalysisSetupErrors.facilitiesSelectionsInvalid ||
+          _analysisStatusCheck.facilityAnalysisHasWarnings) {
           <span class="fa fa-exclamation-triangle text-warning"></span>
           }
         </a>

--- a/src/app/data-evaluation/account/account-analysis/account-analysis-banner/account-analysis-banner.component.html
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-banner/account-analysis-banner.component.html
@@ -1,26 +1,29 @@
-@if (!inDashboard) {
-<div class="analysis banner sticky-top d-flex justify-content-between" [ngClass]="{'modal-open': modalOpen}">
+@let _analysisStatusCheck = analysisStatusCheck();
+@let _accountAnalysisItem = accountAnalysisItem();
+
+@if (!inDashboard() && _accountAnalysisItem && _analysisStatusCheck) {
+<div class="analysis banner sticky-top d-flex justify-content-between" [ngClass]="{'modal-open': modalOpen()}">
   <div>
-    @let setupErrors = accountAnalysisItem.guid | invalidAccountAnalysis;
     <ul class="nav nav-tabs">
       <li class="nav-item">
         <a class="nav-link" routerLink="setup" [routerLinkActive]="['active']">
-          @if (setupErrors.hasSetupErrors) {
-          <span class="fa fa-exclamation-circle"></span>
-          }
           <i class="fa fa-gears"></i>
-          Analysis Setup</a>
-      </li>
-      <li class="nav-item" [ngClass]="{'disabled': setupErrors.hasSetupErrors}">
-        <a class="nav-link" routerLink="select-items" [routerLinkActive]="['active']">
-          @if (setupErrors.facilitiesSelectionsInvalid) {
-          <span class="fa fa-exclamation-circle"></span>
+          Analysis Setup
+          @if (_analysisStatusCheck.accountAnalysisSetupErrors.hasSetupErrors) {
+          <span class="fa fa-exclamation-triangle text-warning"></span>
           }
-          <i class="fa fa-list-check"></i>
-          Select Facility Items</a>
+        </a>
       </li>
-      <li class="nav-item"
-        [ngClass]="{'disabled': setupErrors.hasError}">
+      <li class="nav-item" [ngClass]="{'disabled': _analysisStatusCheck.accountAnalysisSetupErrors.hasSetupErrors}">
+        <a class="nav-link" routerLink="select-items" [routerLinkActive]="['active']">
+          <i class="fa fa-list-check"></i>
+          Select Facility Items
+          @if (_analysisStatusCheck.accountAnalysisSetupErrors.facilitiesSelectionsInvalid || !_analysisStatusCheck.allDatesCurrent) {
+          <span class="fa fa-exclamation-triangle text-warning"></span>
+          }
+        </a>
+      </li>
+      <li class="nav-item" [ngClass]="{'disabled': _analysisStatusCheck.accountAnalysisSetupErrors.hasError}">
         <a class="nav-link" routerLink="results" [routerLinkActive]="['active']">
           <i class="fa fa-magnifying-glass-chart"></i>
           Analysis Results</a>
@@ -32,19 +35,19 @@
       <ul class="nav nav-tabs">
         <li class="nav-item dropdown">
           <a class="nav-link home-link dropdown-toggle" (click)="toggleShow()">
-            @if (accountAnalysisItem.analysisCategory == 'water') {
+            @if (_accountAnalysisItem.analysisCategory == 'water') {
             <i class="fa fa-droplet"></i>
             }
-            @if (accountAnalysisItem.analysisCategory == 'energy') {
+            @if (_accountAnalysisItem.analysisCategory == 'energy') {
             <i class="fa fa-plug"></i>
             }
-            {{accountAnalysisItem.name}}
+            {{_accountAnalysisItem.name}}
           </a>
           <ul class="dropdown-menu" [ngClass]="{'show': showDropdown}">
             <div class="menu-scroll-section">
-              @for (analysisItemOption of accountAnalysisItems; track analysisItemOption) {
-              @if (accountAnalysisItem.guid != analysisItemOption.guid && analysisItemOption.analysisCategory ==
-              accountAnalysisItem.analysisCategory) {
+              @for (analysisItemOption of accountAnalysisItems(); track analysisItemOption) {
+              @if (_accountAnalysisItem.guid != analysisItemOption.guid && analysisItemOption.analysisCategory ==
+              _accountAnalysisItem.analysisCategory) {
               <li>
                 <a class="dropdown-item" (click)="selectItem(analysisItemOption)">
                   @if (analysisItemOption.analysisCategory == 'water') {

--- a/src/app/data-evaluation/account/account-analysis/account-analysis-banner/account-analysis-banner.component.ts
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-banner/account-analysis-banner.component.ts
@@ -1,73 +1,72 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, computed, effect, inject, Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { NavigationEnd, Router } from '@angular/router';
-import { Subscription } from 'rxjs';
+import { filter, map, startWith } from 'rxjs';
+import { AccountAnalysisStatusCheck } from 'src/app/calculations/status-check-calculations/accountAnalysisStatusCheck';
+import { AccountStatusCheck } from 'src/app/calculations/status-check-calculations/accountStatusCheck';
 import { AccountAnalysisDbService } from 'src/app/indexedDB/account-analysis-db.service';
 import { IdbAccountAnalysisItem } from 'src/app/models/idbModels/accountAnalysisItem';
+import { AccountStatusCheckService } from 'src/app/shared/helper-services/account-status-check.service';
 import { SharedDataService } from 'src/app/shared/helper-services/shared-data.service';
 
 @Component({
-    selector: 'app-account-analysis-banner',
-    templateUrl: './account-analysis-banner.component.html',
-    styleUrls: ['./account-analysis-banner.component.css'],
-    standalone: false
+  selector: 'app-account-analysis-banner',
+  templateUrl: './account-analysis-banner.component.html',
+  styleUrls: ['./account-analysis-banner.component.css'],
+  standalone: false
 })
-export class AccountAnalysisBannerComponent implements OnInit {
+export class AccountAnalysisBannerComponent {
+  private router: Router = inject(Router);
+  private sharedDataService: SharedDataService = inject(SharedDataService);
+  private accountAnalysisDbService: AccountAnalysisDbService = inject(AccountAnalysisDbService);
+  private accountStatusCheckService: AccountStatusCheckService = inject(AccountStatusCheckService);
 
-  inDashboard: boolean;
-  modalOpenSub: Subscription;
-  modalOpen: boolean;
+  modalOpen: Signal<boolean> = toSignal(this.sharedDataService.modalOpen);
+  accountAnalysisItem: Signal<IdbAccountAnalysisItem> = toSignal(this.accountAnalysisDbService.selectedAnalysisItem);
+  accountAnalysisItems: Signal<Array<IdbAccountAnalysisItem>> = toSignal(this.accountAnalysisDbService.accountAnalysisItems);
+  accountStatusCheck: Signal<AccountStatusCheck> = toSignal(this.accountStatusCheckService.accountStatusCheck);
 
-  accountAnalysisItem: IdbAccountAnalysisItem;
-  accountAnalysisItemSub: Subscription;
-  routerSub: Subscription;
+  inDashboard: Signal<boolean> = computed(() => {
+    const url = this.url();
+    return url.includes('dashboard') || (url == '/data-evaluation/account/analysis');
+  });
+  
+  url: Signal<string> = toSignal(
+    this.router.events.pipe(
+      filter(event => event instanceof NavigationEnd),
+      map(() => this.router.url),
+      startWith(this.router.url)
+    ),
+    { initialValue: this.router.url }
+  );
 
-  accountAnalysisItems: Array<IdbAccountAnalysisItem>;
-  accountAnalysisItemsSub: Subscription;
+  analysisStatusCheck: Signal<AccountAnalysisStatusCheck> = computed(() => {
+    const accountAnalysisItem = this.accountAnalysisItem();
+    const accountStatusCheck = this.accountStatusCheck();
+    if(accountAnalysisItem && accountStatusCheck) {
+      return accountStatusCheck.getAccountAnalysisStatusCheckById(accountAnalysisItem.guid);
+    }
+    return undefined;
+  });
+
   showDropdown: boolean = false;
-  constructor(private router: Router,
-    private sharedDataService: SharedDataService, private accountAnalysisDbService: AccountAnalysisDbService) { }
 
-  ngOnInit(): void {
-    this.routerSub = this.router.events.subscribe(event => {
-      if (event instanceof NavigationEnd) {
-        this.setInDashboard(event.url);
-      }
+  constructor() {
+    effect(() => {
+      const url = this.url();
       this.showDropdown = false;
-    });
-    this.setInDashboard(this.router.url);
-    this.modalOpenSub = this.sharedDataService.modalOpen.subscribe(val => {
-      this.modalOpen = val;
-    });
-
-    this.accountAnalysisItemSub = this.accountAnalysisDbService.selectedAnalysisItem.subscribe(val => {
-      this.accountAnalysisItem = val;
-    });
-
-    this.accountAnalysisItemsSub = this.accountAnalysisDbService.accountAnalysisItems.subscribe(items => {
-      this.accountAnalysisItems = items;
-    });
-  }
-
-  ngOnDestroy() {
-    this.accountAnalysisItemSub.unsubscribe();
-    this.modalOpenSub.unsubscribe();
-    this.routerSub.unsubscribe();
-    this.accountAnalysisItemsSub.unsubscribe();
-  }
-
-  setInDashboard(url: string) {
-    this.inDashboard = url.includes('dashboard') || (url == '/data-evaluation/account/analysis');
+    })
   }
 
   goToDashboard() {
     this.router.navigateByUrl('/data-evaluation/account/analysis/dashboard')
   }
 
-  toggleShow(){
+  toggleShow() {
     this.showDropdown = !this.showDropdown;
   }
 
-  selectItem(item: IdbAccountAnalysisItem){
+  selectItem(item: IdbAccountAnalysisItem) {
     this.accountAnalysisDbService.selectedAnalysisItem.next(item);
     this.router.navigateByUrl('/data-evaluation/account/analysis/setup');
   }

--- a/src/app/data-evaluation/account/account-analysis/account-analysis-dashboard/account-analysis-details-table/account-analysis-details-table.component.css
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-dashboard/account-analysis-details-table/account-analysis-details-table.component.css
@@ -32,27 +32,32 @@ thead th.can-click:hover {
     color: red;
 }
 
-.fa-circle-check,
-.fa-circle {
+.selection-star {
     font-size: 18px;
-}
-
-.fa-circle-check {
-    color: green;
-}
-
-
-.fa-circle {
-    color: lightgray;
-}
-
-.fa-circle:hover {
-    color: gray;
     cursor: pointer;
+    transition: opacity 0.15s ease;
 }
 
-.fa-circle-check:hover {
-    cursor: pointer;
+.selection-star:hover {
+    opacity: 0.7;
+}
+
+.status-col {
+    width: 80px;
+    min-width: 80px;
+}
+
+.analysis-row-warning td {
+    background-color: rgba(255, 193, 7, 0.08) !important;
+}
+
+.analysis-row-error td {
+    background-color: rgba(220, 53, 69, 0.08) !important;
+}
+
+.issue-badge {
+    font-size: 0.7rem;
+    white-space: nowrap;
 }
 
 .icon-style {
@@ -65,14 +70,6 @@ thead th.can-click:hover {
 
 .select-width{
     width: 200px;
-}
-
-.water.fa-circle-check{
-    color: #3055cf;
-}
-
-.energy.fa-circle-check{
-    color: #339d16;
 }
 
 button:hover .fa-trash {

--- a/src/app/data-evaluation/account/account-analysis/account-analysis-dashboard/account-analysis-details-table/account-analysis-details-table.component.html
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-dashboard/account-analysis-details-table/account-analysis-details-table.component.html
@@ -52,6 +52,7 @@
           @if (!showDeleteColumn) {
           <th></th>
           }
+          <th class="status-col text-center">Status</th>
           <th class="can-click" (click)="setOrderDataField('name')" [ngClass]="{'active': _orderDataField == 'name'}">
             Analysis Item
           </th>
@@ -75,7 +76,11 @@
       <tbody>
         @for (item of _orderedAnalysisListItems | slice: ((currentPageNumber-1) * _itemsPerPage): currentPageNumber *
         _itemsPerPage; track item.analysisItem.guid) {
-        <tr>
+        @let sc = item.accountAnalysisStatusCheck;
+        <tr [ngClass]="{
+            'analysis-row-error': sc?.status === 'error',
+            'analysis-row-warning': sc?.status === 'warning'
+          }">
           @if(showDeleteColumn) {
           <td class="input text-center">
             <input type="checkbox" name="analysisSelected" [checked]="checkedGuids().has(item.analysisItem.guid)"
@@ -85,23 +90,42 @@
           @if(!showDeleteColumn) {
           <td class="text-center">
             @if (item.analysisItem.analysisCategory == 'energy') {
-            <span class="energy fa"
-              [ngClass]="{'fa-circle-check': item.analysisItem.guid == _selectedAccount.selectedEnergyAnalysisId, 'fa-circle':item.analysisItem.guid != _selectedAccount.selectedEnergyAnalysisId}"
+            <span class="fa fa-star selection-star"
+              [ngClass]="{'text-warning': item.analysisItem.guid == _selectedAccount.selectedEnergyAnalysisId, 'text-muted': item.analysisItem.guid != _selectedAccount.selectedEnergyAnalysisId}"
+              [title]="item.analysisItem.guid == _selectedAccount.selectedEnergyAnalysisId ? 'Active energy analysis' : 'Set as active energy analysis'"
               (click)="setUseItem(item.analysisItem)"></span>
             }
             @if (item.analysisItem.analysisCategory == 'water') {
-            <span class="water fa"
-              [ngClass]="{'fa-circle-check': item.analysisItem.guid == _selectedAccount.selectedWaterAnalysisId, 'fa-circle':item.analysisItem.guid != _selectedAccount.selectedWaterAnalysisId}"
+            <span class="fa fa-star selection-star"
+              [ngClass]="{'text-info': item.analysisItem.guid == _selectedAccount.selectedWaterAnalysisId, 'text-muted': item.analysisItem.guid != _selectedAccount.selectedWaterAnalysisId}"
+              [title]="item.analysisItem.guid == _selectedAccount.selectedWaterAnalysisId ? 'Active water analysis' : 'Set as active water analysis'"
               (click)="setUseItem(item.analysisItem)"></span>
             }
           </td>
           }
-          <td>
-            @let setupErrors = item.analysisItem.guid | invalidAccountAnalysis;
-            <a (click)="selectAnalysisItem(item.analysisItem, setupErrors)">
-              @if (setupErrors.hasError || setupErrors.facilitiesSelectionsInvalid) {
-              <span class="me-2 fa fa-exclamation-circle error-icon"></span>
+          <!-- Status column -->
+          <td class="text-center align-middle status-col">
+            <span class="fa fa-fw fa-lg" [ngClass]="{
+              'fa-circle-check text-success': sc?.status === 'good',
+              'fa-exclamation-triangle text-warning': sc?.status === 'warning',
+              'fa-circle-xmark text-danger': sc?.status === 'error'
+            }"></span>
+            @if (sc?.status === 'warning' || sc?.status === 'error') {
+            <div class="d-flex flex-column gap-1 mt-1 align-items-center">
+              @if (sc?.accountAnalysisSetupErrors?.hasSetupErrors) {
+              <span class="badge bg-danger issue-badge">Setup Errors</span>
               }
+              @if (sc?.accountAnalysisSetupErrors?.facilitiesSelectionsInvalid) {
+              <span class="badge bg-danger issue-badge">Selection Errors</span>
+              }
+              @if (!sc?.allDatesCurrent && sc?.status === 'warning') {
+              <span class="badge bg-warning text-dark issue-badge">Data Outdated</span>
+              }
+            </div>
+            }
+          </td>
+          <td>
+            <a (click)="selectAnalysisItem(item.analysisItem, sc)">
               {{item.analysisItem.name}}
             </a>
           </td>
@@ -144,10 +168,10 @@
   </div>
   <div class="d-flex justify-content-between align-items-center">
     <div class="icon-text">
-      <span class="energy fa fa-circle-check"></span> Denotes selected energy analysis.<br>
-      <span class="water fa fa-circle-check"></span> Denotes selected water analysis.
+      <span class="fa fa-star text-warning"></span> Denotes active energy analysis.<br>
+      <span class="fa fa-star text-info"></span> Denotes active water analysis.
       <p class="fw-light pt-2 italic mb-0">
-        The selected analysis is used to track progress towards your goals and for reporting.
+        The active analysis is used to track progress towards your goals and for reporting.
       </p>
     </div>
     <div>

--- a/src/app/data-evaluation/account/account-analysis/account-analysis-dashboard/account-analysis-details-table/account-analysis-details-table.component.html
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-dashboard/account-analysis-details-table/account-analysis-details-table.component.html
@@ -118,8 +118,8 @@
               @if (sc?.accountAnalysisSetupErrors?.facilitiesSelectionsInvalid) {
               <span class="badge bg-danger issue-badge">Selection Errors</span>
               }
-              @if (!sc?.allDatesCurrent && sc?.status === 'warning') {
-              <span class="badge bg-warning text-dark issue-badge">Data Outdated</span>
+              @if (sc?.facilityAnalysisHasWarnings) {
+              <span class="badge bg-warning text-dark issue-badge">Facility Warnings</span>
               }
             </div>
             }

--- a/src/app/data-evaluation/account/account-analysis/account-analysis-dashboard/account-analysis-details-table/account-analysis-details-table.component.ts
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-dashboard/account-analysis-details-table/account-analysis-details-table.component.ts
@@ -10,19 +10,22 @@ import { AccountAnalysisDbService } from 'src/app/indexedDB/account-analysis-db.
 import { AccountdbService } from 'src/app/indexedDB/account-db.service';
 import { AccountReportDbService } from 'src/app/indexedDB/account-report-db.service';
 import { DbChangesService } from 'src/app/indexedDB/db-changes.service';
-import { AccountAnalysisSetupErrors } from 'src/app/models/accountAnalysis';
 import { CalanderizedMeter } from 'src/app/models/calanderization';
 import { IdbAccount } from 'src/app/models/idbModels/account';
 import { IdbAccountAnalysisItem } from 'src/app/models/idbModels/accountAnalysisItem';
 import { IdbAccountReport } from 'src/app/models/idbModels/accountReport';
+import { AccountAnalysisStatusCheck } from 'src/app/calculations/status-check-calculations/accountAnalysisStatusCheck';
+import { AccountStatusCheck } from 'src/app/calculations/status-check-calculations/accountStatusCheck';
 import { CalanderizationService } from 'src/app/shared/helper-services/calanderization.service';
 import { SharedDataService } from 'src/app/shared/helper-services/shared-data.service';
+import { AccountStatusCheckService } from 'src/app/shared/helper-services/account-status-check.service';
 import { getIsEnergyMeter } from 'src/app/shared/sharedHelperFunctions';
 
 interface AnalysisDetailsTableRow {
   analysisItem: IdbAccountAnalysisItem,
   isDeleteChecked: boolean,
-  linkedReports: Array<string>
+  linkedReports: Array<string>,
+  accountAnalysisStatusCheck: AccountAnalysisStatusCheck | undefined
 }
 
 @Component({
@@ -41,11 +44,13 @@ export class AccountAnalysisDetailsTableComponent {
   private sharedDataService: SharedDataService = inject(SharedDataService);
   private calanderizationService: CalanderizationService = inject(CalanderizationService);
   private loadingService: LoadingService = inject(LoadingService);
+  private accountStatusCheckService: AccountStatusCheckService = inject(AccountStatusCheckService);
 
   selectedAccount: Signal<IdbAccount> = toSignal(this.accountDbService.selectedAccount);
   calanderizedMeters: Signal<Array<CalanderizedMeter>> = toSignal(this.calanderizationService.calanderizedMeters);
   accountAnalysisItems: Signal<Array<IdbAccountAnalysisItem>> = toSignal(this.accountAnalysisDbService.accountAnalysisItems);
   accountReports: Signal<Array<IdbAccountReport>> = toSignal(this.accountReportDbService.accountReports);
+  accountStatusCheck: Signal<AccountStatusCheck> = toSignal(this.accountStatusCheckService.accountStatusCheck);
   itemsPerPage: Signal<number> = toSignal(this.sharedDataService.itemsPerPage);
 
   selectedAnalysisCategory: WritableSignal<'energy' | 'water' | 'all'> = signal('all');
@@ -105,6 +110,7 @@ export class AccountAnalysisDetailsTableComponent {
     const selectedAnalysisCategory = this.selectedAnalysisCategory();
     const accountReports = this.accountReports();
     const accountAnalysisItems = this.accountAnalysisItems();
+    const accountStatusCheck = this.accountStatusCheck();
     if (selectedAnalysisCategory && accountReports && accountAnalysisItems) {
       let analysisItemsList: Array<AnalysisDetailsTableRow> = [];
       let filteredAnalysisItems: Array<IdbAccountAnalysisItem> = accountAnalysisItems.filter(item => selectedAnalysisCategory == 'all' || item.analysisCategory == selectedAnalysisCategory);
@@ -117,10 +123,12 @@ export class AccountAnalysisDetailsTableComponent {
             (report.reportType == 'analysis' && report.analysisReportSetup.analysisItemId == analysisItem.guid);
         }).map(report => report.guid);
 
+        const accountAnalysisStatusCheck = accountStatusCheck?.getAccountAnalysisStatusCheckById(analysisItem.guid);
         analysisItemsList.push({
           analysisItem: analysisItem,
           isDeleteChecked: false,
-          linkedReports: linkedReports
+          linkedReports: linkedReports,
+          accountAnalysisStatusCheck: accountAnalysisStatusCheck
         });
       });
       return analysisItemsList;
@@ -214,9 +222,10 @@ export class AccountAnalysisDetailsTableComponent {
     }
   }
 
-  selectAnalysisItem(analysisItem: IdbAccountAnalysisItem, setupErrors: AccountAnalysisSetupErrors) {
+  selectAnalysisItem(analysisItem: IdbAccountAnalysisItem, accountAnalysisStatusCheck: AccountAnalysisStatusCheck | undefined) {
     this.accountAnalysisDbService.selectedAnalysisItem.next(analysisItem);
-    if (setupErrors.hasError || setupErrors.facilitiesSelectionsInvalid) {
+    const setupErrors = accountAnalysisStatusCheck?.accountAnalysisSetupErrors;
+    if (setupErrors?.hasError || setupErrors?.facilitiesSelectionsInvalid) {
       this.router.navigateByUrl('/data-evaluation/account/analysis/setup');
     } else {
       this.router.navigateByUrl('/data-evaluation/account/analysis/results');

--- a/src/app/data-evaluation/account/account-analysis/account-analysis-footer/account-analysis-footer.component.css
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-footer/account-analysis-footer.component.css
@@ -8,3 +8,7 @@
     padding: .5rem;
     font-weight: bold;
 }
+
+.badge{
+    font-size: 15px;
+}

--- a/src/app/data-evaluation/account/account-analysis/account-analysis-footer/account-analysis-footer.component.html
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-footer/account-analysis-footer.component.html
@@ -6,7 +6,7 @@
       <button class="btn" (click)="goBack()"><span class="fa fa-chevron-left pe-1"></span>Back</button>
     </div>
     <div>
-      <div class="badge bg-primary">
+      <div class="badge bg-dark">
         @if(account()?.fiscalYear == 'calendarYear') {
         Latest Complete Year: {{analysisStatusCheck()?.latestCompleteYear}}
         }@else{

--- a/src/app/data-evaluation/account/account-analysis/account-analysis-footer/account-analysis-footer.component.html
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-footer/account-analysis-footer.component.html
@@ -1,14 +1,15 @@
-@if (!inDashboard) {
-  <div class="fixed-bottom footer-nav pb-3" [ngStyle]="{'right.px': helpWidth, 'left.px': sidebarWidth}">
+@let _canContinue = canContinue();
+@if (!inDashboard()) {
+  <div class="fixed-bottom footer-nav pb-3" [ngStyle]="{'right.px': helpWidth(), 'left.px': sidebarWidth()}">
     <div class="d-flex flex-fill justify-content-between pe-3 ps-3">
       <div>
         <button class="btn" (click)="goBack()"><span class="fa fa-chevron-left pe-1"></span>Back</button>
       </div>
       <div>
-        @if (showContinue) {
-          <button class="btn" (click)="continue()">Continue<span class="fa fa-chevron-right ps-1"></span></button>
+        @if (showContinue()) {
+          <button class="btn" (click)="continue()" [disabled]="!_canContinue">Continue<span class="fa fa-chevron-right ps-1"></span></button>
         }
-        @if (!showContinue) {
+        @if (!showContinue()) {
           <button class="btn" (click)="returnToDashboard()">
             <i class="fa fa-list"></i> All Account Analysis
           </button>

--- a/src/app/data-evaluation/account/account-analysis/account-analysis-footer/account-analysis-footer.component.html
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-footer/account-analysis-footer.component.html
@@ -1,20 +1,30 @@
 @let _canContinue = canContinue();
 @if (!inDashboard()) {
-  <div class="fixed-bottom footer-nav pb-3" [ngStyle]="{'right.px': helpWidth(), 'left.px': sidebarWidth()}">
-    <div class="d-flex flex-fill justify-content-between pe-3 ps-3">
-      <div>
-        <button class="btn" (click)="goBack()"><span class="fa fa-chevron-left pe-1"></span>Back</button>
-      </div>
-      <div>
-        @if (showContinue()) {
-          <button class="btn" (click)="continue()" [disabled]="!_canContinue">Continue<span class="fa fa-chevron-right ps-1"></span></button>
-        }
-        @if (!showContinue()) {
-          <button class="btn" (click)="returnToDashboard()">
-            <i class="fa fa-list"></i> All Account Analysis
-          </button>
+<div class="fixed-bottom footer-nav pb-3" [ngStyle]="{'right.px': helpWidth(), 'left.px': sidebarWidth()}">
+  <div class="d-flex flex-fill justify-content-between pe-3 ps-3">
+    <div>
+      <button class="btn" (click)="goBack()"><span class="fa fa-chevron-left pe-1"></span>Back</button>
+    </div>
+    <div>
+      <div class="badge bg-primary">
+        @if(account()?.fiscalYear == 'calendarYear') {
+        Latest Complete Year: {{analysisStatusCheck()?.latestCompleteYear}}
+        }@else{
+        Latest Complete FY: {{analysisStatusCheck()?.latestCompleteYear}}
         }
       </div>
     </div>
+    <div>
+      @if (showContinue()) {
+      <button class="btn" (click)="continue()" [disabled]="!_canContinue">Continue<span
+          class="fa fa-chevron-right ps-1"></span></button>
+      }
+      @if (!showContinue()) {
+      <button class="btn" (click)="returnToDashboard()">
+        <i class="fa fa-list"></i> All Account Analysis
+      </button>
+      }
+    </div>
   </div>
+</div>
 }

--- a/src/app/data-evaluation/account/account-analysis/account-analysis-footer/account-analysis-footer.component.ts
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-footer/account-analysis-footer.component.ts
@@ -12,6 +12,8 @@ import { AnalysisStatusCheck } from 'src/app/calculations/status-check-calculati
 import { AccountStatusCheckService } from 'src/app/shared/helper-services/account-status-check.service';
 import { AccountStatusCheck } from 'src/app/calculations/status-check-calculations/accountStatusCheck';
 import { AccountAnalysisStatusCheck } from 'src/app/calculations/status-check-calculations/accountAnalysisStatusCheck';
+import { IdbAccount } from 'src/app/models/idbModels/account';
+import { AccountdbService } from 'src/app/indexedDB/account-db.service';
 
 @Component({
   selector: 'app-account-analysis-footer',
@@ -26,6 +28,7 @@ export class AccountAnalysisFooterComponent {
   private accountAnalysisDbService: AccountAnalysisDbService = inject(AccountAnalysisDbService);
   private dataEvaluationService: DataEvaluationService = inject(DataEvaluationService);
   private accountStatusCheckService: AccountStatusCheckService = inject(AccountStatusCheckService);
+  private accountDbService: AccountdbService = inject(AccountdbService);
 
   helpWidth: Signal<number> = toSignal(this.dataEvaluationService.helpWidthBs);
   sidebarWidth: Signal<number> = toSignal(this.dataEvaluationService.sidebarWidthBs);
@@ -33,6 +36,7 @@ export class AccountAnalysisFooterComponent {
   accountStatusCheck: Signal<AccountStatusCheck> = toSignal(this.accountStatusCheckService.accountStatusCheck);
   selectedFacility: Signal<IdbFacility> = toSignal(this.facilityDbService.selectedFacility);
   facilities: Signal<Array<IdbFacility>> = toSignal(this.facilityDbService.accountFacilities);
+  account: Signal<IdbAccount> = toSignal(this.accountDbService.selectedAccount);
 
   url: Signal<string> = toSignal(
     this.router.events.pipe(

--- a/src/app/data-evaluation/account/account-analysis/account-analysis-footer/account-analysis-footer.component.ts
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-footer/account-analysis-footer.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit } from '@angular/core';
-import { Subscription } from 'rxjs';
+import { Component, computed, inject, OnInit, Signal } from '@angular/core';
+import { filter, map, startWith, Subscription } from 'rxjs';
 import { NavigationEnd, Router } from '@angular/router';
 import { FacilitydbService } from 'src/app/indexedDB/facility-db.service';
 import { AccountAnalysisService } from '../account-analysis.service';
@@ -7,6 +7,11 @@ import { IdbFacility } from 'src/app/models/idbModels/facility';
 import { AccountAnalysisDbService } from 'src/app/indexedDB/account-analysis-db.service';
 import { IdbAccountAnalysisItem } from 'src/app/models/idbModels/accountAnalysisItem';
 import { DataEvaluationService } from 'src/app/data-evaluation/data-evaluation.service';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { AnalysisStatusCheck } from 'src/app/calculations/status-check-calculations/analysisStatusCheck';
+import { AccountStatusCheckService } from 'src/app/shared/helper-services/account-status-check.service';
+import { AccountStatusCheck } from 'src/app/calculations/status-check-calculations/accountStatusCheck';
+import { AccountAnalysisStatusCheck } from 'src/app/calculations/status-check-calculations/accountAnalysisStatusCheck';
 
 @Component({
   selector: 'app-account-analysis-footer',
@@ -14,59 +19,60 @@ import { DataEvaluationService } from 'src/app/data-evaluation/data-evaluation.s
   styleUrls: ['./account-analysis-footer.component.css'],
   standalone: false
 })
-export class AccountAnalysisFooterComponent implements OnInit {
+export class AccountAnalysisFooterComponent {
 
+  private router: Router = inject(Router);
+  private facilityDbService: FacilitydbService = inject(FacilitydbService);
+  private accountAnalysisDbService: AccountAnalysisDbService = inject(AccountAnalysisDbService);
+  private dataEvaluationService: DataEvaluationService = inject(DataEvaluationService);
+  private accountStatusCheckService: AccountStatusCheckService = inject(AccountStatusCheckService);
 
-  routerSub: Subscription;
-  inDashboard: boolean;
-  showContinue: boolean;
-  analysisItem: IdbAccountAnalysisItem;
-  analysisItemSub: Subscription
+  helpWidth: Signal<number> = toSignal(this.dataEvaluationService.helpWidthBs);
+  sidebarWidth: Signal<number> = toSignal(this.dataEvaluationService.sidebarWidthBs);
+  analysisItem: Signal<IdbAccountAnalysisItem> = toSignal(this.accountAnalysisDbService.selectedAnalysisItem);
+  accountStatusCheck: Signal<AccountStatusCheck> = toSignal(this.accountStatusCheckService.accountStatusCheck);
 
-  helpWidth: number;
-  helpWidthSub: Subscription;
+  url: Signal<string> = toSignal(
+    this.router.events.pipe(
+      filter(event => event instanceof NavigationEnd),
+      map(() => this.router.url),
+      startWith(this.router.url)
+    ),
+    { initialValue: this.router.url }
+  );
 
-  sidebarWidth: number;
-  sidebarWidthSub: Subscription;
+  inDashboard: Signal<boolean> = computed(() => {
+    const url = this.url();
+    return url.includes('dashboard');
+  });
 
-  constructor(
-    private router: Router,
-    private facilityDbService: FacilitydbService,
-    private accountAnalysisService: AccountAnalysisService,
-    private accountAnalysisDbService: AccountAnalysisDbService,
-    private dataEvaluationService: DataEvaluationService) { }
+  showContinue: Signal<boolean> = computed(() => {
+    const url = this.url();
+    return url.includes('/results/monthly-analysis') == false;
+  });
 
-  ngOnInit(): void {
-    this.analysisItemSub = this.accountAnalysisDbService.selectedAnalysisItem.subscribe(val => {
-      this.analysisItem = val;
-    });
+  analysisStatusCheck: Signal<AccountAnalysisStatusCheck> = computed(() => {
+    const analysisItem = this.analysisItem();
+    const accountStatusCheck = this.accountStatusCheck();
+    if(analysisItem && accountStatusCheck) {
+      return accountStatusCheck.getAccountAnalysisStatusCheckById(analysisItem.guid);
+    }
+    return undefined;
+  });
 
-    this.routerSub = this.router.events.subscribe(event => {
-      if (event instanceof NavigationEnd) {
-        this.setInDashboard(event.url);
-        this.setShowContinue(event.url);
+  canContinue: Signal<boolean> = computed(() => {
+    const url = this.url();
+    const analysisItem = this.analysisItem();
+    const analysisStatusCheck = this.analysisStatusCheck();
+    if(url && analysisItem && analysisStatusCheck) {
+      if(url.includes('setup')) {
+        return !analysisStatusCheck.accountAnalysisSetupErrors.hasSetupErrors;
+      } else if (url.includes('select-items')) {
+        return !analysisStatusCheck.accountAnalysisSetupErrors.facilitiesSelectionsInvalid;
       }
-    });
-    this.setInDashboard(this.router.url);
-    this.setShowContinue(this.router.url);
-    this.helpWidthSub = this.dataEvaluationService.helpWidthBs.subscribe(helpWidth => {
-      this.helpWidth = helpWidth;
-    });
-    this.sidebarWidthSub = this.dataEvaluationService.sidebarWidthBs.subscribe(sidebarWidth => {
-      this.sidebarWidth = sidebarWidth;
-    });
-  }
-  ngOnDestroy() {
-    this.routerSub.unsubscribe();
-    this.analysisItemSub.unsubscribe();
-    this.helpWidthSub.unsubscribe();
-    this.sidebarWidthSub.unsubscribe();
-  }
-
-  setInDashboard(url: string) {
-    this.inDashboard = url.includes('dashboard') || (url == '/account/analysis');
-  }
-
+    }
+    return true;
+  });
 
   goBack() {
     if (this.router.url.includes('setup')) {
@@ -105,14 +111,6 @@ export class AccountAnalysisFooterComponent implements OnInit {
       }
     } else if (this.router.url.includes('results')) {
       this.router.navigateByUrl('/data-evaluation/account/analysis/results/monthly-analysis');
-    }
-  }
-
-  setShowContinue(url: string) {
-    if (url.includes('/results/monthly-analysis')) {
-      this.showContinue = false;
-    } else {
-      this.showContinue = true;
     }
   }
 

--- a/src/app/data-evaluation/account/account-analysis/account-analysis-footer/account-analysis-footer.component.ts
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-footer/account-analysis-footer.component.ts
@@ -31,6 +31,8 @@ export class AccountAnalysisFooterComponent {
   sidebarWidth: Signal<number> = toSignal(this.dataEvaluationService.sidebarWidthBs);
   analysisItem: Signal<IdbAccountAnalysisItem> = toSignal(this.accountAnalysisDbService.selectedAnalysisItem);
   accountStatusCheck: Signal<AccountStatusCheck> = toSignal(this.accountStatusCheckService.accountStatusCheck);
+  selectedFacility: Signal<IdbFacility> = toSignal(this.facilityDbService.selectedFacility);
+  facilities: Signal<Array<IdbFacility>> = toSignal(this.facilityDbService.accountFacilities);
 
   url: Signal<string> = toSignal(
     this.router.events.pipe(
@@ -54,7 +56,7 @@ export class AccountAnalysisFooterComponent {
   analysisStatusCheck: Signal<AccountAnalysisStatusCheck> = computed(() => {
     const analysisItem = this.analysisItem();
     const accountStatusCheck = this.accountStatusCheck();
-    if(analysisItem && accountStatusCheck) {
+    if (analysisItem && accountStatusCheck) {
       return accountStatusCheck.getAccountAnalysisStatusCheckById(analysisItem.guid);
     }
     return undefined;
@@ -64,11 +66,13 @@ export class AccountAnalysisFooterComponent {
     const url = this.url();
     const analysisItem = this.analysisItem();
     const analysisStatusCheck = this.analysisStatusCheck();
-    if(url && analysisItem && analysisStatusCheck) {
-      if(url.includes('setup')) {
+    const selectedFacility = this.selectedFacility();
+    if (url && analysisItem && analysisStatusCheck && selectedFacility) {
+      if (url.includes('setup')) {
         return !analysisStatusCheck.accountAnalysisSetupErrors.hasSetupErrors;
       } else if (url.includes('select-items')) {
-        return !analysisStatusCheck.accountAnalysisSetupErrors.facilitiesSelectionsInvalid;
+        const hasSelection = analysisItem.facilityAnalysisItems.find(item => item.facilityId == selectedFacility.guid);
+        return hasSelection.analysisItemId != undefined;
       }
     }
     return true;
@@ -78,9 +82,9 @@ export class AccountAnalysisFooterComponent {
     if (this.router.url.includes('setup')) {
       this.router.navigateByUrl('/data-evaluation/account/analysis/dashboard');
     } else if (this.router.url.includes('account/analysis/select-items')) {
-      let facilities: Array<IdbFacility> = this.facilityDbService.accountFacilities.getValue();
-      let selectedFacility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-      let facilityIndex: number = facilities.findIndex(facility => { return facility.guid == selectedFacility.guid });
+      const facilities: Array<IdbFacility> = this.facilities();
+      const selectedFacility: IdbFacility = this.selectedFacility();
+      const facilityIndex: number = facilities.findIndex(facility => { return facility.guid == selectedFacility.guid });
       if (facilityIndex == 0) {
         this.router.navigateByUrl('/data-evaluation/account/analysis/setup');
       } else {
@@ -90,7 +94,7 @@ export class AccountAnalysisFooterComponent {
       if (this.router.url.includes('monthly-analysis')) {
         this.router.navigateByUrl('/data-evaluation/account/analysis/results/annual-analysis');
       } else {
-        let facilities: Array<IdbFacility> = this.facilityDbService.accountFacilities.getValue();
+        const facilities: Array<IdbFacility> = this.facilities();
         this.facilityDbService.selectedFacility.next(facilities[facilities.length - 1]);
         this.router.navigateByUrl('/data-evaluation/account/analysis/select-items');
       }
@@ -101,9 +105,9 @@ export class AccountAnalysisFooterComponent {
     if (this.router.url.includes('setup')) {
       this.router.navigateByUrl('/data-evaluation/account/analysis/select-items');
     } else if (this.router.url.includes('select-items')) {
-      let facilities: Array<IdbFacility> = this.facilityDbService.accountFacilities.getValue();
-      let selectedFacility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-      let facilityIndex: number = facilities.findIndex(facility => { return facility.guid == selectedFacility.guid });
+      const facilities: Array<IdbFacility> = this.facilities();
+      const selectedFacility: IdbFacility = this.selectedFacility();
+      const facilityIndex: number = facilities.findIndex(facility => { return facility.guid == selectedFacility.guid });
       if (facilityIndex == facilities.length - 1) {
         this.router.navigateByUrl('/data-evaluation/account/analysis/results/annual-analysis');
       } else {

--- a/src/app/data-evaluation/account/account-analysis/account-analysis-results/account-analysis-results.component.ts
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-results/account-analysis-results.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AnnualAccountAnalysisSummaryClass } from 'src/app/calculations/analysis-calculations/annualAccountAnalysisSummaryClass';
 import { AccountAnalysisDbService } from 'src/app/indexedDB/account-analysis-db.service';
 import { AccountdbService } from 'src/app/indexedDB/account-db.service';
@@ -9,7 +10,6 @@ import { SharedDataService } from 'src/app/shared/helper-services/shared-data.se
 import { AccountAnalysisService } from '../account-analysis.service';
 import { UtilityMeterdbService } from 'src/app/indexedDB/utilityMeter-db.service';
 import { UtilityMeterDatadbService } from 'src/app/indexedDB/utilityMeterData-db.service';
-import { IdbAccount } from 'src/app/models/idbModels/account';
 import { IdbFacility } from 'src/app/models/idbModels/facility';
 import { IdbUtilityMeter } from 'src/app/models/idbModels/utilityMeter';
 import { IdbUtilityMeterData } from 'src/app/models/idbModels/utilityMeterData';
@@ -18,83 +18,87 @@ import { PredictorDataDbService } from 'src/app/indexedDB/predictor-data-db.serv
 import { IdbPredictor } from 'src/app/models/idbModels/predictor';
 import { IdbPredictorData } from 'src/app/models/idbModels/predictorData';
 import { IdbAnalysisItem } from 'src/app/models/idbModels/analysisItem';
-import { IdbAccountAnalysisItem } from 'src/app/models/idbModels/accountAnalysisItem';
+import { runWorker } from 'src/app/web-workers/run-worker';
 
 @Component({
-    selector: 'app-account-analysis-results',
-    templateUrl: './account-analysis-results.component.html',
-    styleUrls: ['./account-analysis-results.component.css'],
-    standalone: false
+  selector: 'app-account-analysis-results',
+  templateUrl: './account-analysis-results.component.html',
+  styleUrls: ['./account-analysis-results.component.css'],
+  standalone: false
 })
 export class AccountAnalysisResultsComponent implements OnInit {
-
-  accountAnalysisItem: IdbAccountAnalysisItem;
-  account: IdbAccount;
-  worker: Worker;
-  constructor(private accountAnalysisService: AccountAnalysisService,
-    private accountAnalysisDbService: AccountAnalysisDbService,
-    private accountDbService: AccountdbService,
-    private facilityDbService: FacilitydbService,
-    private predictorDbService: PredictorDbService,
-    private predictorDataDbService: PredictorDataDbService,
-    private analysisDbService: AnalysisDbService,
-    private sharedDataService: SharedDataService,
-    private utilityMeterDbService: UtilityMeterdbService,
-    private utilityMeterDataDbService: UtilityMeterDatadbService) { }
+  private readonly accountAnalysisService = inject(AccountAnalysisService);
+  private readonly accountAnalysisDbService = inject(AccountAnalysisDbService);
+  private readonly accountDbService = inject(AccountdbService);
+  private readonly facilityDbService = inject(FacilitydbService);
+  private readonly predictorDbService = inject(PredictorDbService);
+  private readonly predictorDataDbService = inject(PredictorDataDbService);
+  private readonly analysisDbService = inject(AnalysisDbService);
+  private readonly sharedDataService = inject(SharedDataService);
+  private readonly utilityMeterDbService = inject(UtilityMeterdbService);
+  private readonly utilityMeterDataDbService = inject(UtilityMeterDatadbService);
+  private readonly destroyRef = inject(DestroyRef);
 
   ngOnInit(): void {
-    this.accountAnalysisItem = this.accountAnalysisDbService.selectedAnalysisItem.getValue();
-    this.account = this.accountDbService.selectedAccount.getValue();
-    let accountFacilities: Array<IdbFacility> = this.facilityDbService.accountFacilities.getValue();
+    const accountAnalysisItem = this.accountAnalysisDbService.selectedAnalysisItem.getValue();
+    const account = this.accountDbService.selectedAccount.getValue();
+    const accountFacilities: IdbFacility[] = this.facilityDbService.accountFacilities.getValue();
+    const accountPredictorEntries: IdbPredictorData[] = this.predictorDataDbService.accountPredictorData.getValue();
+    const accountPredictors: IdbPredictor[] = this.predictorDbService.accountPredictors.getValue();
+    const accountAnalysisItems: IdbAnalysisItem[] = this.analysisDbService.accountAnalysisItems.getValue();
+    const meters: IdbUtilityMeter[] = this.utilityMeterDbService.accountMeters.getValue();
+    const meterData: IdbUtilityMeterData[] = this.utilityMeterDataDbService.accountMeterData.getValue();
 
-    let accountPredictorEntries: Array<IdbPredictorData> = this.predictorDataDbService.accountPredictorData.getValue();
-    let accountPredictors: Array<IdbPredictor> = this.predictorDbService.accountPredictors.getValue();
-    let accountAnalysisItems: Array<IdbAnalysisItem> = this.analysisDbService.accountAnalysisItems.getValue();
-    let meters: Array<IdbUtilityMeter> = this.utilityMeterDbService.accountMeters.getValue();
-    let meterData: Array<IdbUtilityMeterData> = this.utilityMeterDataDbService.accountMeterData.getValue();
+    const payload = {
+      accountAnalysisItem,
+      account,
+      accountFacilities,
+      accountPredictorEntries,
+      allAccountAnalysisItems: accountAnalysisItems,
+      calculateAllMonthlyData: false,
+      meters,
+      meterData,
+      accountPredictors
+    };
+
     if (typeof Worker !== 'undefined') {
-      this.worker = new Worker(new URL('../../../../web-workers/annual-account-analysis.worker', import.meta.url));
-      this.worker.onmessage = ({ data }) => {
-        this.worker.terminate();
-        if (!data.error) {
-          this.accountAnalysisService.annualAnalysisSummary.next(data.annualAnalysisSummaries);
-          this.accountAnalysisService.monthlyAccountAnalysisData.next(data.monthlyAnalysisSummaryData);
-          this.accountAnalysisService.facilitySummaries.next(data.facilitySummaries);
-          this.accountAnalysisService.calculating.next(false);
-        } else {
+      const worker = new Worker(new URL('../../../../web-workers/annual-account-analysis.worker', import.meta.url));
+      this.accountAnalysisService.calculating.next(true);
+      runWorker<any>(worker, payload).pipe(
+        takeUntilDestroyed(this.destroyRef)
+      ).subscribe({
+        next: (data) => {
+          if (!data.error) {
+            this.accountAnalysisService.annualAnalysisSummary.next(data.annualAnalysisSummaries);
+            this.accountAnalysisService.monthlyAccountAnalysisData.next(data.monthlyAnalysisSummaryData);
+            this.accountAnalysisService.facilitySummaries.next(data.facilitySummaries);
+            this.accountAnalysisService.calculating.next(false);
+          } else {
+            this.accountAnalysisService.annualAnalysisSummary.next(undefined);
+            this.accountAnalysisService.monthlyAccountAnalysisData.next(undefined);
+            this.accountAnalysisService.facilitySummaries.next(undefined);
+            this.accountAnalysisService.calculating.next('error');
+          }
+        },
+        error: () => {
           this.accountAnalysisService.annualAnalysisSummary.next(undefined);
           this.accountAnalysisService.monthlyAccountAnalysisData.next(undefined);
           this.accountAnalysisService.facilitySummaries.next(undefined);
           this.accountAnalysisService.calculating.next('error');
         }
-      };
-      this.accountAnalysisService.calculating.next(true);
-      this.worker.postMessage({
-        accountAnalysisItem: this.accountAnalysisItem,
-        account: this.account,
-        accountFacilities: accountFacilities,
-        accountPredictorEntries: accountPredictorEntries,
-        allAccountAnalysisItems: accountAnalysisItems,
-        calculateAllMonthlyData: false,
-        meters: meters,
-        meterData: meterData,
-        accountPredictors: accountPredictors
       });
     } else {
       // Web Workers are not supported in this environment.
-      let annualAnalysisSummaryClass: AnnualAccountAnalysisSummaryClass = new AnnualAccountAnalysisSummaryClass(this.accountAnalysisItem, this.account, accountFacilities, accountPredictorEntries, accountAnalysisItems, false, meters, meterData, accountPredictors);
-      let annualAnalysisSummaries: Array<AnnualAnalysisSummary> = annualAnalysisSummaryClass.getAnnualAnalysisSummaries();
-      let monthlyAnalysisSummaryData: Array<MonthlyAnalysisSummaryData> = annualAnalysisSummaryClass.monthlyAnalysisSummaryData;
+      const annualAnalysisSummaryClass = new AnnualAccountAnalysisSummaryClass(
+        accountAnalysisItem, account, accountFacilities, accountPredictorEntries,
+        accountAnalysisItems, false, meters, meterData, accountPredictors
+      );
+      const annualAnalysisSummaries: AnnualAnalysisSummary[] = annualAnalysisSummaryClass.getAnnualAnalysisSummaries();
+      const monthlyAnalysisSummaryData: MonthlyAnalysisSummaryData[] = annualAnalysisSummaryClass.monthlyAnalysisSummaryData;
       this.accountAnalysisService.annualAnalysisSummary.next(annualAnalysisSummaries);
       this.accountAnalysisService.monthlyAccountAnalysisData.next(monthlyAnalysisSummaryData);
       this.accountAnalysisService.facilitySummaries.next(annualAnalysisSummaryClass.facilitySummaries);
       this.accountAnalysisService.calculating.next(false);
-    }
-  }
-
-  ngOnDestroy() {
-    if (this.worker) {
-      this.worker.terminate();
     }
   }
 

--- a/src/app/data-evaluation/account/account-analysis/account-analysis-setup/account-analysis-setup.component.html
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-setup/account-analysis-setup.component.html
@@ -20,9 +20,6 @@
               @if (_analysisStatusCheck.accountAnalysisSetupErrors.facilitiesSelectionsInvalid) {
               <span class="badge rounded-pill bg-danger">Missing Facility Selections</span>
               }
-              @if (_analysisStatusCheck.allDatesCurrent == false) {
-              <span class="badge rounded-pill bg-warning text-dark">Missing Facility Data</span>
-              }
             }
           }
         </div>

--- a/src/app/data-evaluation/account/account-analysis/account-analysis-setup/account-analysis-setup.component.html
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-setup/account-analysis-setup.component.html
@@ -1,37 +1,63 @@
 <div class="wrapper main-content p-0">
   <div class="content-padding">
-    <h4>Analysis Setup</h4>
-    @if (showInUseMessage) {
+    @let _analysisStatusCheck = analysisStatusCheck();
+
+    <h4 class="mb-2">
+      <div class="d-flex align-items-center flex-wrap justify-content-between">
+        <div class="h4 mb-0 mt-auto">
+          Analysis Setup
+        </div>
+        <div class="d-flex gap-2">
+          @if (_analysisStatusCheck) {
+            @if (_analysisStatusCheck.status === 'good') {
+            <span class="badge rounded-pill bg-success">
+              <span class="fa fa-circle-check me-1"></span>Analysis Valid
+            </span>
+            } @else {
+              @if (_analysisStatusCheck.accountAnalysisSetupErrors.hasSetupErrors) {
+              <span class="badge rounded-pill bg-danger">Setup Errors</span>
+              }
+              @if (_analysisStatusCheck.accountAnalysisSetupErrors.facilitiesSelectionsInvalid) {
+              <span class="badge rounded-pill bg-danger">Missing Facility Selections</span>
+              }
+              @if (_analysisStatusCheck.allDatesCurrent == false) {
+              <span class="badge rounded-pill bg-warning text-dark">Missing Facility Data</span>
+              }
+            }
+          }
+        </div>
+      </div>
+    </h4>
+
+    @if (showInUseMessage()) {
     <div class="row">
       <div class="col-12 alert alert-info text-center">
-        <button type="button" class="btn-close" aria-label="Close" (click)="hideInUseMessage()"></button>
+        <button type="button" class="btn-close" aria-label="Close" (click)="toggleHideInUseMessage()"></button>
         This analysis is used in one or more reports. Changes to this analysis may effect the results of the
         corresponding reports.
       </div>
     </div>
     }
-    <form>
+    <form [formGroup]="form">
       <div class="row">
         <div class="col-6">
           <div class="row form-group">
             <label class="col-5 col-form-label" for="analysisName">Name</label>
             <div class="col-7">
-              <input class="form-control" type="text" id="analysisName" name="analysisName"
-                [(ngModel)]="analysisItem.name" (input)="saveItem()">
+              <input class="form-control" type="text" id="analysisName"
+                formControlName="name">
             </div>
           </div>
-          @if (analysisItem.analysisCategory == 'energy') {
+          @if (analysisItem()?.analysisCategory == 'energy') {
           <div class="form-group row">
             <label class="col-5 col-form-label">Analysis Boundary </label>
             <div class="col-7">
               <div class="form-check">
-                <input type="radio" class="form-check-input" name="energyIsSource" [value]="true" id="sourceEnergy"
-                  [(ngModel)]="analysisItem.energyIsSource" (change)="saveItem()" [disabled]="disableForm">
+                <input type="radio" class="form-check-input" formControlName="energyIsSource" [value]="true" id="sourceEnergy">
                 <label class="form-check-label" for="sourceEnergy">Source Energy</label>
               </div>
               <div class="form-check">
-                <input type="radio" class="form-check-input" name="energyIsSource" [value]="false" id="siteEnergy"
-                  [(ngModel)]="analysisItem.energyIsSource" (change)="saveItem()" [disabled]="disableForm">
+                <input type="radio" class="form-check-input" formControlName="energyIsSource" [value]="false" id="siteEnergy">
                 <label class="form-check-label" for="siteEnergy">Site Energy</label>
               </div>
             </div>
@@ -39,8 +65,7 @@
           <div class="form-group row">
             <label class="col-5 col-form-label" for="energyUnit">Energy Unit</label>
             <div class="col-7">
-              <select class="form-select" name="energyUnit" id="energyUnit" [(ngModel)]="analysisItem.energyUnit"
-                (change)="saveItem()" [disabled]="disableForm">
+              <select class="form-select" id="energyUnit" formControlName="energyUnit">
                 @for (energyUnitOption of energyUnitOptions; track energyUnitOption) {
                 <option [ngValue]="energyUnitOption.value">
                   <span [innerHTML]="energyUnitOption.display"></span>
@@ -50,12 +75,11 @@
             </div>
           </div>
           }
-          @if (analysisItem.analysisCategory == 'water') {
+          @if (analysisItem()?.analysisCategory == 'water') {
           <div class="form-group row">
             <label class="col-5 col-form-label" for="waterUnit">Water Unit</label>
             <div class="col-7">
-              <select class="form-select" name="waterUnit" id="waterUnit" [(ngModel)]="analysisItem.waterUnit"
-                (change)="saveItem()" [disabled]="disableForm">
+              <select class="form-select" id="waterUnit" formControlName="waterUnit">
                 @for (waterUnitOption of waterUnitOptions; track waterUnitOption) {
                 <option [ngValue]="waterUnitOption.value">
                   <span [innerHTML]="waterUnitOption.display"></span>
@@ -72,29 +96,28 @@
               Baseline Year
             </label>
             <div class="col-7">
-              <select required class="form-select" id="baselineYear" name="baselineYear"
-                [(ngModel)]="analysisItem.baselineYear" (change)="changeBaselineYear()" [disabled]="disableForm">
-                @for (year of yearOptions; track year) {
+              <select required class="form-select" id="baselineYear" formControlName="baselineYear">
+                @for (year of yearOptions(); track year) {
                 <option [ngValue]="year">
-                  {{year| yearDisplay: account.fiscalYear}}</option>
+                  {{year| yearDisplay: account()?.fiscalYear}}</option>
                 }
               </select>
             </div>
           </div>
-          @if (baselineYearWarning) {
+          @if (baselineYearWarning()) {
           <div class="alert alert-warning text-center p-1">
-            {{baselineYearWarning}}
+            {{baselineYearWarning()}}
           </div>
           }
 
-          @if (account.fiscalYear == 'nonCalendarYear') {
+          @if (account()?.fiscalYear == 'nonCalendarYear') {
           <p class="mb-0 mt-2 italic">
             The account fiscal year option is set to <b>non-calendar year</b>. For more information, go to the
             "Financial Reporting" section
             of the account settings in the "<a class="click-link" (click)="goToSettings()"><span
                 class="fa fa-gear"></span> Settings</a>" tab.
           </p>
-          }@else {
+          } @else {
           <p class="mb-0 mt-2 italic">
             The account fiscal year option is set to <b>calendar year</b>. For more information, go to the "Financial
             Reporting" section
@@ -111,7 +134,7 @@
             display results for that year. If you have no changes to your models or modeling techniques, this
             means you no longer have to update your analysis settings each year.
           </p>
-          @if (!disableForm && analysisItem.baselineYear) {
+          @if (!disableForm() && form.controls.baselineYear.value) {
           <div class="d-flex w-100 justify-content-end">
             <div class="d-flex">
               <button class="btn btn-outline btn-sm" (click)="openBulkAnalysisModal()">Create Bulk
@@ -127,7 +150,7 @@
         <hr>
       </div>
     </div>
-    @if (disableForm) {
+    @if (disableForm()) {
     <div class="row">
       <div class="col-12 alert alert-warning text-center">
         Facility items selected for this analysis. Changing these settings will clear out the current selections
@@ -149,7 +172,7 @@
   <div class="popup-body">
     Are you sure you want to clear the existing facility analysis item selections? This cannot be undone!
     <hr>
-    @if (showInUseMessage) {
+    @if (showInUseMessage()) {
     <div class="col-12 alert alert-info text-center">
       This analysis is used in one or more reports. Changes to this analysis may effect the results of the
       corresponding reports.
@@ -174,13 +197,13 @@
       <label class="col-5 col-form-label bold">Analysis Type </label>
       <div class="col-7">
         <div class="form-check">
-          <input type="radio" class="form-check-input" name="analysisType" [value]="'absoluteEnergyConsumption'"
-            id="absoluteEnergyConsumption" [(ngModel)]="analysisType">
+          <input type="radio" class="form-check-input" [formControl]="analysisTypeControl" [value]="'absoluteEnergyConsumption'"
+            id="absoluteEnergyConsumption">
           <label class="form-check-label" for="absoluteEnergyConsumption">Absolute</label>
         </div>
         <div class="form-check">
-          <input type="radio" class="form-check-input" name="analysisType" [value]="'energyIntensity'"
-            id="energyIntensity" [(ngModel)]="analysisType">
+          <input type="radio" class="form-check-input" [formControl]="analysisTypeControl" [value]="'energyIntensity'"
+            id="energyIntensity">
           <label class="form-check-label" for="energyIntensity">Classic Intensity</label>
 
         </div>

--- a/src/app/data-evaluation/account/account-analysis/account-analysis-setup/account-analysis-setup.component.ts
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-setup/account-analysis-setup.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, computed, effect, inject, Signal, untracked } from '@angular/core';
 import { Router } from '@angular/router';
 import { AccountAnalysisDbService } from 'src/app/indexedDB/account-analysis-db.service';
 import { AccountdbService } from 'src/app/indexedDB/account-db.service';
@@ -6,7 +6,7 @@ import { Month, Months } from 'src/app/shared/form-data/months';
 import { EnergyUnitOptions, UnitOption, VolumeLiquidOptions } from 'src/app/shared/unitOptions';
 import { DbChangesService } from 'src/app/indexedDB/db-changes.service';
 import { AnalysisDbService } from 'src/app/indexedDB/analysis-db.service';
-import { firstValueFrom, Subscription } from 'rxjs';
+import { debounceTime, firstValueFrom } from 'rxjs';
 import { CalanderizationService } from 'src/app/shared/helper-services/calanderization.service';
 import { AccountReportDbService } from 'src/app/indexedDB/account-report-db.service';
 import { AccountAnalysisService } from '../account-analysis.service';
@@ -22,6 +22,14 @@ import { IdbUtilityMeterGroup } from 'src/app/models/idbModels/utilityMeterGroup
 import { UtilityMeterGroupdbService } from 'src/app/indexedDB/utilityMeterGroup-db.service';
 import { PredictorDbService } from 'src/app/indexedDB/predictor-db.service';
 import { IdbPredictor } from 'src/app/models/idbModels/predictor';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { CalanderizedMeter } from 'src/app/models/calanderization';
+import { getYearsWithFullDataAccountAnalysis } from 'src/app/calculations/shared-calculations/calculationsHelpers';
+import { IdbAccountReport } from 'src/app/models/idbModels/accountReport';
+import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { AccountStatusCheckService } from 'src/app/shared/helper-services/account-status-check.service';
+import { AccountStatusCheck } from 'src/app/calculations/status-check-calculations/accountStatusCheck';
+import { AccountAnalysisStatusCheck } from 'src/app/calculations/status-check-calculations/accountAnalysisStatusCheck';
 
 @Component({
   selector: 'app-account-analysis-setup',
@@ -29,186 +37,275 @@ import { IdbPredictor } from 'src/app/models/idbModels/predictor';
   styleUrls: ['./account-analysis-setup.component.css'],
   standalone: false
 })
-export class AccountAnalysisSetupComponent implements OnInit {
+export class AccountAnalysisSetupComponent {
+  private readonly accountDbService = inject(AccountdbService);
+  private readonly accountAnalysisDbService = inject(AccountAnalysisDbService);
+  private readonly router = inject(Router);
+  private readonly dbChangesService = inject(DbChangesService);
+  private readonly analysisDbService = inject(AnalysisDbService);
+  private readonly calendarizationService = inject(CalanderizationService);
+  private readonly accountReportDbService = inject(AccountReportDbService);
+  private readonly accountAnalysisService = inject(AccountAnalysisService);
+  private readonly facilityDbService = inject(FacilitydbService);
+  private readonly loadingService = inject(LoadingService);
+  private readonly toastNotificationService = inject(ToastNotificationsService);
+  private readonly utiltiyMeterGroupDbService = inject(UtilityMeterGroupdbService);
+  private readonly predictorDbService = inject(PredictorDbService);
+  private readonly fb = inject(FormBuilder);
+  private readonly accountStatusCheckService = inject(AccountStatusCheckService);
 
-  energyUnitOptions: Array<UnitOption> = EnergyUnitOptions;
-  waterUnitOptions: Array<UnitOption> = VolumeLiquidOptions;
-  months: Array<Month> = Months;
+  readonly account: Signal<IdbAccount> = toSignal(this.accountDbService.selectedAccount);
+  readonly analysisItem: Signal<IdbAccountAnalysisItem> = toSignal(this.accountAnalysisDbService.selectedAnalysisItem);
+  readonly calanderizedMeters: Signal<Array<CalanderizedMeter>> = toSignal(this.calendarizationService.calanderizedMeters);
+  readonly accountReports: Signal<Array<IdbAccountReport>> = toSignal(this.accountReportDbService.accountReports);
+  private readonly _accountStatusCheck: Signal<AccountStatusCheck> = toSignal(this.accountStatusCheckService.accountStatusCheck);
+  private readonly _hideInUseMessage: Signal<boolean> = toSignal(this.accountAnalysisService.hideInUseMessage);
 
-  account: IdbAccount;
-  energyUnit: string;
-  analysisItem: IdbAccountAnalysisItem;
-  yearOptions: Array<number>;
-  baselineYearWarning: string;
-  disableForm: boolean;
-  showInUseMessage: boolean;
-  displayEnableForm: boolean = false;
-  displayBulkAnalysisModal: boolean = false;
-  analysisType: AnalysisType = 'absoluteEnergyConsumption';
+  readonly analysisStatusCheck: Signal<AccountAnalysisStatusCheck | undefined> = computed(() => {
+    const accountStatusCheck = this._accountStatusCheck();
+    const analysisItem = this.analysisItem();
+    if (!accountStatusCheck || !analysisItem) { return undefined; }
+    return accountStatusCheck.getAccountAnalysisStatusCheckById(analysisItem.guid);
+  });
 
-  analysisItemSub: Subscription;
-  isFormChange: boolean = false;
-  constructor(private accountDbService: AccountdbService, private accountAnalysisDbService: AccountAnalysisDbService,
-    private router: Router,
-    private dbChangesService: DbChangesService,
-    private analysisDbService: AnalysisDbService,
-    private calendarizationService: CalanderizationService,
-    private accountReportDbService: AccountReportDbService,
-    private accountAnalysisService: AccountAnalysisService,
-    private facilityDbService: FacilitydbService,
-    private loadingService: LoadingService,
-    private toastNotificationService: ToastNotificationsService,
-    private utiltiyMeterGroupDbService: UtilityMeterGroupdbService,
-    private predictorDbService: PredictorDbService) { }
+  readonly energyUnitOptions: Array<UnitOption> = EnergyUnitOptions;
+  readonly waterUnitOptions: Array<UnitOption> = VolumeLiquidOptions;
+  readonly months: Array<Month> = Months;
 
-  ngOnInit(): void {
-    this.analysisItemSub = this.accountAnalysisDbService.selectedAnalysisItem.subscribe(item => {
-      if (!this.isFormChange) {
-        this.analysisItem = item;
-        if (!this.analysisItem) {
-          this.router.navigateByUrl('/data-evaluation/account/analysis/dashboard')
+  readonly showInUseMessage: Signal<boolean> = computed(() => {
+    const analysisItem = this.analysisItem();
+    const reports = this.accountReports();
+    if (this._hideInUseMessage()) { return false; }
+    if (analysisItem && reports) {
+      return reports.some(report => {
+        if (report.reportType == 'betterPlants' && report.betterPlantsReportSetup.analysisItemId == analysisItem.guid) {
+          return true;
+        } else if (report.reportType == 'analysis' && report.analysisReportSetup.analysisItemId == analysisItem.guid) {
+          return true;
+        } else if (report.reportType == 'accountSavings' && report.accountSavingsReportSetup.analysisItemId == analysisItem.guid) {
+          return true;
+        } else if (report.reportType == 'performance' && report.performanceReportSetup.analysisItemId == analysisItem.guid) {
+          return true;
         }
-        this.account = this.accountDbService.selectedAccount.getValue();
-        this.setDisableForm();
-        this.setShowInUseMessage();
-        this.energyUnit = this.account.energyUnit;
-        this.yearOptions = this.calendarizationService.getYearOptions(this.analysisItem.analysisCategory, true);
-        this.setBaselineYearWarning();
+        return false;
+      });
+    }
+    return false;
+  });
+
+  readonly baselineYearWarning: Signal<string> = computed(() => {
+    const analysisItem = this.analysisItem();
+    const account = this.account();
+    if (!analysisItem) {
+      return undefined;
+    }
+    if (analysisItem.analysisCategory == 'water') {
+      if (analysisItem.baselineYear && account.sustainabilityQuestions.waterReductionGoal && account.sustainabilityQuestions.waterReductionBaselineYear != analysisItem.baselineYear) {
+        return 'This baseline year does not match your corporate baseline year. This analysis cannot be included in reports or figures relating to the corporate water goal.';
+      }
+    } else if (analysisItem.analysisCategory == 'energy') {
+      if (analysisItem.baselineYear && account.sustainabilityQuestions.energyReductionGoal && account.sustainabilityQuestions.energyReductionBaselineYear != analysisItem.baselineYear) {
+        return 'This baseline year does not match your corporate baseline year. This analysis cannot be included in reports or figures relating to the corporate energy goal.';
+      }
+    }
+    return undefined;
+  });
+
+  readonly yearOptions: Signal<Array<number>> = computed(() => {
+    const account: IdbAccount = this.account();
+    const analysisItem: IdbAccountAnalysisItem = this.analysisItem();
+    const calanderizedMeters = this.calanderizedMeters();
+    if (account && analysisItem && calanderizedMeters) {
+      return getYearsWithFullDataAccountAnalysis(calanderizedMeters, analysisItem, account);
+    }
+    return [];
+  });
+
+  readonly disableForm: Signal<boolean> = computed(() => {
+    const analysisItem = this.analysisItem();
+    if (!analysisItem) { return false; }
+    return analysisItem.facilityAnalysisItems.some(item => item.analysisItemId != undefined);
+  });
+
+  displayEnableForm = false;
+  displayBulkAnalysisModal = false;
+
+  // Tracks the GUID of the selected analysis item to detect item switches vs. saves of the same item.
+  private readonly _currentItemGuid = computed(() => this.analysisItem()?.guid);
+
+  readonly form: FormGroup<{
+    name: FormControl<string>;
+    energyIsSource: FormControl<boolean>;
+    energyUnit: FormControl<string>;
+    waterUnit: FormControl<string>;
+    baselineYear: FormControl<number | null>;
+  }> = this.fb.group({
+    name: this.fb.nonNullable.control('', Validators.required),
+    energyIsSource: this.fb.nonNullable.control<boolean>(true),
+    energyUnit: this.fb.nonNullable.control(''),
+    waterUnit: this.fb.nonNullable.control(''),
+    baselineYear: this.fb.control<number | null>(null, Validators.required),
+  });
+
+  readonly analysisTypeControl = this.fb.nonNullable.control<AnalysisType>('absoluteEnergyConsumption');
+
+  constructor() {
+    // Patch form only when switching to a different analysis item (GUID change).
+    // Using untracked() to read the item value without creating an additional reactive dependency.
+    effect(() => {
+      this._currentItemGuid();
+      const item = untracked(() => this.analysisItem());
+      if (!item) {
+        this.router.navigateByUrl('/data-evaluation/account/analysis/dashboard');
+        return;
+      }
+      this.form.patchValue({
+        name: item.name,
+        energyIsSource: item.energyIsSource,
+        energyUnit: item.energyUnit,
+        waterUnit: item.waterUnit,
+        baselineYear: item.baselineYear ?? null,
+      }, { emitEvent: false });
+    });
+
+    // Manage control disabled states based on disableForm signal.
+    effect(() => {
+      const disabled = this.disableForm();
+      const { energyIsSource, energyUnit, waterUnit, baselineYear } = this.form.controls;
+      if (disabled) {
+        energyIsSource.disable({ emitEvent: false });
+        energyUnit.disable({ emitEvent: false });
+        waterUnit.disable({ emitEvent: false });
+        baselineYear.disable({ emitEvent: false });
       } else {
-        this.isFormChange = false;
+        energyIsSource.enable({ emitEvent: false });
+        energyUnit.enable({ emitEvent: false });
+        waterUnit.enable({ emitEvent: false });
+        baselineYear.enable({ emitEvent: false });
+      }
+    });
+
+    // Auto-save on any valid form value change.
+    this.form.valueChanges.pipe(
+      debounceTime(100),
+      takeUntilDestroyed()
+    ).subscribe(() => {
+      if (this.form.valid) {
+        this.saveItem();
       }
     });
   }
 
-  ngOnDestroy() {
-    this.analysisItemSub.unsubscribe();
-  }
-
-  async saveItem() {
-    this.isFormChange = true;
-    this.analysisItem.isAnalysisVisited = false;
-    await firstValueFrom(this.accountAnalysisDbService.updateWithObservable(this.analysisItem));
-    let account: IdbAccount = this.accountDbService.selectedAccount.getValue();
+  async saveItem(): Promise<void> {
+    const item = this.analysisItem();
+    if (!item) { return; }
+    const raw = this.form.getRawValue();
+    const updatedItem: IdbAccountAnalysisItem = {
+      ...item,
+      isAnalysisVisited: false,
+      name: raw.name,
+      energyIsSource: raw.energyIsSource,
+      energyUnit: raw.energyUnit,
+      waterUnit: raw.waterUnit,
+      baselineYear: raw.baselineYear ?? item.baselineYear,
+    };
+    await firstValueFrom(this.accountAnalysisDbService.updateWithObservable(updatedItem));
+    const account: IdbAccount = this.accountDbService.selectedAccount.getValue();
     await this.dbChangesService.setAccountAnalysisItems(account, false);
-    this.accountAnalysisDbService.selectedAnalysisItem.next(this.analysisItem);
+    this.accountAnalysisDbService.selectedAnalysisItem.next(updatedItem);
   }
 
-  async changeBaselineYear(){
-    this.setBaselineYearWarning();
-    await this.saveItem();
+  toggleHideInUseMessage(): void {
+    this.accountAnalysisService.hideInUseMessage.next(true);
   }
 
-  setBaselineYearWarning() {
-    if (this.analysisItem.analysisCategory == 'water') {
-      if (this.analysisItem.baselineYear && this.account.sustainabilityQuestions.waterReductionGoal && this.account.sustainabilityQuestions.waterReductionBaselineYear != this.analysisItem.baselineYear) {
-        this.baselineYearWarning = "This baseline year does not match your corporate baseline year. This analysis cannot be included in reports or figures relating to the corporate water goal."
-      } else {
-        this.baselineYearWarning = undefined;
-      }
-    } else if (this.analysisItem.analysisCategory == 'energy') {
-      if (this.analysisItem.baselineYear && this.account.sustainabilityQuestions.energyReductionGoal && this.account.sustainabilityQuestions.energyReductionBaselineYear != this.analysisItem.baselineYear) {
-        this.baselineYearWarning = "This baseline year does not match your corporate baseline year. This analysis cannot be included in reports or figures relating to the corporate energy goal."
-      } else {
-        this.baselineYearWarning = undefined;
-      }
-    } else {
-      this.baselineYearWarning = undefined;
-    }
-  }
-
-  setDisableForm() {
-    let hasItemsSelected: boolean = false;
-    this.analysisItem.facilityAnalysisItems.forEach(item => {
-      if (item.analysisItemId != undefined) {
-        hasItemsSelected = true;
-      }
-    });
-    this.disableForm = hasItemsSelected;
-  }
-
-  setShowInUseMessage() {
-    let hasCorrespondingReport: boolean = this.accountReportDbService.getHasCorrespondingReport(this.analysisItem.guid);
-    if (hasCorrespondingReport && this.accountAnalysisService.hideInUseMessage == false) {
-      this.showInUseMessage = true;
-    }
-  }
-
-  hideInUseMessage() {
-    this.showInUseMessage = false;
-    this.accountAnalysisService.hideInUseMessage = true;
-  }
-
-  showEnableForm() {
+  showEnableForm(): void {
     this.displayEnableForm = true;
   }
 
-  cancelEnableForm() {
+  cancelEnableForm(): void {
     this.displayEnableForm = false;
   }
 
-  async confirmEnableForm() {
-    this.analysisItem.facilityItemsInitialized = false;
-    this.analysisItem.facilityAnalysisItems.forEach(item => {
-      item.analysisItemId = undefined;
-    });
-    await this.saveItem();
-    this.disableForm = false;
-    this.displayEnableForm = undefined;
+  async confirmEnableForm(): Promise<void> {
+    const item = this.analysisItem();
+    if (!item) { return; }
+    const clearedItem: IdbAccountAnalysisItem = {
+      ...item,
+      facilityItemsInitialized: false,
+      facilityAnalysisItems: item.facilityAnalysisItems.map(fi => ({
+        ...fi,
+        analysisItemId: undefined,
+      })),
+    };
+    await firstValueFrom(this.accountAnalysisDbService.updateWithObservable(clearedItem));
+    const account: IdbAccount = this.accountDbService.selectedAccount.getValue();
+    await this.dbChangesService.setAccountAnalysisItems(account, false);
+    this.accountAnalysisDbService.selectedAnalysisItem.next(clearedItem);
+    this.displayEnableForm = false;
   }
 
-  openBulkAnalysisModal() {
+  openBulkAnalysisModal(): void {
     this.displayBulkAnalysisModal = true;
   }
 
-  closeBulkAnalysisModal() {
+  closeBulkAnalysisModal(): void {
     this.displayBulkAnalysisModal = false;
   }
 
-  async confirmBulkAnalysisCreate() {
+  async confirmBulkAnalysisCreate(): Promise<void> {
     this.closeBulkAnalysisModal();
     this.loadingService.setLoadingMessage('Creating Analysis Items...');
     this.loadingService.setLoadingStatus(true);
-    let accountMeterGroups: Array<IdbUtilityMeterGroup> = this.utiltiyMeterGroupDbService.accountMeterGroups.getValue();
-    let accountPredictors: Array<IdbPredictor> = this.predictorDbService.accountPredictors.getValue();
-    let facilities: Array<IdbFacility> = this.facilityDbService.accountFacilities.getValue();
+    const account = this.account();
+    const analysisItem = this.analysisItem();
+    const accountMeterGroups: Array<IdbUtilityMeterGroup> = this.utiltiyMeterGroupDbService.accountMeterGroups.getValue();
+    const accountPredictors: Array<IdbPredictor> = this.predictorDbService.accountPredictors.getValue();
+    const facilities: Array<IdbFacility> = this.facilityDbService.accountFacilities.getValue();
+    const analysisType = this.analysisTypeControl.value;
+    let updatedFacilityAnalysisItems = analysisItem.facilityAnalysisItems.map(fi => ({ ...fi }));
     for (let i = 0; i < facilities.length; i++) {
-      let facility: IdbFacility = facilities[i];
+      const facility: IdbFacility = facilities[i];
       this.dbChangesService.selectFacility(facility);
-      let newIdbItem: IdbAnalysisItem = getNewIdbAnalysisItem(this.account, facility, accountMeterGroups, accountPredictors, this.analysisItem.analysisCategory);
-      newIdbItem.energyIsSource = this.analysisItem.energyIsSource;
+      let newIdbItem: IdbAnalysisItem = getNewIdbAnalysisItem(account, facility, accountMeterGroups, accountPredictors, analysisItem.analysisCategory);
+      newIdbItem.energyIsSource = analysisItem.energyIsSource;
       let facilityBaselineYear: number;
-      if (this.analysisItem.analysisCategory == 'energy') {
+      if (analysisItem.analysisCategory == 'energy') {
         facilityBaselineYear = facility.sustainabilityQuestions.energyReductionBaselineYear;
-      }
-      else if (this.analysisItem.analysisCategory == 'water') {
+      } else if (analysisItem.analysisCategory == 'water') {
         facilityBaselineYear = facility.sustainabilityQuestions.waterReductionBaselineYear;
       }
-      if (facility.isNewFacility && (facilityBaselineYear > this.analysisItem.baselineYear)) {
+      if (facility.isNewFacility && (facilityBaselineYear > analysisItem.baselineYear)) {
         newIdbItem.baselineYear = facilityBaselineYear;
       } else {
-        newIdbItem.baselineYear = this.analysisItem.baselineYear;
+        newIdbItem.baselineYear = analysisItem.baselineYear;
       }
-      if (this.analysisItem.name != '') {
-        newIdbItem.name = this.analysisItem.name;
+      if (analysisItem.name != '') {
+        newIdbItem.name = analysisItem.name;
       }
       newIdbItem.groups.forEach(group => {
-        group.analysisType = this.analysisType;
+        group.analysisType = analysisType;
       });
       newIdbItem = await firstValueFrom(this.analysisDbService.addWithObservable(newIdbItem));
-      for (let f = 0; f < this.analysisItem.facilityAnalysisItems.length; f++) {
-        if (this.analysisItem.facilityAnalysisItems[f].facilityId == facility.guid) {
-          this.analysisItem.facilityAnalysisItems[f].analysisItemId = newIdbItem.guid;
-        }
-      }
+      updatedFacilityAnalysisItems = updatedFacilityAnalysisItems.map(fi =>
+        fi.facilityId === facility.guid ? { ...fi, analysisItemId: newIdbItem.guid } : fi
+      );
     }
-    await this.dbChangesService.setAnalysisItems(this.account, true);
-    await this.saveItem();
+    await this.dbChangesService.setAnalysisItems(account, true);
+    const updatedItem: IdbAccountAnalysisItem = {
+      ...analysisItem,
+      isAnalysisVisited: false,
+      facilityAnalysisItems: updatedFacilityAnalysisItems,
+    };
+    await firstValueFrom(this.accountAnalysisDbService.updateWithObservable(updatedItem));
+    await this.dbChangesService.setAccountAnalysisItems(account, false);
+    this.accountAnalysisDbService.selectedAnalysisItem.next(updatedItem);
     this.loadingService.setLoadingStatus(false);
     this.toastNotificationService.showToast('Facility Analysis Items Created.', undefined, undefined, false, 'alert-success');
     this.router.navigateByUrl('/data-evaluation/account/analysis/select-items');
   }
 
-  goToSettings(){
+  goToSettings(): void {
     this.router.navigateByUrl('/data-evaluation/account/settings');
   }
 }

--- a/src/app/data-evaluation/account/account-analysis/account-analysis.component.ts
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis.component.ts
@@ -40,7 +40,7 @@ export class AccountAnalysisComponent implements OnInit {
   ngOnDestroy() {
     this.utilityMeterDataSub.unsubscribe();
     this.accountSub.unsubscribe();
-    this.accountAnalysisService.hideInUseMessage = false; 
+    this.accountAnalysisService.hideInUseMessage.next(false); 
     this.analysisService.getDisplaySubject(this.annualKey, 'table').next('table');
     this.analysisService.getDisplaySubject(this.monthlyKey, 'graph').next('graph');
   }

--- a/src/app/data-evaluation/account/account-analysis/account-analysis.module.ts
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis.module.ts
@@ -5,7 +5,7 @@ import { AccountAnalysisDashboardComponent } from './account-analysis-dashboard/
 import { AccountAnalysisBannerComponent } from './account-analysis-banner/account-analysis-banner.component';
 import { RouterModule } from '@angular/router';
 import { NgbPaginationModule } from '@ng-bootstrap/ng-bootstrap';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HelperPipesModule } from 'src/app/shared/helper-pipes/_helper-pipes.module';
 import { AccountAnalysisSetupComponent } from './account-analysis-setup/account-analysis-setup.component';
 import { SelectFacilityAnalysisItemsComponent } from './select-facility-analysis-items/select-facility-analysis-items.component';
@@ -42,6 +42,7 @@ import { AccountAnalysisDetailsTableComponent } from './account-analysis-dashboa
     RouterModule,
     NgbPaginationModule,
     FormsModule,
+    ReactiveFormsModule,
     HelperPipesModule,
     SharedAnalysisModule,
     CalculatingSpinnerModule,

--- a/src/app/data-evaluation/account/account-analysis/account-analysis.service.ts
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis.service.ts
@@ -15,7 +15,7 @@ export class AccountAnalysisService {
   monthlyAccountAnalysisData: BehaviorSubject<Array<MonthlyAnalysisSummaryData>>;
   facilitySummaries: BehaviorSubject<Array<{ facility: IdbFacility, analysisItem: IdbAnalysisItem, monthlySummaryData: Array<MonthlyAnalysisSummaryData> }>>;
 
-  hideInUseMessage: boolean = false;
+  hideInUseMessage: BehaviorSubject<boolean>;
 
   calanderizedMeters: BehaviorSubject<Array<CalanderizedMeter>>;
   constructor() {
@@ -23,6 +23,7 @@ export class AccountAnalysisService {
     this.annualAnalysisSummary = new BehaviorSubject([]);
     this.monthlyAccountAnalysisData = new BehaviorSubject([]);
     this.facilitySummaries = new BehaviorSubject([]);
+    this.hideInUseMessage = new BehaviorSubject<boolean>(false);
     this.calanderizedMeters = new BehaviorSubject([]);
   }
 }

--- a/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.css
+++ b/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.css
@@ -1,66 +1,119 @@
-.content-padding{
-    padding: 20px 30px;
-    height: calc(100vh - 290px);
-    overflow-y: auto;
+.wrapper {
+    padding: 0;
+    height: calc(100vh - 250px);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
 }
 
-.wrapper{
-    /* margin-bottom: 100px; */
-    padding: 0px;
-    height: calc(100vh - 290px);
+/* ── Sidebar ─────────────────────────────────────── */
+.sidebar {
+    width: 220px;
+    flex-shrink: 0;
+    display: flex;
+    flex-direction: column;
+    border-right: 2px solid #154c79;
+    background-color: #f8f9fa;
+    height: 100%;
 }
 
-.nav-tabs{
-    background-color: #f1f1f1;
-}
-
-
-.nav-tabs a:not([href]).nav-link.active{
-    color: #ff6000 !important;
-    background-color: white;
-}
-
-.nav-tabs .nav-link:not(.active){
-    background-color: #145A32;
+.sidebar-header {
+    padding: 10px 12px 8px;
+    background-color: #154c79;
     color: white;
-    border: solid 1px white;
+    flex-shrink: 0;
 }
 
-
-
-.nav-link{
-    font-weight: 600;
-    font-size: 16px;
+.sidebar-title {
+    font-weight: 700;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    display: block;
+    color: white;
+}
+.progress{
+    height: 3px;
 }
 
-a:not([href]).active, .nav .nav-link.active i.fa{
-    color: #ff6000 !important;
+.sidebar-count {
+    color: white;
+    font-size: 0.78rem;
 }
 
-.fa.fa-exclamation-circle, .banner a.nav-link:not(.active) .fa.fa.fa-exclamation-circle{
-    color: red;
-}
-
-
-.nav{
-    border-right: solid #145A32;
-    width: 210px;
-    max-height: 100%;
+.facility-nav {
+    flex: 1;
     overflow-y: auto;
-    flex-wrap: nowrap;
+    padding: 4px 0;
 }
 
-.nav-item{
-    border-bottom: groove 1px;
+/* ── Facility items ──────────────────────────────── */
+.facility-item {
+    display: flex;
+    align-items: center;
     width: 100%;
-    height: fit-content;
-}
-
-.nav-link.active{
-    background-color: #efefef;
-}
-
-.nav-link:hover{
+    padding: 8px 10px 8px 12px;
+    border: none;
+    border-left: 3px solid #e9ecef;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+    background: none;
+    text-align: left;
     cursor: pointer;
-    background-color: #efefef;
+    font-size: 0.875rem;
+    color: #333;
+    transition: background-color 0.12s;
 }
+
+.facility-item:hover {
+    background-color: rgba(21, 76, 121, 0.06);
+}
+
+/* Active state: blue tint background, bold text */
+.facility-item.active {
+    background-color: rgba(21, 76, 121, 0.1);
+    font-weight: 600;
+}
+
+/* Status border colors — declared after .active so they always win */
+.facility-item.item-error  { border-left-color: #dc3545; }
+.facility-item.item-warning { border-left-color: #ffc107; }
+.facility-item.item-good   { border-left-color: #198754; }
+.facility-item.item-skip   { border-left-color: #6c757d; color: #6c757d; }
+
+/* Active + status background tints */
+.facility-item.active.item-error   { background-color: rgba(220, 53,  69, 0.07); }
+.facility-item.active.item-warning { background-color: rgba(255, 193,  7, 0.1);  }
+.facility-item.active.item-good    { background-color: rgba(25,  135, 84, 0.07); }
+
+.facility-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    display: inline-block;
+    flex-shrink: 0;
+    margin-right: 7px;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+}
+
+.facility-name {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.status-icon-sm {
+    font-size: 0.75rem;
+    flex-shrink: 0;
+    margin-left: 4px;
+}
+
+/* ── Main content area ───────────────────────────── */
+.content-area {
+    flex: 1;
+    overflow-y: auto;
+    padding: 12px 24px 72px 20px; /* bottom pad clears fixed footer */
+    min-width: 0;
+}
+

--- a/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.html
+++ b/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.html
@@ -1,26 +1,26 @@
-@let _selectedAnalysisItem = selectedAnalysisItem();
+<!-- @let _selectedAnalysisItem = selectedAnalysisItem(); -->
+@let _facilityList = facilityList();
 
-@if(_selectedAnalysisItem){
+@if(_facilityList){
 <div class="wrapper">
   <div class="d-flex w-100 h-100">
     <div class="p-2 nav flex-column">
-      @for (facilityItem of _selectedAnalysisItem.facilityAnalysisItems; track facilityItem.facilityId) {
-      <div class="nav-item"><a class="nav-link" (click)="selectFacility(facilityItem.facilityId)"
-          [ngClass]="{'active': facilityItem.facilityId == selectedFacility().guid}">
+      @for (facilityItem of _facilityList; track facilityItem.facility.guid) {
+      <div class="nav-item"><a class="nav-link" (click)="selectFacility(facilityItem.facility.guid)"
+          [ngClass]="{'active': facilityItem.facility.guid == selectedFacility().guid}">
           <i class="pe-2 fa" [ngClass]="{
               'fa-square-minus': !facilityItem.analysisItemId || facilityItem.analysisItemId === 'skip',
               'fa-square-check': facilityItem.analysisItemId && facilityItem.analysisItemId !== 'skip'
             }"></i>
-          @if(facilityItem.analysisItemId && facilityItem.analysisItemId != 'skip') {
-          @let analysisItem = facilityItem.analysisItemId | analysisItem;
-          @let analysisSetupErrors = analysisItem.guid | invalidAnalysis;
-          @if (analysisSetupErrors.hasError || analysisSetupErrors.groupsHaveErrors) {
-          <span class="fa fa-exclamation-circle"></span>
+          {{facilityItem.facility.name}}
+          @if(facilityItem.analysisItemId != 'skip') {
+          @if(!facilityItem.analysisItemId || facilityItem.analysisStatusCheck?.status == 'error'){
+          <span class="fa fa-exclamation-triangle text-danger"></span>
+          }@else if (facilityItem.analysisStatusCheck?.status == 'warning') {
+          <span class="fa fa-exclamation-triangle text-warning"></span>
           }
-          }@else if(!facilityItem.analysisItemId){
-          <span class="fa fa-exclamation-circle"></span>
           }
-          {{facilityItem.facilityId | facilityName}}</a>
+        </a>
       </div>
       }
     </div>
@@ -28,7 +28,7 @@
       @if (showInUseMessage()) {
       <div class="p-2">
         <div class="alert alert-info text-center mb-0">
-          <button type="button" class="btn-close" aria-label="Close" (click)="hideInUseMessage()"></button>
+          <button type="button" class="btn-close" aria-label="Close" (click)="toggleHideInUseMessage()"></button>
           This analysis is used in one or more reports. Changes to this analysis may effect the results of the
           corresponding reports.
         </div>

--- a/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.html
+++ b/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.html
@@ -4,38 +4,69 @@
 @if(_facilityList){
 <div class="wrapper">
   <div class="d-flex w-100 h-100">
-    <div class="p-2 nav flex-column">
-      @for (facilityItem of _facilityList; track facilityItem.facility.guid) {
-      <div class="nav-item"><a class="nav-link" (click)="selectFacility(facilityItem.facility.guid)"
-          [ngClass]="{'active': facilityItem.facility.guid == selectedFacility().guid}">
-          <i class="pe-2 fa" [ngClass]="{
-              'fa-square-minus': !facilityItem.analysisItemId || facilityItem.analysisItemId === 'skip',
-              'fa-square-check': facilityItem.analysisItemId && facilityItem.analysisItemId !== 'skip'
-            }"></i>
-          {{facilityItem.facility.name}}
-          @if(facilityItem.analysisItemId != 'skip') {
-          @if(!facilityItem.analysisItemId || facilityItem.analysisStatusCheck?.status == 'error'){
-          <span class="fa fa-exclamation-triangle text-danger"></span>
-          }@else if (facilityItem.analysisStatusCheck?.status == 'warning') {
-          <span class="fa fa-exclamation-triangle text-warning"></span>
-          }
-          }
-        </a>
-      </div>
-      }
-    </div>
-    <div class="flex-fill pt-2 ps-4 pe-4 pb-4">
-      @if (showInUseMessage()) {
-      <div class="p-2">
-        <div class="alert alert-info text-center mb-0">
-          <button type="button" class="btn-close" aria-label="Close" (click)="toggleHideInUseMessage()"></button>
-          This analysis is used in one or more reports. Changes to this analysis may effect the results of the
-          corresponding reports.
+
+    <!-- ── Sidebar ─────────────────────────────────────────── -->
+    <div class="sidebar">
+      <div class="sidebar-header">
+        <span class="sidebar-title">Facilities</span>
+        <div class="d-flex justify-content-between align-items-center mt-1">
+          <span class="sidebar-count">{{configuredCount()}} / {{_facilityList.length}} assigned</span>
         </div>
+        <div class="progress mt-2">
+          <div class="progress-bar bg-success"
+            [style.width.%]="_facilityList.length ? (configuredCount() / _facilityList.length) * 100 : 0">
+          </div>
+        </div>
+      </div>
+
+      <nav class="facility-nav">
+        @for (facilityItem of _facilityList; track facilityItem.facility.guid) {
+        @let isSkipped = facilityItem.analysisItemId === 'skip';
+        @let isAssigned = facilityItem.analysisItemId != null && !isSkipped;
+        @let isNotConfigured = !isSkipped && !isAssigned;
+        @let isError = isAssigned && facilityItem.analysisStatusCheck?.status === 'error';
+        @let isWarning = isAssigned && facilityItem.analysisStatusCheck?.status === 'warning';
+        @let isGood = isAssigned && facilityItem.analysisStatusCheck?.status === 'good';
+        <button class="facility-item" (click)="selectFacility(facilityItem.facility.guid)"
+          [ngClass]="{
+            'active':       facilityItem.facility.guid == selectedFacility()?.guid,
+            'item-error':   isNotConfigured || isError,
+            'item-warning': isWarning,
+            'item-good':    isGood,
+            'item-skip':    isSkipped
+          }">
+          <span class="facility-dot" [style.backgroundColor]="facilityItem.facility.color || '#6c757d'"></span>
+          <span class="facility-name">{{facilityItem.facility.name}}</span>
+          <span class="status-icon-sm">
+            @if (isNotConfigured) {
+            <i class="fa fa-circle-minus text-danger" title="Not configured"></i>
+            } @else if (isError) {
+            <i class="fa fa-circle-xmark text-danger" title="Has errors"></i>
+            } @else if (isWarning) {
+            <i class="fa fa-exclamation-triangle text-warning" title="Has warnings"></i>
+            } @else if (isGood) {
+            <i class="fa fa-circle-check text-success" title="Valid"></i>
+            } @else if (isSkipped) {
+            <i class="fa fa-forward-step text-muted" title="Skipped"></i>
+            }
+          </span>
+        </button>
+        }
+      </nav>
+    </div>
+
+    <!-- ── Main content ───────────────────────────────────── -->
+    <div class="content-area">
+      @if (showInUseMessage()) {
+      <div class="alert alert-info text-center mb-3">
+        <button type="button" class="btn-close" aria-label="Close" (click)="toggleHideInUseMessage()"></button>
+        This analysis is used in one or more reports. Changes to this analysis may effect the results of the
+        corresponding reports.
       </div>
       }
       <app-select-item-table></app-select-item-table>
     </div>
+
   </div>
 </div>
 }

--- a/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.ts
+++ b/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.ts
@@ -13,6 +13,7 @@ import { IdbAccountReport } from 'src/app/models/idbModels/accountReport';
 import { AnalysisStatusCheck } from 'src/app/calculations/status-check-calculations/analysisStatusCheck';
 import { AccountStatusCheckService } from 'src/app/shared/helper-services/account-status-check.service';
 import { AccountStatusCheck } from 'src/app/calculations/status-check-calculations/accountStatusCheck';
+import { AccountAnalysisStatusCheck } from 'src/app/calculations/status-check-calculations/accountAnalysisStatusCheck';
 
 interface FacilityListItem {
   facility: IdbFacility;
@@ -43,24 +44,39 @@ export class SelectFacilityAnalysisItemsComponent {
   hideInUseMessage: Signal<boolean> = toSignal(this.accountAnalysisService.hideInUseMessage);
   accountStatusCheck: Signal<AccountStatusCheck> = toSignal(this.accountStatusCheckService.accountStatusCheck);
 
+  accountAnalysisStatusCheck: Signal<AccountAnalysisStatusCheck> = computed(() => {
+    const selectedItem = this.selectedAnalysisItem();
+    const accountStatusCheck = this.accountStatusCheck();
+    if (selectedItem && accountStatusCheck) {
+      return accountStatusCheck.getAccountAnalysisStatusCheckById(selectedItem.guid);
+    }
+    return null;
+  });
+
   facilityList: Signal<Array<FacilityListItem>> = computed(() => {
     const facilities = this.facilities();
     const facilityAnalysisItems = this.facilityAnalysisItems();
     const analysisItem = this.selectedAnalysisItem();
     const accountStatusCheck = this.accountStatusCheck();
+    const accountAnalysisStatusCheck = this.accountAnalysisStatusCheck();
     if (!facilities || !facilityAnalysisItems || !analysisItem || !accountStatusCheck) {
       return [];
     }
+    console.log(accountAnalysisStatusCheck.latestDataAllEntries);
     return analysisItem.facilityAnalysisItems.map(facilityItem => {
       const facility = facilities.find(fac => fac.guid === facilityItem.facilityId);
       const facilityStatusCheck = accountStatusCheck.getFacilityStatusCheckByFacilityId(facilityItem.facilityId);
-      const analysisStatusCheck = facilityStatusCheck?.getAnalysisStatusById(facilityItem.analysisItemId);
+      const analysisStatusCheck = facilityStatusCheck?.getAnalysisStatusById(facilityItem.analysisItemId, accountAnalysisStatusCheck?.latestDataDate);
       return {
         facility: facility,
         analysisItemId: facilityItem.analysisItemId,
         analysisStatusCheck: analysisStatusCheck
       }
     });
+  });
+
+  configuredCount: Signal<number> = computed(() => {
+    return this.facilityList().filter(item => item.analysisItemId != null && item.analysisItemId !== undefined).length;
   });
 
   showInUseMessage: Signal<boolean> = computed(() => {

--- a/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.ts
+++ b/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.ts
@@ -10,6 +10,15 @@ import { IdbAccountAnalysisItem } from 'src/app/models/idbModels/accountAnalysis
 import { IdbAnalysisItem } from 'src/app/models/idbModels/analysisItem';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { IdbAccountReport } from 'src/app/models/idbModels/accountReport';
+import { AnalysisStatusCheck } from 'src/app/calculations/status-check-calculations/analysisStatusCheck';
+import { AccountStatusCheckService } from 'src/app/shared/helper-services/account-status-check.service';
+import { AccountStatusCheck } from 'src/app/calculations/status-check-calculations/accountStatusCheck';
+
+interface FacilityListItem {
+  facility: IdbFacility;
+  analysisItemId: string;
+  analysisStatusCheck: AnalysisStatusCheck;
+}
 
 @Component({
   selector: 'app-select-facility-analysis-items',
@@ -24,16 +33,43 @@ export class SelectFacilityAnalysisItemsComponent {
   private router: Router = inject(Router);
   private accountAnalysisService: AccountAnalysisService = inject(AccountAnalysisService);
   private accountReportDbService: AccountReportDbService = inject(AccountReportDbService);
+  private accountStatusCheckService: AccountStatusCheckService = inject(AccountStatusCheckService);
 
   selectedAnalysisItem: Signal<IdbAccountAnalysisItem> = toSignal(this.accountAnalysisDbService.selectedAnalysisItem);
   facilityAnalysisItems: Signal<Array<IdbAnalysisItem>> = toSignal(this.analysisDbService.facilityAnalysisItems);
   facilities: Signal<Array<IdbFacility>> = toSignal(this.facilityDbService.accountFacilities);
   selectedFacility: Signal<IdbFacility> = toSignal(this.facilityDbService.selectedFacility);
   accountReports: Signal<Array<IdbAccountReport>> = toSignal(this.accountReportDbService.accountReports);
+  hideInUseMessage: Signal<boolean> = toSignal(this.accountAnalysisService.hideInUseMessage);
+  accountStatusCheck: Signal<AccountStatusCheck> = toSignal(this.accountStatusCheckService.accountStatusCheck);
+
+  facilityList: Signal<Array<FacilityListItem>> = computed(() => {
+    const facilities = this.facilities();
+    const facilityAnalysisItems = this.facilityAnalysisItems();
+    const analysisItem = this.selectedAnalysisItem();
+    const accountStatusCheck = this.accountStatusCheck();
+    if (!facilities || !facilityAnalysisItems || !analysisItem || !accountStatusCheck) {
+      return [];
+    }
+    return analysisItem.facilityAnalysisItems.map(facilityItem => {
+      const facility = facilities.find(fac => fac.guid === facilityItem.facilityId);
+      const facilityStatusCheck = accountStatusCheck.getFacilityStatusCheckByFacilityId(facilityItem.facilityId);
+      const analysisStatusCheck = facilityStatusCheck?.getAnalysisStatusById(facilityItem.analysisItemId);
+      return {
+        facility: facility,
+        analysisItemId: facilityItem.analysisItemId,
+        analysisStatusCheck: analysisStatusCheck
+      }
+    });
+  });
 
   showInUseMessage: Signal<boolean> = computed(() => {
     const selectedItem = this.selectedAnalysisItem();
     const reports = this.accountReports();
+    const hideInUseMessage = this.hideInUseMessage();
+    if (hideInUseMessage) {
+      return false;
+    }
     if (selectedItem && reports) {
       const hasCorrespondingReport = reports.some(report => {
         if (report.reportType == 'betterPlants' && report.betterPlantsReportSetup.analysisItemId == selectedItem.guid) {
@@ -47,7 +83,7 @@ export class SelectFacilityAnalysisItemsComponent {
         }
         return false;
       });
-      return hasCorrespondingReport && this.accountAnalysisService.hideInUseMessage == false;
+      return hasCorrespondingReport;
     }
     return false;
   });
@@ -74,7 +110,7 @@ export class SelectFacilityAnalysisItemsComponent {
     this.facilityDbService.selectedFacility.next(selectedFacility);
   }
 
-  hideInUseMessage() {
-    this.accountAnalysisService.hideInUseMessage = true;
+  toggleHideInUseMessage() {
+    this.accountAnalysisService.hideInUseMessage.next(true);
   }
 }

--- a/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.ts
+++ b/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.ts
@@ -13,7 +13,6 @@ import { IdbAccountReport } from 'src/app/models/idbModels/accountReport';
 import { AnalysisStatusCheck } from 'src/app/calculations/status-check-calculations/analysisStatusCheck';
 import { AccountStatusCheckService } from 'src/app/shared/helper-services/account-status-check.service';
 import { AccountStatusCheck } from 'src/app/calculations/status-check-calculations/accountStatusCheck';
-import { AccountAnalysisStatusCheck } from 'src/app/calculations/status-check-calculations/accountAnalysisStatusCheck';
 
 interface FacilityListItem {
   facility: IdbFacility;
@@ -44,29 +43,18 @@ export class SelectFacilityAnalysisItemsComponent {
   hideInUseMessage: Signal<boolean> = toSignal(this.accountAnalysisService.hideInUseMessage);
   accountStatusCheck: Signal<AccountStatusCheck> = toSignal(this.accountStatusCheckService.accountStatusCheck);
 
-  accountAnalysisStatusCheck: Signal<AccountAnalysisStatusCheck> = computed(() => {
-    const selectedItem = this.selectedAnalysisItem();
-    const accountStatusCheck = this.accountStatusCheck();
-    if (selectedItem && accountStatusCheck) {
-      return accountStatusCheck.getAccountAnalysisStatusCheckById(selectedItem.guid);
-    }
-    return null;
-  });
-
   facilityList: Signal<Array<FacilityListItem>> = computed(() => {
     const facilities = this.facilities();
     const facilityAnalysisItems = this.facilityAnalysisItems();
     const analysisItem = this.selectedAnalysisItem();
     const accountStatusCheck = this.accountStatusCheck();
-    const accountAnalysisStatusCheck = this.accountAnalysisStatusCheck();
     if (!facilities || !facilityAnalysisItems || !analysisItem || !accountStatusCheck) {
       return [];
     }
-    console.log(accountAnalysisStatusCheck.latestDataAllEntries);
     return analysisItem.facilityAnalysisItems.map(facilityItem => {
       const facility = facilities.find(fac => fac.guid === facilityItem.facilityId);
       const facilityStatusCheck = accountStatusCheck.getFacilityStatusCheckByFacilityId(facilityItem.facilityId);
-      const analysisStatusCheck = facilityStatusCheck?.getAnalysisStatusById(facilityItem.analysisItemId, accountAnalysisStatusCheck?.latestDataDate);
+      const analysisStatusCheck = facilityStatusCheck?.getAnalysisStatusById(facilityItem.analysisItemId);
       return {
         facility: facility,
         analysisItemId: facilityItem.analysisItemId,

--- a/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-item-table/select-item-table.component.css
+++ b/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-item-table/select-item-table.component.css
@@ -10,3 +10,47 @@ i.fa-industry{
 .fa.fa-exclamation-circle, .banner a.nav-link:not(.active) .fa.fa.fa-exclamation-circle{
     color: red;
 }
+
+.table {
+    overflow: hidden;
+    border: black 1px solid;
+}
+
+.table th {
+    background-color: #154c79;
+    color: white;
+    text-align: center;
+}
+
+.table td,
+.table th {
+    vertical-align: middle;
+}
+
+.status-col {
+    width: 90px;
+    min-width: 90px;
+}
+
+.analysis-row-warning td {
+    background-color: rgba(255, 193, 7, 0.08) !important;
+}
+
+.analysis-row-error td {
+    background-color: rgba(220, 53, 69, 0.08) !important;
+}
+
+.issue-badge {
+    font-size: 0.7rem;
+    white-space: nowrap;
+}
+
+.data-through-col {
+    width: 90px;
+    min-width: 90px;
+}
+
+.modified-col {
+    width: 100px;
+    min-width: 100px;
+}

--- a/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-item-table/select-item-table.component.html
+++ b/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-item-table/select-item-table.component.html
@@ -1,5 +1,5 @@
 @let _facility = selectedFacility();
-@let _facilityAnalysisItems = facilityAnalysisItems();
+@let _facilityAnalysisListItems = facilityAnalysisListItems();
 @let _selectedFacilityItem = selectedFacilityItem();
 @let _selectedAnalysisItem = selectedAnalysisItem();
 @let _selectedFacilityItemId = selectedFacilityItemId();
@@ -49,22 +49,23 @@
       </tr>
     </thead>
     <tbody class="table-group-divider">
-      @for (analysisItem of _facilityAnalysisItems; track analysisItem.guid) {
+      @for (facilityAnalysisListItem of _facilityAnalysisListItems; track facilityAnalysisListItem.analysisItem.guid) {
       <tr>
         <td class="radio-td">
-          <input type="radio" class="rowToggle" [ngModel]="selectedFacilityItemId()" [value]="analysisItem.guid"
-            name="{{analysisItem.id+'_selectedFacilityItemId'}}" id="{{analysisItem.id+'_selectedFacilityItemId'}}"
-            (change)="save(analysisItem.guid)">
+          <input type="radio" class="rowToggle" [ngModel]="selectedFacilityItemId()" [value]="facilityAnalysisListItem.analysisItem.guid"
+            name="{{facilityAnalysisListItem.analysisItem.id+'_selectedFacilityItemId'}}" id="{{facilityAnalysisListItem.analysisItem.id+'_selectedFacilityItemId'}}"
+            (change)="save(facilityAnalysisListItem.analysisItem.guid)">
         </td>
         <td class="w-25">
-          @let setupErrors = analysisItem.guid | invalidAnalysis;
-          @if (setupErrors.hasError || setupErrors.groupsHaveErrors) {
-          <span class="fa fa-exclamation-circle"></span>
+          {{facilityAnalysisListItem.analysisItem.name}}
+          @if (facilityAnalysisListItem.statusCheck?.status == 'error') {
+          <span class="fa fa-exclamation-triangle text-warning"></span>
+          }@else if(facilityAnalysisListItem.statusCheck?.status == 'warning') {
+          <span class="fa fa-exclamation-circle text-warning"></span>
           }
-          {{analysisItem.name}}
         </td>
         <td class="w-50">
-          @for (group of analysisItem.groups; track group) {
+          @for (group of facilityAnalysisListItem.analysisItem.groups; track group) {
           <span>
             {{group.idbGroupId | groupName}}:
             @if (group.analysisType == 'absoluteEnergyConsumption') {
@@ -90,13 +91,13 @@
           </span>
           }
         </td>
-        <td>{{analysisItem.modifiedDate | date:'short'}}</td>
+        <td>{{facilityAnalysisListItem.analysisItem.modifiedDate | date:'short'}}</td>
         <td class="actions">
-          <a class="click-link" (click)="editItem(analysisItem)">View Analysis</a>
+          <a class="click-link" (click)="editItem(facilityAnalysisListItem.analysisItem)">View Analysis</a>
         </td>
       </tr>
       }
-      @if (_facilityAnalysisItems.length == 0) {
+      @if (_facilityAnalysisListItems.length == 0) {
       <tr>
         <td colspan="7" class="text-center">
           No @if (_selectedAnalysisItem.energyIsSource) {

--- a/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-item-table/select-item-table.component.html
+++ b/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-item-table/select-item-table.component.html
@@ -17,13 +17,13 @@
 </h4>
 
 @if (_selectedFacilityItem) {
-  @let setupErrors = _selectedFacilityItem.guid | invalidAnalysis;
-  @if (setupErrors.hasError || setupErrors.groupsHaveErrors) {
-  <div class="alert alert-danger w-100 text-center">
-    The selected facility analysis contains errors. Click "View Analysis" to view and fix the errors.
-  </div>
-  <hr>
-  }
+@let setupErrors = _selectedFacilityItem.guid | invalidAnalysis;
+@if (setupErrors.hasError || setupErrors.groupsHaveErrors) {
+<div class="alert alert-danger w-100 text-center">
+  The selected facility analysis contains errors. Click "View Analysis" to view and fix the errors.
+</div>
+<hr>
+}
 }
 
 @if (_selectedFacilityItemId == null) {
@@ -76,11 +76,11 @@
             <span class="badge bg-danger issue-badge">Meter Errors</span>
             }
             @if (sc.hasPredictorSetupErrors) {
-              @if (sc.status === 'error') {
-              <span class="badge bg-danger issue-badge">Predictor Errors</span>
-              } @else if (sc.status === 'warning') {
-              <span class="badge bg-warning text-dark issue-badge">Predictor Warnings</span>
-              }
+            @if (sc.status === 'error') {
+            <span class="badge bg-danger issue-badge">Predictor Errors</span>
+            } @else if (sc.status === 'warning') {
+            <span class="badge bg-warning text-dark issue-badge">Predictor Warnings</span>
+            }
             }
             @if (sc.groupsHaveErrors) {
             <span class="badge bg-danger issue-badge">Analysis Errors</span>
@@ -88,11 +88,11 @@
             <span class="badge bg-warning text-dark issue-badge">Analysis Warnings</span>
             }
             @if(sc.isDateCurrentWithAccountAnalysis === false){
-              <span class="badge bg-warning text-dark issue-badge">Data Lagging</span>
+            <span class="badge bg-warning text-dark issue-badge">Data Lagging</span>
             }
           </div>
           }@else {
-            <span class="text-success">No Issues</span>
+          <span class="text-success">No Issues</span>
           }
         </td>
         <!-- Analysis Item Name -->
@@ -128,10 +128,7 @@
         <!-- Data Through -->
         <td class="text-center data-through-col">
           @if (sc?.latestDataAllEntries) {
-          <span class="fw-semibold" [ngClass]="{
-            'text-success': sc.allDatesCurrent,
-            'text-warning': !sc.allDatesCurrent
-          }">{{sc.latestDataAllEntries | date:'MMM y'}}</span>
+          <span class="fw-semibold">{{sc.latestDataAllEntries | date:'MMM y'}}</span>
           } @else {
           <span class="text-muted">&mdash;</span>
           }
@@ -174,9 +171,8 @@
 </div>
 <p class="text-muted mb-0 mt-1">
   <i class="fa fa-circle-info me-1"></i>
-  <b>Data Through</b> shows the most recent month/year through which all meters and predictors in the analysis have data.
-  <span class="text-success fw-semibold">Green</span> = all sources current;
-  <span class="text-warning fw-semibold">Yellow</span> = some sources lag behind.
+  <b>Data Through</b> shows the most recent month/year through which all meters and predictors in the analysis have
+  data.
 </p>
 
 

--- a/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-item-table/select-item-table.component.html
+++ b/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-item-table/select-item-table.component.html
@@ -10,22 +10,21 @@
       <i class="fa fa-industry pe-2" [ngStyle]="{color: _facility?.color}"></i>{{_facility?.name}}
       Analysis Items
     </div>
-
     <div>
       <button class="btn btn-outline m-0" (click)="createNewItem()">+Add Facility Analysis</button>
     </div>
   </div>
 </h4>
-@if(_selectedFacilityItem){
-@let setupErrors = _selectedFacilityItem.guid | invalidAnalysis;
-@if (setupErrors.hasError || setupErrors.groupsHaveErrors) {
-<div class="alert alert-danger w-100 text-center">
-  The selected facility analysis contains errors. Click "View Analysis" to view and fix the errors.
-</div>
-<hr>
-}
-}
 
+@if (_selectedFacilityItem) {
+  @let setupErrors = _selectedFacilityItem.guid | invalidAnalysis;
+  @if (setupErrors.hasError || setupErrors.groupsHaveErrors) {
+  <div class="alert alert-danger w-100 text-center">
+    The selected facility analysis contains errors. Click "View Analysis" to view and fix the errors.
+  </div>
+  <hr>
+  }
+}
 
 @if (_selectedFacilityItemId == null) {
 <div class="alert alert-danger w-100 text-center">
@@ -34,97 +33,151 @@
 <hr>
 }
 
-
 <div class="table-responsive">
-  <table class="table table-bordered table-sm table-hover">
+  <table class="table table-bordered table-hover">
     <thead>
       <tr>
-        <th></th>
+        <th class="radio-td"></th>
+        <th class="status-col">Status</th>
         <th>Analysis Item</th>
-        <th>
-          Group Analysis
-        </th>
-        <th>Last Modified</th>
-        <th></th>
+        <th>Group Analysis</th>
+        <th class="data-through-col">Data Through</th>
+        <th class="modified-col">Last Modified</th>
+        <th>Actions</th>
       </tr>
     </thead>
     <tbody class="table-group-divider">
       @for (facilityAnalysisListItem of _facilityAnalysisListItems; track facilityAnalysisListItem.analysisItem.guid) {
-      <tr>
-        <td class="radio-td">
-          <input type="radio" class="rowToggle" [ngModel]="selectedFacilityItemId()" [value]="facilityAnalysisListItem.analysisItem.guid"
-            name="{{facilityAnalysisListItem.analysisItem.id+'_selectedFacilityItemId'}}" id="{{facilityAnalysisListItem.analysisItem.id+'_selectedFacilityItemId'}}"
+      @let sc = facilityAnalysisListItem.statusCheck;
+      <tr [ngClass]="{
+        'analysis-row-error': sc?.status === 'error',
+        'analysis-row-warning': sc?.status === 'warning'
+      }">
+        <!-- Select -->
+        <td class="radio-td text-center">
+          <input type="radio" class="rowToggle" [ngModel]="selectedFacilityItemId()"
+            [value]="facilityAnalysisListItem.analysisItem.guid"
+            name="{{facilityAnalysisListItem.analysisItem.id + '_selectedFacilityItemId'}}"
+            id="{{facilityAnalysisListItem.analysisItem.id + '_selectedFacilityItemId'}}"
             (change)="save(facilityAnalysisListItem.analysisItem.guid)">
         </td>
-        <td class="w-25">
-          {{facilityAnalysisListItem.analysisItem.name}}
-          @if (facilityAnalysisListItem.statusCheck?.status == 'error') {
-          <span class="fa fa-exclamation-triangle text-warning"></span>
-          }@else if(facilityAnalysisListItem.statusCheck?.status == 'warning') {
-          <span class="fa fa-exclamation-circle text-warning"></span>
+        <!-- Status -->
+        <td class="text-center align-middle status-col">
+          @if (sc && sc.status !== 'good') {
+          <span class="fa fa-fw fa-lg" [ngClass]="{
+            'fa-exclamation-triangle text-warning': sc.status === 'warning',
+            'fa-circle-xmark text-danger': sc.status === 'error'
+          }"></span>
+          <div class="d-flex flex-column gap-1 mt-1 align-items-center">
+            @if (sc.hasSetupErrors) {
+            <span class="badge bg-danger issue-badge">Setup Errors</span>
+            }
+            @if (sc.hasMeterSetupErrors) {
+            <span class="badge bg-danger issue-badge">Meter Errors</span>
+            }
+            @if (sc.hasPredictorSetupErrors) {
+              @if (sc.status === 'error') {
+              <span class="badge bg-danger issue-badge">Predictor Errors</span>
+              } @else if (sc.status === 'warning') {
+              <span class="badge bg-warning text-dark issue-badge">Predictor Warnings</span>
+              }
+            }
+            @if (sc.groupsHaveErrors) {
+            <span class="badge bg-danger issue-badge">Analysis Errors</span>
+            } @else if (sc.groupsHaveWarnings) {
+            <span class="badge bg-warning text-dark issue-badge">Analysis Warnings</span>
+            }
+            @if(sc.isDateCurrentWithAccountAnalysis === false){
+              <span class="badge bg-warning text-dark issue-badge">Data Lagging</span>
+            }
+          </div>
+          }@else {
+            <span class="text-success">No Issues</span>
           }
         </td>
-        <td class="w-50">
+        <!-- Analysis Item Name -->
+        <td class="fw-semibold">
+          {{facilityAnalysisListItem.analysisItem.name}}
+        </td>
+        <!-- Group Analysis -->
+        <td>
           @for (group of facilityAnalysisListItem.analysisItem.groups; track group) {
-          <span>
-            {{group.idbGroupId | groupName}}:
+          <div class="small">
+            <span class="text-muted">{{group.idbGroupId | groupName}}:</span>
             @if (group.analysisType == 'absoluteEnergyConsumption') {
-            <span>Absolute Energy
-              Consumption</span>
+            <span> Absolute</span>
             }
             @if (group.analysisType == 'energyIntensity') {
-            <span>Energy Intensity</span>
+            <span> Intensity</span>
             }
             @if (group.analysisType == 'modifiedEnergyIntensity') {
-            <span>Modified Energy Intensity</span>
+            <span> Mod. Intensity</span>
             }
             @if (group.analysisType == 'regression') {
-            <span>Regression</span>
+            <span> Regression</span>
             }
             @if (group.analysisType == 'skip') {
-            <span>Exclude from Analysis</span>
+            <span class="text-muted"> Exclude</span>
             }
             @if (group.analysisType == 'skipAnalysis') {
-            <span>Skip Analysis</span>
+            <span class="text-muted"> Skip All</span>
             }
-            <br>
-          </span>
+          </div>
           }
         </td>
-        <td>{{facilityAnalysisListItem.analysisItem.modifiedDate | date:'short'}}</td>
-        <td class="actions">
+        <!-- Data Through -->
+        <td class="text-center data-through-col">
+          @if (sc?.latestDataAllEntries) {
+          <span class="fw-semibold" [ngClass]="{
+            'text-success': sc.allDatesCurrent,
+            'text-warning': !sc.allDatesCurrent
+          }">{{sc.latestDataAllEntries | date:'MMM y'}}</span>
+          } @else {
+          <span class="text-muted">&mdash;</span>
+          }
+        </td>
+        <!-- Last Modified -->
+        <td class="text-center modified-col">
+          {{facilityAnalysisListItem.analysisItem.modifiedDate | date:'shortDate'}}
+        </td>
+        <!-- Actions -->
+        <td class="text-center">
           <a class="click-link" (click)="editItem(facilityAnalysisListItem.analysisItem)">View Analysis</a>
         </td>
       </tr>
       }
       @if (_facilityAnalysisListItems.length == 0) {
       <tr>
-        <td colspan="7" class="text-center">
-          No @if (_selectedAnalysisItem.energyIsSource) {
+        <td colspan="7" class="text-center fst-italic text-muted py-3">
+          No
+          @if (_selectedAnalysisItem?.energyIsSource) {
           <b>source energy</b>
-          }
-          @if (!_selectedAnalysisItem.energyIsSource) {
+          } @else {
           <b>site energy</b>
-          } analysis items found for this
-          facility that match
-          the <b>selected baseline year.</b><br>
-          Click the "+Add Facility Analysis" button to conduct a facility level analysis that will be added to
-          the account analysis in progress.
+          }
+          analysis items found for this facility that match the <b>selected baseline year.</b><br>
+          Click "+Add Facility Analysis" to conduct a facility level analysis to include in this account analysis.
         </td>
       </tr>
       }
-      <tr>
-        <td>
+      <tr class="table-light">
+        <td class="radio-td text-center">
           <input type="radio" class="rowToggle" [ngModel]="selectedFacilityItemId()" [value]="'skip'"
-            name="{{_facility.name+'undefined'}}" id="{{_facility.name+'undefined'}}" (change)="save('skip')">
+            name="{{_facility?.name + 'skip'}}" id="{{_facility?.name + 'skip'}}" (change)="save('skip')">
         </td>
-        <td colspan="6">
-          Skip Facility
+        <td colspan="6" class="text-muted fst-italic">
+          <i class="fa fa-forward-step me-1"></i> Skip this facility
         </td>
       </tr>
     </tbody>
   </table>
 </div>
+<p class="text-muted mb-0 mt-1">
+  <i class="fa fa-circle-info me-1"></i>
+  <b>Data Through</b> shows the most recent month/year through which all meters and predictors in the analysis have data.
+  <span class="text-success fw-semibold">Green</span> = all sources current;
+  <span class="text-warning fw-semibold">Yellow</span> = some sources lag behind.
+</p>
 
 
 <div [ngClass]="{'windowOverlay': itemToEdit || showCreateItem}"></div>
@@ -143,8 +196,6 @@
     <button class="btn btn-outline" (click)="confirmEditItem()">Go To Facility Analysis</button>
   </div>
 </div>
-
-
 
 <div class="popup" [class.open]="showCreateItem">
   <div class="popup-header">Create New Facility Analysis

--- a/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-item-table/select-item-table.component.ts
+++ b/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-item-table/select-item-table.component.ts
@@ -21,6 +21,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { AnalysisStatusCheck } from 'src/app/calculations/status-check-calculations/analysisStatusCheck';
 import { AccountStatusCheckService } from 'src/app/shared/helper-services/account-status-check.service';
 import { AccountStatusCheck } from 'src/app/calculations/status-check-calculations/accountStatusCheck';
+import { AccountAnalysisStatusCheck } from 'src/app/calculations/status-check-calculations/accountAnalysisStatusCheck';
 
 interface FacilityAnalysisListItem {
   analysisItem: IdbAnalysisItem;
@@ -52,13 +53,23 @@ export class SelectItemTableComponent {
   selectedFacility: Signal<IdbFacility> = toSignal(this.facilityDbservice.selectedFacility);
   accountStatusCheck: Signal<AccountStatusCheck> = toSignal(this.accountStatusCheckService.accountStatusCheck);
 
+  accountAnalysisStatusCheck: Signal<AccountAnalysisStatusCheck> = computed(() => {
+    const selectedItem = this.selectedAnalysisItem();
+    const accountStatusCheck = this.accountStatusCheck();
+    if (selectedItem && accountStatusCheck) {
+      return accountStatusCheck.getAccountAnalysisStatusCheckById(selectedItem.guid);
+    }
+    return null;
+  });
+
   facilityAnalysisListItems: Signal<Array<FacilityAnalysisListItem>> = computed(() => {
     const allItems = this.allFacilityAnalysisItems();
     const selectedItem = this.selectedAnalysisItem();
     const selectedFacility = this.selectedFacility();
     const accountStatusCheck = this.accountStatusCheck();
+    const accountAnalysisStatusCheck = this.accountAnalysisStatusCheck();
     let filteredItems: Array<FacilityAnalysisListItem> = [];
-    if (allItems && selectedItem && selectedFacility && accountStatusCheck) {
+    if (allItems && selectedItem && selectedFacility && accountStatusCheck && accountAnalysisStatusCheck) {
       const facilityStatusCheck = accountStatusCheck.getFacilityStatusCheckByFacilityId(selectedFacility.guid);
       let filteredAnalysisItems: Array<IdbAnalysisItem> = [];
       if (selectedItem.analysisCategory == 'energy') {
@@ -82,7 +93,7 @@ export class SelectItemTableComponent {
       filteredItems = filteredAnalysisItems.map(item => {
         return {
           analysisItem: item,
-          statusCheck: facilityStatusCheck ? facilityStatusCheck.getAnalysisStatusById(item.guid) : null
+          statusCheck: facilityStatusCheck ? facilityStatusCheck.getAnalysisStatusById(item.guid, accountAnalysisStatusCheck?.latestDataDate) : null
         }
       });
     }

--- a/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-item-table/select-item-table.component.ts
+++ b/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-item-table/select-item-table.component.ts
@@ -93,7 +93,7 @@ export class SelectItemTableComponent {
       filteredItems = filteredAnalysisItems.map(item => {
         return {
           analysisItem: item,
-          statusCheck: facilityStatusCheck ? facilityStatusCheck.getAnalysisStatusById(item.guid, accountAnalysisStatusCheck?.latestDataDate) : null
+          statusCheck: facilityStatusCheck ? facilityStatusCheck.getAnalysisStatusById(item.guid) : null
         }
       });
     }

--- a/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-item-table/select-item-table.component.ts
+++ b/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-item-table/select-item-table.component.ts
@@ -18,6 +18,14 @@ import { IdbPredictor } from 'src/app/models/idbModels/predictor';
 import { PredictorDbService } from 'src/app/indexedDB/predictor-db.service';
 import { IdbAccountAnalysisItem } from 'src/app/models/idbModels/accountAnalysisItem';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { AnalysisStatusCheck } from 'src/app/calculations/status-check-calculations/analysisStatusCheck';
+import { AccountStatusCheckService } from 'src/app/shared/helper-services/account-status-check.service';
+import { AccountStatusCheck } from 'src/app/calculations/status-check-calculations/accountStatusCheck';
+
+interface FacilityAnalysisListItem {
+  analysisItem: IdbAnalysisItem;
+  statusCheck: AnalysisStatusCheck;
+}
 
 @Component({
   selector: 'app-select-item-table',
@@ -37,34 +45,45 @@ export class SelectItemTableComponent {
   private utilityMeterGroupDbService: UtilityMeterGroupdbService = inject(UtilityMeterGroupdbService);
   private predictorDbService: PredictorDbService = inject(PredictorDbService);
   private facilityDbservice: FacilitydbService = inject(FacilitydbService);
+  private accountStatusCheckService: AccountStatusCheckService = inject(AccountStatusCheckService);
 
   selectedAnalysisItem: Signal<IdbAccountAnalysisItem> = toSignal(this.accountAnalysisDbService.selectedAnalysisItem);
   allFacilityAnalysisItems: Signal<Array<IdbAnalysisItem>> = toSignal(this.analysisDbService.accountAnalysisItems);
   selectedFacility: Signal<IdbFacility> = toSignal(this.facilityDbservice.selectedFacility);
+  accountStatusCheck: Signal<AccountStatusCheck> = toSignal(this.accountStatusCheckService.accountStatusCheck);
 
-  facilityAnalysisItems: Signal<Array<IdbAnalysisItem>> = computed(() => {
+  facilityAnalysisListItems: Signal<Array<FacilityAnalysisListItem>> = computed(() => {
     const allItems = this.allFacilityAnalysisItems();
     const selectedItem = this.selectedAnalysisItem();
     const selectedFacility = this.selectedFacility();
-    let filteredItems: Array<IdbAnalysisItem> = [];
-    if (allItems && selectedItem && selectedFacility) {
+    const accountStatusCheck = this.accountStatusCheck();
+    let filteredItems: Array<FacilityAnalysisListItem> = [];
+    if (allItems && selectedItem && selectedFacility && accountStatusCheck) {
+      const facilityStatusCheck = accountStatusCheck.getFacilityStatusCheckByFacilityId(selectedFacility.guid);
+      let filteredAnalysisItems: Array<IdbAnalysisItem> = [];
       if (selectedItem.analysisCategory == 'energy') {
-        filteredItems = allItems.filter(item => {
+        filteredAnalysisItems = allItems.filter(item => {
           return (item.analysisCategory == selectedItem.analysisCategory
             && item.facilityId == selectedFacility.guid
             && item.energyIsSource == selectedItem.energyIsSource
             && (item.baselineYear == selectedItem.baselineYear || selectedFacility.isNewFacility));
         });
       } else if (selectedItem.analysisCategory == 'water') {
-        filteredItems = allItems.filter(item => {
+        filteredAnalysisItems = allItems.filter(item => {
           return (item.analysisCategory == selectedItem.analysisCategory
             && item.facilityId == selectedFacility.guid
             && (item.baselineYear == selectedItem.baselineYear || selectedFacility.isNewFacility));
         });
       }
       //order by modified date
-      filteredItems = filteredItems.sort((a, b) => {
+      filteredAnalysisItems = filteredAnalysisItems.sort((a, b) => {
         return new Date(b.modifiedDate).getTime() - new Date(a.modifiedDate).getTime();
+      });
+      filteredItems = filteredAnalysisItems.map(item => {
+        return {
+          analysisItem: item,
+          statusCheck: facilityStatusCheck ? facilityStatusCheck.getAnalysisStatusById(item.guid) : null
+        }
       });
     }
     return filteredItems;

--- a/src/app/data-evaluation/account/account-home/account-energy-card/account-energy-reduction-goal/account-energy-reduction-goal.component.html
+++ b/src/app/data-evaluation/account/account-home/account-energy-card/account-energy-reduction-goal/account-energy-reduction-goal.component.html
@@ -40,3 +40,16 @@
   </a>
 </div>
 }
+<div class="row justify-content-center">
+  <div class="col-12">
+    @let _analysisStatusCheck = analysisStatusCheck();
+    @if(_analysisStatusCheck && !_analysisStatusCheck.allDatesCurrent && _analysisStatusCheck.latestDataAllEntries){
+    <p class="fw-light italic mb-1 mt-1">
+      <span class="fa fa-asterisk"></span>Note: {{_analysisStatusCheck.latestDataAllEntries| date:'MMM. yyyy'}} is the month
+      with the most recent complete predictor and meter data. VERIFI detects data entered after this date for some but not
+      all of the necessary meters and predictors. For more details, please
+      check the Account Status card above.
+    </p>
+    }
+  </div>
+</div>

--- a/src/app/data-evaluation/account/account-home/account-energy-card/account-energy-reduction-goal/account-energy-reduction-goal.component.ts
+++ b/src/app/data-evaluation/account/account-home/account-energy-card/account-energy-reduction-goal/account-energy-reduction-goal.component.ts
@@ -8,6 +8,9 @@ import { IdbAccountAnalysisItem } from 'src/app/models/idbModels/accountAnalysis
 import { AccountAnalysisDbService } from 'src/app/indexedDB/account-analysis-db.service';
 import { Router } from '@angular/router';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { AccountStatusCheckService } from 'src/app/shared/helper-services/account-status-check.service';
+import { AccountStatusCheck } from 'src/app/calculations/status-check-calculations/accountStatusCheck';
+import { AccountAnalysisStatusCheck } from 'src/app/calculations/status-check-calculations/accountAnalysisStatusCheck';
 
 @Component({
   selector: 'app-account-energy-reduction-goal',
@@ -21,10 +24,12 @@ export class AccountEnergyReductionGoalComponent {
   private accountHomeService: AccountHomeService = inject(AccountHomeService);
   private accountAnalysisDbService: AccountAnalysisDbService = inject(AccountAnalysisDbService);
   private router: Router = inject(Router);
+  private accountStatusCheckService: AccountStatusCheckService = inject(AccountStatusCheckService);
 
   latestAnalysisItem: Signal<IdbAccountAnalysisItem> = toSignal(this.accountHomeService.latestEnergyAnalysisItem, { initialValue: undefined });
   account: Signal<IdbAccount> = toSignal(this.accountDbService.selectedAccount, { initialValue: undefined });
   monthlyEnergyAnalysisData: Signal<Array<MonthlyAnalysisSummaryData>> = toSignal(this.accountHomeService.monthlyEnergyAnalysisData, { initialValue: [] });
+  accountStatusCheck: Signal<AccountStatusCheck> = toSignal(this.accountStatusCheckService.accountStatusCheck, { initialValue: null });
 
   latestAnalysisSummary: Signal<MonthlyAnalysisSummaryData> = computed(() => {
     const monthlyEnergyAnalysisData = this.monthlyEnergyAnalysisData();
@@ -41,7 +46,7 @@ export class AccountEnergyReductionGoalComponent {
   percentTowardsGoal: Signal<number> = computed(() => {
     const percentSavings = this.percentSavings();
     const percentGoal = this.percentGoal();
-    if(percentGoal === 0){
+    if (percentGoal === 0) {
       return 0;
     }
     const percentTowardsGoal = percentGoal ? (percentSavings / percentGoal) * 100 : 0;
@@ -58,6 +63,14 @@ export class AccountEnergyReductionGoalComponent {
   latestAnalysisDate: Signal<Date> = computed(() => {
     const latestAnalysisSummary = this.latestAnalysisSummary();
     return latestAnalysisSummary ? new Date(latestAnalysisSummary.date) : undefined;
+  });
+  analysisStatusCheck: Signal<AccountAnalysisStatusCheck> = computed(() => {
+    const latestAnalysisItem = this.latestAnalysisItem();
+    const accountStatusCheck = this.accountStatusCheck();
+    if (latestAnalysisItem && accountStatusCheck) {
+      return accountStatusCheck.getAccountAnalysisStatusCheckById(latestAnalysisItem.guid);
+    }
+    return null;
   });
 
   goToAnalysisItem() {

--- a/src/app/data-evaluation/account/account-home/account-status-check/account-status-check.component.css
+++ b/src/app/data-evaluation/account/account-home/account-status-check/account-status-check.component.css
@@ -23,3 +23,12 @@
     max-height: 20rem;
     opacity: 1;
 }
+
+
+.badge .fa{
+    color: inherit;
+}
+
+button strong {
+    color: inherit;
+}

--- a/src/app/data-evaluation/account/account-home/account-status-check/account-status-check.component.html
+++ b/src/app/data-evaluation/account/account-home/account-status-check/account-status-check.component.html
@@ -9,19 +9,14 @@
                 data-bs-target="#accountStatusCollapse" aria-expanded="false" aria-controls="accountStatusCollapse"
                 [ngClass]="{
           'bg-warning': _statusCheck.status === 'warning',
-          'bg-danger':  _statusCheck.status === 'error'
+          'bg-danger text-white':  _statusCheck.status === 'error'
         }">
                 <span class="fa me-2" [ngClass]="{
           'fa-circle-check text-success':      _statusCheck.status === 'good',
           'fa-exclamation-triangle':           _statusCheck.status === 'warning',
-          'fa-circle-xmark':                   _statusCheck.status === 'error'
+          'fa-circle-xmark text-white':                   _statusCheck.status === 'error'
         }"></span>
                 <strong>Account Status</strong>
-                @if (_statusCheck.totalActionCount > 0) {
-                <span class="badge bg-secondary ms-2">
-                    {{_statusCheck.totalActionCount}} item{{_statusCheck.totalActionCount !== 1 ? 's' : ''}}
-                </span>
-                }
             </button>
         </h2>
 
@@ -97,20 +92,32 @@
                                     <span class="fa fa-boxes-stacked me-1"></span>Predictors
                                 </span>
                                 }
-                                @if (fc.energyAnalysisStatusCheck && fc.energyAnalysisStatusCheck?.status !== 'good') {
+                                @if (fc.energyAnalysisStatusCheck) {
                                 <span class="badge" [ngClass]="{
                   'bg-warning text-dark': fc.energyAnalysisStatusCheck?.status === 'warning',
-                  'bg-danger':           fc.energyAnalysisStatusCheck?.status === 'error'
+                  'bg-danger':           fc.energyAnalysisStatusCheck?.status === 'error',
+                  'bg-success text-white':    fc.energyAnalysisStatusCheck?.status === 'good'
                 }">
                                     <span class="fa fa-bolt me-1"></span>Energy Analysis
+
+                                    @if(fc.energyAnalysisStatusCheck.latestDataAllEntries) {
+                                    ({{fc.energyAnalysisStatusCheck.latestDataAllEntries | date:'MMMM yyyy'}})
+                                    }@else{ (N/A)
+                                    }
                                 </span>
                                 }
-                                @if (fc.waterAnalysisStatusCheck && fc.waterAnalysisStatusCheck?.status !== 'good') {
+                                @if (fc.waterAnalysisStatusCheck) {
                                 <span class="badge" [ngClass]="{
                   'bg-warning text-dark': fc.waterAnalysisStatusCheck?.status === 'warning',
-                  'bg-danger':           fc.waterAnalysisStatusCheck?.status === 'error'
+                  'bg-danger':           fc.waterAnalysisStatusCheck?.status === 'error',
+                  'bg-success text-white':    fc.waterAnalysisStatusCheck?.status === 'good'
                 }">
                                     <span class="fa fa-droplet me-1"></span>Water Analysis
+                                    @if(fc.waterAnalysisStatusCheck.latestDataAllEntries) {
+                                    ({{fc.waterAnalysisStatusCheck.latestDataAllEntries | date:'MMMM yyyy'}})
+                                    }@else{
+                                    (N/A)
+                                    }
                                 </span>
                                 }
                             </span>
@@ -167,13 +174,54 @@
                                     <span class="fa fa-chevron-right text-muted float-end mt-1 small"></span>
                                 </li>
                                 }
-                                @if(fc.hasPredictorWeatherWarnings){
+                                @if(fc.predictorsStatus === 'error'){
+                                <li class="list-group-item list-group-item-action sub-issue py-1 d-flex align-items-center gap-2"
+                                    [routerLink]="'/data-evaluation/facility/' + fc.facility.guid + '/utility/predictors'">
+                                    <span class="fa fa-circle-xmark text-danger me-2"></span>Some predictors have
+                                    errors
+                                    <span class="fa fa-chevron-right text-muted float-end mt-1 small"></span>
+                                </li>
+                                }@else if(fc.hasPredictorWeatherWarnings){
                                 <li class="list-group-item list-group-item-action sub-issue py-1 d-flex align-items-center gap-2"
                                     [routerLink]="'/data-evaluation/facility/' + fc.facility.guid + '/utility/predictors'">
                                     <span class="fa fa-circle-xmark text-warning me-2"></span>Some predictors have
                                     weather data warnings
                                     <span class="fa fa-chevron-right text-muted float-end mt-1 small"></span>
                                 </li>
+                                }
+                                @if(fc.energyAnalysisStatusCheck && fc.energyAnalysisStatusCheck.status !== 'good'){
+                                @if(fc.energyAnalysisStatusCheck.status === 'error'){
+                                <li class="list-group-item list-group-item-action sub-issue py-1 d-flex align-items-center gap-2"
+                                    [routerLink]="'/data-evaluation/facility/' + fc.facility.guid + '/analysis'">
+                                    <span class="fa fa-circle-xmark text-danger me-2"></span>Energy analysis has
+                                    errors
+                                    <span class="fa fa-chevron-right text-muted float-end mt-1 small"></span>
+                                </li>
+                                }@else {
+                                <li class="list-group-item list-group-item-action sub-issue py-1 d-flex align-items-center gap-2"
+                                    [routerLink]="'/data-evaluation/facility/' + fc.facility.guid + '/analysis'">
+                                    <span class="fa fa-circle-xmark text-warning me-2"></span>Energy analysis has
+                                    warnings
+                                    <span class="fa fa-chevron-right text-muted float-end mt-1 small"></span>
+                                </li>
+                                }
+                                }
+                                @if(fc.waterAnalysisStatusCheck && fc.waterAnalysisStatusCheck.status !== 'good'){
+                                @if(fc.waterAnalysisStatusCheck.status === 'error'){
+                                <li class="list-group-item list-group-item-action sub-issue py-1 d-flex align-items-center gap-2"
+                                    [routerLink]="'/data-evaluation/facility/' + fc.facility.guid + '/analysis/water'">
+                                    <span class="fa fa-circle-xmark text-danger me-2"></span>Water analysis has
+                                    errors
+                                    <span class="fa fa-chevron-right text-muted float-end mt-1 small"></span>
+                                </li>
+                                }@else{
+                                <li class="list-group-item list-group-item-action sub-issue py-1 d-flex align-items-center gap-2"
+                                    [routerLink]="'/data-evaluation/facility/' + fc.facility.guid + '/analysis/water'">
+                                    <span class="fa fa-circle-xmark text-warning me-2"></span>Water analysis has
+                                    warnings
+                                    <span class="fa fa-chevron-right text-muted float-end mt-1 small"></span>
+                                </li>
+                                }
                                 }
                             </ul>
                         </div>

--- a/src/app/data-evaluation/facility/analysis/analysis-footer/analysis-footer.component.css
+++ b/src/app/data-evaluation/facility/analysis/analysis-footer/analysis-footer.component.css
@@ -2,3 +2,6 @@
     transition: .2s left;
     transition: .2s right;
 }
+.badge{
+    font-size: 15px;
+}

--- a/src/app/data-evaluation/facility/analysis/analysis-footer/analysis-footer.component.html
+++ b/src/app/data-evaluation/facility/analysis/analysis-footer/analysis-footer.component.html
@@ -4,6 +4,15 @@
       <button class="btn" (click)="goBack()"><span class="fa fa-chevron-left pe-1"></span>Back </button>
     </div>
     <div>
+      <div class="badge bg-dark">
+        @if(facility()?.fiscalYear == 'calendarYear') {
+        Latest Complete Year: {{analysisStatusCheck()?.latestCompleteYear}}
+        }@else{
+        Latest Complete FY: {{analysisStatusCheck()?.latestCompleteYear}}
+        }
+      </div>
+    </div>
+    <div>
       @if (showGoBackToAccount()) {
       <button class="btn btn-secondary me-1" (click)="goBackToAccount()">Return to Account Analysis</button>
       }

--- a/src/app/data-evaluation/facility/analysis/analysis-footer/analysis-footer.component.ts
+++ b/src/app/data-evaluation/facility/analysis/analysis-footer/analysis-footer.component.ts
@@ -1,5 +1,5 @@
-import { Component, computed, inject, OnInit, Signal } from '@angular/core';
-import { filter, map, startWith, Subscription } from 'rxjs';
+import { Component, computed, inject, Signal } from '@angular/core';
+import { filter, map, startWith } from 'rxjs';
 import { NavigationEnd, Router } from '@angular/router';
 import { FacilitydbService } from 'src/app/indexedDB/facility-db.service';
 import { AnalysisService } from '../analysis.service';
@@ -10,8 +10,6 @@ import { IdbFacility } from 'src/app/models/idbModels/facility';
 import { IdbAnalysisItem } from 'src/app/models/idbModels/analysisItem';
 import { IdbAccountAnalysisItem } from 'src/app/models/idbModels/accountAnalysisItem';
 import { DataEvaluationService } from 'src/app/data-evaluation/data-evaluation.service';
-import { CalanderizationService } from 'src/app/shared/helper-services/calanderization.service';
-import { PredictorDataDbService } from 'src/app/indexedDB/predictor-data-db.service';
 import { AnalysisSetupErrors, GroupAnalysisErrors } from 'src/app/models/validation';
 import { AccountStatusCheckService } from 'src/app/shared/helper-services/account-status-check.service';
 import { toSignal } from '@angular/core/rxjs-interop';
@@ -38,6 +36,7 @@ export class AnalysisFooterComponent {
   sidebarWidth: Signal<number> = toSignal(this.dataEvaluationService.sidebarWidthBs);
   accountAnalysisItem: Signal<IdbAccountAnalysisItem> = toSignal(this.analysisService.accountAnalysisItem);
   facilityStatusCheck: Signal<FacilityStatusCheck> = toSignal(this.accountStatusCheckService.selectedFacilityStatusCheck$);
+  facility: Signal<IdbFacility> = toSignal(this.facilityDbService.selectedFacility);
 
   url = toSignal(
     this.router.events.pipe(
@@ -127,7 +126,7 @@ export class AnalysisFooterComponent {
   });
 
   goBack() {
-    const facility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
+    const facility: IdbFacility = this.facility();
     const selectedGroup: AnalysisGroup = this.selectedGroup();
     const analysisItem: IdbAnalysisItem = this.analysisItem();
     const facilityUrlStr: string = '/data-evaluation/facility/' + facility.guid + '/analysis/run-analysis/';
@@ -168,7 +167,7 @@ export class AnalysisFooterComponent {
   }
 
   continue() {
-    const facility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
+    const facility: IdbFacility = this.facility();
     const selectedGroup: AnalysisGroup = this.selectedGroup();
     const analysisItem: IdbAnalysisItem = this.analysisItem();
     const facilityUrlStr: string = '/data-evaluation/facility/' + facility.guid + '/analysis/run-analysis/';

--- a/src/app/data-evaluation/facility/facility-home/facility-energy-card/facility-energy-reduction-goal/facility-energy-reduction-goal.component.html
+++ b/src/app/data-evaluation/facility/facility-home/facility-energy-card/facility-energy-reduction-goal/facility-energy-reduction-goal.component.html
@@ -44,7 +44,7 @@
       <span class="fa fa-asterisk"></span>Note: {{_facilityStatusCheck.energyAnalysisStatusCheck.latestDataAllEntries| date:'MMM. yyyy'}} is the month
       with the most recent complete predictor and meter data. VERIFI detects data entered after this date for some but not
       all of the necessary meters and predictors. For more details, please
-      check the Facility Status Check card above.
+      check the Facility Status card above.
     </p>
     }
   </div>

--- a/src/app/data-evaluation/facility/facility-home/facility-status-check/facility-status-check.component.html
+++ b/src/app/data-evaluation/facility/facility-home/facility-status-check/facility-status-check.component.html
@@ -14,7 +14,7 @@
                         'fa-exclamation-triangle': _facilityStatusCheck?.status === 'warning',
                         'fa-circle-xmark': _facilityStatusCheck?.status === 'error'
                     }"></span>
-                <strong>Facility Status Check</strong>
+                <strong>Facility Status</strong>
             </button>
         </h2>
         <div id="statusCheckCollapse" class="accordion-collapse collapse" aria-labelledby="statusCheckHeading"

--- a/src/app/data-evaluation/facility/facility-home/facility-water-card/facility-water-reduction-goal/facility-water-reduction-goal.component.html
+++ b/src/app/data-evaluation/facility/facility-home/facility-water-card/facility-water-reduction-goal/facility-water-reduction-goal.component.html
@@ -48,7 +48,7 @@
       <span class="fa fa-asterisk"></span>Note: {{_facilityStatusCheck.waterAnalysisStatusCheck.latestDataAllEntries| date:'MMM. yyyy'}} is the month
       with the most recent complete predictor and meter data. VERIFI detects data entered after this date for some but not
       all of the necessary meters and predictors. For more details, please
-      check the Facility Status Check card above.
+      check the Facility Status card above.
     </p>
     }
   </div>

--- a/src/app/shared/shared-meter-content/meter-data/meter-data-table/meter-data-table.component.html
+++ b/src/app/shared/shared-meter-content/meter-data/meter-data-table/meter-data-table.component.html
@@ -83,7 +83,8 @@
   @if(_meterStatusCheck.isDataCurrent == false && _meterStatusCheck.lastDateEntry){
   <div class="alert alert-warning text-center p-1 fw-bold">
     <span class="fa fa-triangle-exclamation"></span>
-    Facility data entered through {{_meterStatusCheck.latestFacilityEntryDate | date:'MMM, yyyy'}} but this meter only has data through
+    Facility data calendarized through {{_meterStatusCheck.latestFacilityEntryDate | date:'MMM, yyyy'}} but this meter
+    only has monthly data through
     {{_meterStatusCheck.lastDateEntry | date:'MMM, yyyy'}}.
   </div>
   }

--- a/src/app/web-workers/annual-account-analysis.worker.ts
+++ b/src/app/web-workers/annual-account-analysis.worker.ts
@@ -2,11 +2,14 @@
 
 import { AnnualAnalysisSummary, MonthlyAnalysisSummaryData } from "../models/analysis";
 import { AnnualAccountAnalysisSummaryClass } from "../calculations/analysis-calculations/annualAccountAnalysisSummaryClass";
-import { MonthlyFacilityAnalysisClass } from "../calculations/analysis-calculations/monthlyFacilityAnalysisClass";
 
 addEventListener('message', ({ data }) => {
     try {
-        let annualAnalysisSummaryClass: AnnualAccountAnalysisSummaryClass = new AnnualAccountAnalysisSummaryClass(data.accountAnalysisItem, data.account, data.accountFacilities, data.accountPredictorEntries, data.allAccountAnalysisItems, data.calculateAllMonthlyData, data.meters, data.meterData, data.accountPredictors);
+        let annualAnalysisSummaryClass: AnnualAccountAnalysisSummaryClass = new AnnualAccountAnalysisSummaryClass(
+            data.accountAnalysisItem, data.account, data.accountFacilities, data.accountPredictorEntries,
+            data.allAccountAnalysisItems, data.calculateAllMonthlyData, data.meters, data.meterData,
+            data.accountPredictors
+        );
         let annualAnalysisSummaries: Array<AnnualAnalysisSummary> = annualAnalysisSummaryClass.getAnnualAnalysisSummaries();
         let monthlyAnalysisSummaryData: Array<MonthlyAnalysisSummaryData> = annualAnalysisSummaryClass.monthlyAnalysisSummaryData;
         postMessage({


### PR DESCRIPTION
connects #2174 

This pull request introduces significant enhancements to the account-level analysis and status check logic, particularly for determining the latest complete year of data and improving the structure and reporting of analysis status checks. The changes include new utility functions, improved calculation of report years, and a new `AccountAnalysisStatusCheck` class to encapsulate account-level analysis validation and status.

Key changes:

### Account Analysis Year Calculation and Data Handling

* The `AnnualAccountAnalysisSummaryClass` now uses a more robust method to determine the report year, ensuring it only considers meters and predictors included in the analysis and that a full year of data is available for all inputs. This is achieved by collecting relevant meter and predictor IDs and checking for years with complete data across all of them. [[1]](diffhunk://#diff-bdce21cff05541c4e2909dd1087dad44d72033932ed0d63abd68855c8045c33eL1-R5) [[2]](diffhunk://#diff-bdce21cff05541c4e2909dd1087dad44d72033932ed0d63abd68855c8045c33eL35-R36) [[3]](diffhunk://#diff-bdce21cff05541c4e2909dd1087dad44d72033932ed0d63abd68855c8045c33eL54-R177)
* Added a helper function `getYearsWithFullDataAccountAnalysis` to filter meters by analysis category and determine years with full data at the account level.

### Status Check Refactoring and Improvements

* Introduced a new `AccountAnalysisStatusCheck` class that centralizes account-level analysis validation, error aggregation, and status computation (including latest data dates and complete years). This class is now used by `AccountStatusCheck` to manage and retrieve account analysis errors and statuses more effectively. [[1]](diffhunk://#diff-49919309f9948cdf65f1669d98ff2e654c24209bb8f2f79216fddaae704b5ca1R1-R97) [[2]](diffhunk://#diff-8e2323fa0035f230dd408357b727b282edd7296851802800fb627289fff5ba1bL16-R35)
* Refactored `AccountStatusCheck` to use the new `AccountAnalysisStatusCheck` class, replacing the old array of setup errors with a richer array of status checks. Also added helper methods to retrieve status checks and errors by analysis ID, and to track the latest energy and water analysis status checks. [[1]](diffhunk://#diff-8e2323fa0035f230dd408357b727b282edd7296851802800fb627289fff5ba1bR93-R98) [[2]](diffhunk://#diff-8e2323fa0035f230dd408357b727b282edd7296851802800fb627289fff5ba1bR107-R141)

### Additional Data Tracking

* Both `AccountAnalysisStatusCheck` and `AnalysisStatusCheck` now track the latest complete year of data, providing more precise information for reporting and validation. [[1]](diffhunk://#diff-31875925cf2827d54219cf9ab10a37c8e0b968f401d8e82e6fc8fb3debcb5ae8R22-R23) [[2]](diffhunk://#diff-49919309f9948cdf65f1669d98ff2e654c24209bb8f2f79216fddaae704b5ca1R1-R97)

These changes collectively improve the accuracy and maintainability of account-level analysis and status reporting, ensuring that all relevant data is considered and that reporting is consistent and robust.