### PR TITLE
feat: add ability to ignore weather data gap warnings

### DIFF
--- a/src/app/calculations/status-check-calculations/predictorStatusCheck.ts
+++ b/src/app/calculations/status-check-calculations/predictorStatusCheck.ts
@@ -173,7 +173,7 @@ export class PredictorStatusCheck {
     }
 
     private setHasWeatherDataWarning(predictor: IdbPredictor, predictorData: Array<IdbPredictorData>) {
-        if (predictor.predictorType !== 'Weather') {
+        if (predictor.predictorType !== 'Weather' || predictor.ignoreWeatherDataWarning) {
             this.hasWeatherDataWarning = false;
             return;
         }

--- a/src/app/data-evaluation/facility/utility-data/energy-consumption/utility-meter-data/utility-meter-data.component.html
+++ b/src/app/data-evaluation/facility/utility-data/energy-consumption/utility-meter-data/utility-meter-data.component.html
@@ -1,5 +1,7 @@
 @let _selectedMeter = selectedMeter();
 
+@if(_selectedMeter){
 <h4>{{_selectedMeter.name}} {{label()}} <span class="badge float-end"
         [ngStyle]="{'background-color': _selectedMeter.source | meterSourceColor}">{{_selectedMeter.source}}</span></h4>
 <router-outlet></router-outlet>
+}

--- a/src/app/models/idbModels/predictor.ts
+++ b/src/app/models/idbModels/predictor.ts
@@ -29,7 +29,8 @@ export interface IdbPredictor extends IdbEntry {
     sidebarOpen?: boolean,
     isValid?: boolean,
     skipImport?: boolean
-    // weatherOverride: boolean
+    //status checks
+    ignoreWeatherDataWarning?: boolean
 }
 
 export function getNewIdbPredictor(accountId: string, facilityId: string): IdbPredictor {

--- a/src/app/shared/shared-predictors-content/predictor-table/predictor-table.component.html
+++ b/src/app/shared/shared-predictors-content/predictor-table/predictor-table.component.html
@@ -1,6 +1,7 @@
 @let _facilityPredictors = facilityPredictors();
 @let _standardPredictors = standardPredictors();
 @let _degreeDayPredictors = degreeDayPredictors();
+@let _hasIgnoredWeatherDataWarning = hasIgnoredWeatherDataWarning();
 
 @if (_facilityPredictors.length != 0) {
 <div class="d-flex w-100 justify-content-end mb-2">
@@ -131,6 +132,20 @@
   button. It may be best to choose a different weather station
   to pull data from, use the <a (click)="goToWeatherData()">Weather Data</a> page to explore other stations in the
   area of this facility.
+  <div class="mt-2">
+    <button class="btn btn-sm btn-outline-warning" (click)="openIgnoreAllWarningsModal()">
+      <i class="fa fa-eye-slash"></i> Dismiss All Weather Gap Warnings
+    </button>
+  </div>
+</div>
+}
+@if (_hasIgnoredWeatherDataWarning) {
+<div class="alert alert-secondary d-flex align-items-center justify-content-center gap-2 p-2">
+  <i class="fa fa-eye-slash"></i>
+  <span>Weather data gap warnings are dismissed for one or more predictors.</span>
+  <button class="btn btn-sm btn-outline-secondary" (click)="setAllIgnoreWeatherDataWarning(false)">
+    <i class="fa fa-eye"></i> Re-enable All Warnings
+  </button>
 </div>
 }
 <div class="table-responsive">
@@ -269,7 +284,7 @@
 </div>
 }
 
-<div [ngClass]="{'windowOverlay': displayDeletePredictor}"></div>
+<div [ngClass]="{'windowOverlay': displayDeletePredictor || showIgnoreAllWarningsModal}"></div>
 <!--delete-->
 <div class="popup" [class.open]="displayDeletePredictor">
   <div class="popup-header">
@@ -293,4 +308,30 @@
     <button class="btn btn-secondary" (click)="cancelDelete()">Cancel</button>
     <button class="btn btn-danger" (click)="confirmDelete()">Confirm Delete</button>
   </div>
+</div>
+
+<div class="popup" [class.open]="showIgnoreAllWarningsModal">
+  @if (showIgnoreAllWarningsModal) {
+  <div class="popup-header">
+    Dismiss All Weather Gap Warnings?
+    <button class="item-right" (click)="cancelIgnoreAllWarningsModal()">x</button>
+  </div>
+  <div class="popup-body">
+    <p>
+      Are you sure you want to dismiss weather data gap warnings for all weather predictors in this facility?
+    </p>
+    <p>
+      These warnings indicate some calculated entries may be based on weather data with gaps of 12 or more hours and
+      <strong>may not be accurate</strong>.
+    </p>
+    <p class="mb-0 text-muted small">
+      <i class="fa fa-info-circle"></i> You can re-enable these warnings at any time from this table.
+    </p>
+  </div>
+  <div class="saveCancel popup-footer text-end">
+    <button class="btn btn-secondary" (click)="cancelIgnoreAllWarningsModal()">Cancel</button>
+    <button class="btn btn-warning" (click)="confirmIgnoreAllWarningsModal()"><i class="fa fa-eye-slash"></i>
+      Dismiss All Warnings</button>
+  </div>
+  }
 </div>

--- a/src/app/shared/shared-predictors-content/predictor-table/predictor-table.component.ts
+++ b/src/app/shared/shared-predictors-content/predictor-table/predictor-table.component.ts
@@ -81,9 +81,16 @@ export class PredictorTableComponent {
     if (!degreeDayPredictorsList) return false;
     return degreeDayPredictorsList.some(item => item.statusCheck && item.statusCheck.hasWeatherDataWarning);
   });
+
+  hasIgnoredWeatherDataWarning: Signal<boolean> = computed(() => {
+    const degreeDayPredictorsList = this.degreeDayPredictors();
+    if (!degreeDayPredictorsList) return false;
+    return degreeDayPredictorsList.some(item => item.predictor.ignoreWeatherDataWarning);
+  });
   
   predictorUsedGroupIds: Array<string> = [];
   displayDeletePredictor: boolean = false;
+  showIgnoreAllWarningsModal: boolean = false;
 
   selectDelete(predictor: IdbPredictor) {
     this.predictorToDelete = predictor;
@@ -236,6 +243,41 @@ export class PredictorTableComponent {
     } else {
       this.router.navigateByUrl('/data-evaluation/weather-data');
     }
+  }
+
+  openIgnoreAllWarningsModal() {
+    this.showIgnoreAllWarningsModal = true;
+  }
+
+  cancelIgnoreAllWarningsModal() {
+    this.showIgnoreAllWarningsModal = false;
+  }
+
+  async confirmIgnoreAllWarningsModal() {
+    this.showIgnoreAllWarningsModal = false;
+    await this.setAllIgnoreWeatherDataWarning(true);
+  }
+
+  async setAllIgnoreWeatherDataWarning(ignoreWarning: boolean) {
+    const predictorsToUpdate = this.degreeDayPredictors()
+      .map(item => item.predictor)
+      .filter(predictor => Boolean(predictor.ignoreWeatherDataWarning) !== ignoreWarning);
+    if (predictorsToUpdate.length === 0) {
+      return;
+    }
+    for (const predictor of predictorsToUpdate) {
+      predictor.ignoreWeatherDataWarning = ignoreWarning;
+      await firstValueFrom(this.predictorDbService.updateWithObservable(predictor));
+    }
+    const account: IdbAccount = this.accountDbService.selectedAccount.getValue();
+    await this.dbChangesService.setPredictorsV2(account, this.selectedFacility());
+    this.toastNotificationService.showToast(
+      ignoreWarning ? 'Weather gap warnings dismissed' : 'Weather gap warnings re-enabled',
+      undefined,
+      1200,
+      false,
+      'alert-success'
+    );
   }
 
   navigateToPredictorData(predictor: IdbPredictor) {

--- a/src/app/shared/shared-predictors-content/predictors-data-table/predictors-data-table.component.html
+++ b/src/app/shared/shared-predictors-content/predictors-data-table/predictors-data-table.component.html
@@ -67,17 +67,30 @@
   </div>
 </div>
 @if (_predictorStatusCheck && _predictorStatusCheck.hasWeatherDataWarning) {
-<div class="alert alert-warning text-center p-1">
-  <span class="fa fa-exclamation-circle"></span> Indicates that the predictor entry was calculated from weather
-  data
-  with gaps of twelve hours or more and the
-  results may not be accurate. To inspect the weather data for that month, click the <span
-    class="fa fa-thermometer-half"></span> button. To manually override
-  the values click the <span class="fa fa-pencil"></span> button. If you have several <span
-    class="fa fa-exclamation-circle"></span>, it may be best to select a different weather station for
-  this facility - use the <a (click)="goToWeatherData()">Weather Data</a> page to explore other stations in the
-  area
-  of this facility.
+<div class="alert alert-warning p-2">
+  <div class="text-center">
+    <span class="fa fa-exclamation-circle"></span> Indicates that the predictor entry was calculated from weather
+    data with gaps of twelve hours or more and the results may not be accurate. To inspect the weather data for
+    that month, click the <span class="fa fa-thermometer-half"></span> button. To manually override the values
+    click the <span class="fa fa-pencil"></span> button. If you have several <span
+      class="fa fa-exclamation-circle"></span>, it may be best to select a different weather station for this
+    facility - use the <a (click)="goToWeatherData()">Weather Data</a> page to explore other stations in the area
+    of this facility.
+  </div>
+  <div class="text-center mt-2">
+    <button class="btn btn-sm btn-outline-warning" (click)="openIgnoreWarningModal()">
+      <i class="fa fa-eye-slash"></i> Dismiss Warning
+    </button>
+  </div>
+</div>
+}
+@if (_predictor.ignoreWeatherDataWarning) {
+<div class="alert alert-secondary d-flex align-items-center justify-content-center gap-2 p-2">
+  <i class="fa fa-eye-slash"></i>
+  <span>Weather data gap warnings are dismissed for this predictor.</span>
+  <button class="btn btn-sm btn-outline-secondary" (click)="setIgnoreWeatherDataWarning()">
+    <i class="fa fa-eye"></i> Re-enable Warning
+  </button>
 </div>
 }
 
@@ -223,7 +236,7 @@
 }
 
 
-<div [ngClass]="{'windowOverlay': predictorDataToDelete || showBulkDelete}"></div>
+<div [ngClass]="{'windowOverlay': predictorDataToDelete || showBulkDelete || showIgnoreWarningModal}"></div>
 <div class="popup" [class.open]="predictorDataToDelete">
   @if(predictorDataToDelete) {
   <div class="popup-header">
@@ -255,4 +268,30 @@
     <button class="btn btn-secondary" (click)="cancelBulkDelete()">Cancel</button>
     <button class="btn btn-danger" (click)="bulkDelete()">Confirm Delete</button>
   </div>
+</div>
+<div class="popup" [class.open]="showIgnoreWarningModal">
+  @if (showIgnoreWarningModal) {
+  <div class="popup-header">
+    Dismiss Weather Data Warning?
+    <button class="item-right" (click)="cancelIgnoreWarningModal()">x</button>
+  </div>
+  <div class="popup-body">
+    <p>
+      Are you sure you want to dismiss weather data gap warnings for
+      <strong>{{_predictor?.name}}</strong>?
+    </p>
+    <p>
+      Some entries for this predictor were calculated from weather data with gaps of 12 or more hours and
+      <strong>may not be accurate</strong>. Dismissing this warning will hide it from the status checks.
+    </p>
+    <p class="mb-0 text-muted small">
+      <i class="fa fa-info-circle"></i> You can re-enable the warning at any time from this table.
+    </p>
+  </div>
+  <div class="saveCancel popup-footer text-end">
+    <button class="btn btn-secondary" (click)="cancelIgnoreWarningModal()">Cancel</button>
+    <button class="btn btn-warning" (click)="confirmIgnoreWarningModal()"><i class="fa fa-eye-slash"></i> Dismiss
+      Warning</button>
+  </div>
+  }
 </div>

--- a/src/app/shared/shared-predictors-content/predictors-data-table/predictors-data-table.component.ts
+++ b/src/app/shared/shared-predictors-content/predictors-data-table/predictors-data-table.component.ts
@@ -127,6 +127,7 @@ export class PredictorsDataTableComponent {
   currentPageNumber: number = 1;
   allChecked: boolean = false;
   showBulkDelete: boolean = false;
+  showIgnoreWarningModal: boolean = false;
 
   ngOnInit() {
     this.inDataManagement = this.router.url.includes('data-management');
@@ -318,5 +319,26 @@ export class PredictorsDataTableComponent {
     const predictor = this.predictor();
     const facility = this.facility();
     this.router.navigateByUrl('/data-management/' + facility.accountId + '/facilities/' + facility.guid + '/predictors/' + predictor.guid + '/data-quality-report');
+  }
+
+  async setIgnoreWeatherDataWarning() {
+    const predictor = this.predictor();
+    predictor.ignoreWeatherDataWarning = !predictor.ignoreWeatherDataWarning;
+    await firstValueFrom(this.predictorDbService.updateWithObservable(predictor));
+    const account: IdbAccount = this.accountDbService.selectedAccount.getValue();
+    await this.dbChangesService.setPredictorsV2(account, this.facility());
+  }
+
+  openIgnoreWarningModal() {
+    this.showIgnoreWarningModal = true;
+  }
+
+  cancelIgnoreWarningModal() {
+    this.showIgnoreWarningModal = false;
+  }
+
+  async confirmIgnoreWarningModal() {
+    this.showIgnoreWarningModal = false;
+    await this.setIgnoreWeatherDataWarning();
   }
 }


### PR DESCRIPTION
connects #2464 

This pull request introduces a new feature allowing users to dismiss weather data gap warnings for individual weather predictors or all predictors in a facility. It adds UI controls for dismissing and re-enabling these warnings, updates the predictor model to track this state, and ensures the warning logic respects the new setting. The changes improve user control and reduce unnecessary alerts when users are aware of weather data issues.

**Feature: Weather Data Gap Warning Dismissal**

* Added `ignoreWeatherDataWarning` property to the `IdbPredictor` model to track whether weather gap warnings are ignored for each predictor.
* Updated weather status check logic in `PredictorStatusCheck` to suppress warnings if `ignoreWeatherDataWarning` is set.

**UI Enhancements for Warning Control**

* In the predictors data table and predictors table components, added "Dismiss Warning" and "Dismiss All Weather Gap Warnings" buttons, confirmation modals, and indicators for when warnings are dismissed, along with "Re-enable" options. [[1]](diffhunk://#diff-599aabee7534793574d560acacabce0dae5e2b54e49c1e1d606c8f7e7ab674c3L70-R94) [[2]](diffhunk://#diff-46c7e31abe17511c0438258b462ab41fa3e077242721d64eb406a864166d94aeR135-R148) [[3]](diffhunk://#diff-46c7e31abe17511c0438258b462ab41fa3e077242721d64eb406a864166d94aeR312-R337)
* Added overlay and modal logic to handle warning dismissal confirmations in both individual and bulk contexts. [[1]](diffhunk://#diff-599aabee7534793574d560acacabce0dae5e2b54e49c1e1d606c8f7e7ab674c3L226-R239) [[2]](diffhunk://#diff-599aabee7534793574d560acacabce0dae5e2b54e49c1e1d606c8f7e7ab674c3R272-R297) [[3]](diffhunk://#diff-46c7e31abe17511c0438258b462ab41fa3e077242721d64eb406a864166d94aeL272-R287)

**Component Logic Updates**

* Implemented methods in `PredictorsDataTableComponent` and `PredictorTableComponent` for opening modals, toggling the ignore state, and persisting changes to the database. [[1]](diffhunk://#diff-b7f21605e8ebe107a5099638ef493a2257fdebd525d99ae9c70f24d4ab8019ffR130) [[2]](diffhunk://#diff-b7f21605e8ebe107a5099638ef493a2257fdebd525d99ae9c70f24d4ab8019ffR323-R343) [[3]](diffhunk://#diff-6acee47b08d84180c0f80739174886b37905fe74b5daa8444effd91c6f632735R248-R282)
* Added computed signals and UI state tracking for whether any predictors have warnings dismissed. [[1]](diffhunk://#diff-6acee47b08d84180c0f80739174886b37905fe74b5daa8444effd91c6f632735R85-R93) [[2]](diffhunk://#diff-46c7e31abe17511c0438258b462ab41fa3e077242721d64eb406a864166d94aeR4)

**Minor UI Fix**

* Ensured the utility meter data header only renders if a meter is selected.