### PR TITLE
Issue 2476: bug when entering data in user defined model

### DIFF
--- a/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-menu/regression-model-menu.component.ts
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-menu/regression-model-menu.component.ts
@@ -176,6 +176,7 @@ export class RegressionModelMenuComponent {
   changedModel: { modelId: string, oldModel: JStatRegressionModel, newModel: JStatRegressionModel } | null = null;
   showModelComparison: boolean = false;
   private lastPredictorIds: Array<string> = [];
+  private _suppressFormPatch = false;
 
   // --- Form ---
   form: RegressionMenuForm = this.fb.group({
@@ -220,6 +221,14 @@ export class RegressionModelMenuComponent {
           );
         });
       }
+      // Skip patching form values when the signal update originated from our own save —
+      // the form already has the correct values and patching would reset cursor position.
+      if (this._suppressFormPatch) {
+        this._suppressFormPatch = false;
+        this.updateFieldDisabledStates(group.isGeneratedModel);
+        return;
+      }
+
       // Patch the scalar fields without triggering valueChanges
       this.form.patchValue({
         isGeneratedModel: group.isGeneratedModel,
@@ -327,6 +336,7 @@ export class RegressionModelMenuComponent {
     const selectedAccount: IdbAccount = this.selectedAccount();
     this.dbChangesService.setAnalysisItems(selectedAccount, false, this.selectedFacility());
     this.analysisDbService.selectedAnalysisItem.next(_analysisItem);
+    this._suppressFormPatch = true;
     this.analysisService.selectedGroup.next(_group);
   }
 


### PR DESCRIPTION
connects #2476 

This pull request improves the user experience in the `RegressionModelMenuComponent` by preventing unnecessary form value patching when a model is saved, which could otherwise disrupt the user's cursor position. The core logic introduces a suppression flag to distinguish between internal and external updates to the form.

Key changes:

**Form update suppression logic:**

* Added a private `_suppressFormPatch` flag to the component to track when form patching should be skipped.
* When saving a model, `_suppressFormPatch` is set to `true` before updating the selected group, indicating that the next form patch is internally triggered.
* In the form update handler, checks for `_suppressFormPatch` and, if set, skips patching form values to avoid resetting the cursor position, then resets the flag.