### PR TITLE
Issue 2491: Updates for date entries and navigation in meter data

### DIFF
--- a/src/app/calculations/analysis-calculations/annualAccountAnalysisSummaryClass.ts
+++ b/src/app/calculations/analysis-calculations/annualAccountAnalysisSummaryClass.ts
@@ -157,7 +157,7 @@ export class AnnualAccountAnalysisSummaryClass {
                 // Collect unique meter IDs for all calanderized meters belonging to this group.
                 const groupMeters: Array<IdbUtilityMeter> = meters.filter(meter => meter.groupId === group.idbGroupId);
                 for (const meter of groupMeters) {
-                    if (!includedMeterIds.includes(meter.guid)) {
+                    if (!meter.noLongerInUse && !includedMeterIds.includes(meter.guid)) {
                         includedMeterIds.push(meter.guid);
                     }
                 }

--- a/src/app/calculations/status-check-calculations/analysisStatusCheck.ts
+++ b/src/app/calculations/status-check-calculations/analysisStatusCheck.ts
@@ -196,7 +196,7 @@ export class AnalysisStatusCheck {
             // Collect unique meter IDs for all calanderized meters belonging to this group.
             const groupMeters: Array<MeterStatusCheck> = meterStatusChecks.filter(cm => cm.groupId === group.idbGroupId);
             for (const cm of groupMeters) {
-                if (!includedMeterIds.includes(cm.meterId)) {
+                if (!cm.isMeterNoLongerInUse && !includedMeterIds.includes(cm.meterId)) {
                     includedMeterIds.push(cm.meterId);
                 }
             }

--- a/src/app/calculations/status-check-calculations/analysisStatusCheck.ts
+++ b/src/app/calculations/status-check-calculations/analysisStatusCheck.ts
@@ -80,12 +80,12 @@ export class AnalysisStatusCheck {
         const { includedMeterIds, includedPredictorIds } = this.collectRegressionGroupInputIds(analysisItem.groups, meterStatusChecks);
         this.includedPredictorStatusChecks = includedPredictorIds.map(predictorId =>
             this.getPredictorDateEntry(predictorId, predictorStatusChecks)
-        );
+        ).filter(p => p !== undefined);
         const latestPredictorDates: Array<Date> = this.includedPredictorStatusChecks.map(d => d.latestEntryDate);
 
         this.includedMeterStatusChecks = includedMeterIds.map(meterId =>
             this.getMeterDateEntry(meterId, meterStatusChecks)
-        );
+        ).filter(m => m !== undefined);
         const latestMeterData: Array<Date> = this.includedMeterStatusChecks.map(d => d.lastDateEntry);
 
         const allDates: Array<Date> = [

--- a/src/app/calculations/status-check-calculations/meterStatusCheck.ts
+++ b/src/app/calculations/status-check-calculations/meterStatusCheck.ts
@@ -23,6 +23,7 @@ export class MeterStatusCheck {
     status: STATUS_CHECK_OPTIONS;
     actions: Array<StatusCheckAction>;
     latestFacilityEntryDate: Date;
+    isMeterNoLongerInUse: boolean;
 
     constructor(
         meter: IdbUtilityMeter,
@@ -37,6 +38,7 @@ export class MeterStatusCheck {
         this.meterName = meter.name;
         this.hasNoData = meterReadings.length === 0;
         this.hasNoCalendarizationMethod = !meter.meterReadingDataApplication;
+        this.isMeterNoLongerInUse = meter.noLongerInUse;
         this.setHasNegativeReadings(meter, meterReadings);
         this.latestFacilityEntryDate = facilityLatestEntry ? new Date(facilityLatestEntry.year, facilityLatestEntry.month - 1, 1) : undefined;
         if (calanderizedMeter) {

--- a/src/app/data-management/account-facilities/facility-data/facility-meters/facility-meter/facility-meter.component.html
+++ b/src/app/data-management/account-facilities/facility-data/facility-meters/facility-meter/facility-meter.component.html
@@ -8,6 +8,11 @@
 
         <div class="d-flex w-100 justify-content-end">
           <div>
+            <button class="btn nav-btn me-2" (click)="goToMeterData()">
+              <i class="fa fa-table me-1"></i>View Meter Data
+            </button>
+          </div>
+          <div>
             <button class="btn btn-primary me-2" (click)="saveChanges()"
               [disabled]="meterForm.invalid || meterForm.pristine">
               <span class="fa fa-save"></span>

--- a/src/app/data-management/account-facilities/facility-data/facility-meters/facility-meter/facility-meter.component.ts
+++ b/src/app/data-management/account-facilities/facility-data/facility-meters/facility-meter/facility-meter.component.ts
@@ -180,6 +180,10 @@ export class FacilityMeterComponent {
     this.router.navigateByUrl('/data-management/' + selectedFacility.accountId + '/facilities/' + selectedFacility.guid + '/meters')
   }
 
+  goToMeterData() {
+    this.router.navigateByUrl('/data-management/' + this.utilityMeter.accountId + '/facilities/' + this.utilityMeter.facilityId + '/meters/' + this.utilityMeter.guid + '/meter-data');
+  }
+
   canDeactivate(): Observable<boolean> {
     if (this.meterForm && this.meterForm.dirty) {
       this.routerGuardService.setShowSave(true);

--- a/src/app/shared/shared-meter-content/edit-meter-form/edit-meter-form.component.html
+++ b/src/app/shared/shared-meter-content/edit-meter-form/edit-meter-form.component.html
@@ -350,13 +350,23 @@
             <label class="form-check-label semibold" for="meterNoLongerInUse">No Longer In Use</label>
           </div>
           @if (meterForm.controls.noLongerInUse.value) {
-          <div class="row">
-            <div class="col">
-              <label class="semibold" for="meterNoLongerInUseDate">Stop Month/Year</label>
-              <div class="mb-3">
-                <input id="meterNoLongerInUseDate" class="form-control" type="month"
-                  [value]="noLongerInUseDateValue" (change)="setNoLongerInUseDate($event)">
-              </div>
+          <div class="row g-2 align-items-end mb-3">
+            <div class="col-auto">
+              <label class="semibold d-block" for="noLongerInUseMonth">Stop Month / Year</label>
+              <select id="noLongerInUseMonth" class="form-select" formControlName="noLongerInUseMonth">
+                <option [ngValue]="null" disabled>Month</option>
+                @for (month of months; track month.monthNumValue) {
+                  <option [ngValue]="month.monthNumValue">{{month.abbreviation}}</option>
+                }
+              </select>
+            </div>
+            <div class="col-auto">
+              <select id="noLongerInUseYear" class="form-select" formControlName="noLongerInUseYear" aria-label="Stop year">
+                <option [ngValue]="null" disabled>Year</option>
+                @for (year of noLongerInUseYearOptions; track year) {
+                  <option [ngValue]="year">{{year}}</option>
+                }
+              </select>
             </div>
           </div>
           }

--- a/src/app/shared/shared-meter-content/edit-meter-form/edit-meter-form.component.ts
+++ b/src/app/shared/shared-meter-content/edit-meter-form/edit-meter-form.component.ts
@@ -64,6 +64,10 @@ export class EditMeterFormComponent implements OnInit {
   displayWaterIntakeTypes: boolean;
   displayWaterDischargeTypes: boolean;
   months: Array<Month> = Months;
+  noLongerInUseYearOptions: Array<number> = Array.from(
+    { length: new Date().getFullYear() - 1999 },
+    (_, i) => new Date().getFullYear() - i
+  );
 
   assessmentReportOption: AssessmentReportVersion = 'AR6';
   constructor(

--- a/src/app/shared/shared-meter-content/edit-meter/edit-meter.component.html
+++ b/src/app/shared/shared-meter-content/edit-meter/edit-meter.component.html
@@ -1,19 +1,26 @@
 <div class="row">
   <div class="col-12">
     <div class="d-flex w-100 justify-content-end">
-      <button class="btn btn-secondary me-2" (click)="cancel()">Cancel</button>
-      <button class="btn btn-primary" (click)="saveChanges()" [disabled]="meterForm.invalid">
-        @if (addOrEdit == 'add') {
+      <div>
+        <button class="btn btn-secondary me-2" (click)="cancel()">Cancel</button>
+        <button class="btn btn-primary me-2" (click)="saveChanges()" [disabled]="meterForm.invalid">
+          @if (addOrEdit == 'add') {
           <span>Add Meter</span>
-        }
-        @if (addOrEdit == 'edit') {
+          }
+          @if (addOrEdit == 'edit') {
           <span>Save Changes</span>
+          }
+        </button>
+        @if (addOrEdit == 'edit') {
+        <button class="btn nav-btn" (click)="goToMeterData()">
+          <i class="fa fa-table me-1"></i>View Meter Data
+        </button>
         }
-      </button>
+      </div>
     </div>
   </div>
   <div class="col-12">
     <app-edit-meter-form [meterForm]="meterForm" [meterDataExists]="meterDataExists"
-    [facility]="selectedFacility"></app-edit-meter-form>
+      [facility]="selectedFacility"></app-edit-meter-form>
   </div>
 </div>

--- a/src/app/shared/shared-meter-content/edit-meter/edit-meter.component.ts
+++ b/src/app/shared/shared-meter-content/edit-meter/edit-meter.component.ts
@@ -116,6 +116,10 @@ export class EditMeterComponent implements OnInit {
     this.router.navigateByUrl('/data-evaluation/facility/' + selectedFacility.guid + '/utility/energy-consumption/energy-source/meters')
   }
 
+  goToMeterData() {
+    this.router.navigateByUrl('/data-evaluation/facility/' + this.selectedFacility.guid + '/utility/energy-consumption/utility-meter/' + this.editMeter.guid + '/data-table');
+  }
+
   async updateMeterData(meter: IdbUtilityMeter) {
     this.loadingService.setLoadingMessage('Updating Meter Data...')
     this.loadingService.setLoadingStatus(true);

--- a/src/app/shared/shared-meter-content/meter-data/meter-data-table/meter-data-table.component.css
+++ b/src/app/shared/shared-meter-content/meter-data/meter-data-table/meter-data-table.component.css
@@ -5,3 +5,7 @@
 .filter-reading {
     width: auto;
 }
+
+.fw-inherit{
+    font-size: inherit;
+}

--- a/src/app/shared/shared-meter-content/meter-data/meter-data-table/meter-data-table.component.html
+++ b/src/app/shared/shared-meter-content/meter-data/meter-data-table/meter-data-table.component.html
@@ -61,6 +61,10 @@
         [meterData]="_meterData"></app-meter-data-quality-report-modal>
       }
     </div>
+    <!--Meter Settings-->
+    <div class="ps-1 pe-1 mb-2">
+      <button class="btn nav-btn" (click)="editMeter()" title="Meter Settings"><i class="fa fa-gear"></i> Meter Settings</button>
+    </div>
     <!--Import/Export-->
     <div class="ps-1 pe-1 mb-2">
       <button class="btn nav-btn" (click)="uploadData()"><i class="fa fa-upload"></i> Import Data</button>
@@ -89,12 +93,23 @@
   </div>
   }
   @if(_meterStatusCheck.isDataCurrent == false && _meterStatusCheck.lastDateEntry){
-  <div class="alert alert-warning text-center p-1 fw-bold">
-    <span class="fa fa-triangle-exclamation"></span>
-    Facility data calendarized through {{_meterStatusCheck.latestFacilityEntryDate | date:'MMM, yyyy'}} but this meter
-    only has monthly data through
-    {{_meterStatusCheck.lastDateEntry | date:'MMM, yyyy'}}.
-  </div>
+    @if(_meterStatusCheck.isMeterNoLongerInUse){
+    <div class="alert alert-secondary text-center p-1">
+      <span class="fa fa-circle-info me-1"></span>
+      This meter is no longer in use. Data was last recorded through
+      <strong>{{_meterStatusCheck.lastDateEntry | date:'MMM, yyyy'}}</strong>.
+    </div>
+    } @else {
+    <div class="alert alert-warning text-center p-1 fw-bold">
+      <span class="fa fa-triangle-exclamation me-1"></span>
+      Facility data calendarized through {{_meterStatusCheck.latestFacilityEntryDate | date:'MMM, yyyy'}} but this meter
+      only has monthly data through
+      {{_meterStatusCheck.lastDateEntry | date:'MMM, yyyy'}}.
+      <div class="fw-normal mt-1 small">
+        If this meter is no longer active, <a class="click-link fw-inherit" (click)="editMeter()">update the meter settings</a> to mark it as no longer in use.
+      </div>
+    </div>
+    }
   }
   <div class="row no-margin">
     <div class="col no-margin table-responsive">

--- a/src/app/shared/shared-predictors-content/calculated-predictor-data-update/calculated-predictor-data-update.component.html
+++ b/src/app/shared/shared-predictors-content/calculated-predictor-data-update/calculated-predictor-data-update.component.html
@@ -1,21 +1,58 @@
 <div class="d-flex w-100 justify-content-between mb-2">
-  <div class="d-flex">
-    <div class="d-flex pe-4">
-      <label class="label mt-auto" for="startDate">Start Date</label>
-      <div class="input-group">
-        <input id="startDate" class="form-control" type="month" [ngModel]="startDate | date:'yyyy-MM'"
-          (ngModelChange)="setStartDate($event)" name="date" [disabled]="calculatingData">
+  <div class="d-flex gap-3">
+    <div>
+      <label class="label d-block mb-1" for="startDateMonth">Start Date</label>
+      <div class="d-flex gap-1">
+        <select id="startDateMonth" class="form-select form-select-sm"
+          [ngModel]="startDate?.getMonth() ?? null"
+          (ngModelChange)="onStartMonthChange($event)"
+          [disabled]="calculatingData">
+          <option [ngValue]="null" disabled>Month</option>
+          @for (month of months; track month.monthNumValue) {
+            <option [ngValue]="month.monthNumValue">{{month.abbreviation}}</option>
+          }
+        </select>
+        <select id="startDateYear" class="form-select form-select-sm"
+          [ngModel]="startDate?.getFullYear() ?? null"
+          (ngModelChange)="onStartYearChange($event)"
+          [disabled]="calculatingData">
+          <option [ngValue]="null" disabled>Year</option>
+          @for (year of yearOptions; track year) {
+            <option [ngValue]="year">{{year}}</option>
+          }
+        </select>
       </div>
     </div>
-    <div class="d-flex">
-      <label class="label mt-auto" for="endDate">End Date</label>
-      <div class="input-group">
-        <input id="endDate" class="form-control" type="month" [ngModel]="endDate | date:'yyyy-MM'"
-          (ngModelChange)="setEndDate($event)" name="date" [disabled]="calculatingData">
+    <div>
+      <label class="label d-block mb-1" for="endDateMonth">End Date</label>
+      <div class="d-flex gap-1">
+        <select id="endDateMonth" class="form-select form-select-sm"
+          [ngModel]="endDate?.getMonth() ?? null"
+          (ngModelChange)="onEndMonthChange($event)"
+          [disabled]="calculatingData">
+          <option [ngValue]="null" disabled>Month</option>
+          @for (month of months; track month.monthNumValue) {
+            <option [ngValue]="month.monthNumValue">{{month.abbreviation}}</option>
+          }
+        </select>
+        <select id="endDateYear" class="form-select form-select-sm"
+          [ngModel]="endDate?.getFullYear() ?? null"
+          (ngModelChange)="onEndYearChange($event)"
+          [disabled]="calculatingData">
+          <option [ngValue]="null" disabled>Year</option>
+          @for (year of yearOptions; track year) {
+            <option [ngValue]="year">{{year}}</option>
+          }
+        </select>
       </div>
+      @if (endDate > today) {
+        <div class="text-danger small mt-1">
+          <i class="fa fa-clock me-1"></i>Sorry, we can't predict the weather...
+        </div>
+      }
     </div>
   </div>
-  <div class="d-flex">
+  <div class="d-flex align-items-end">
     <!--Items Per Page-->
     @if (firstMeterReading) {
       <button class="btn btn-outline me-1" (click)="openCheckForUpdatesModal()">

--- a/src/app/shared/shared-predictors-content/calculated-predictor-data-update/calculated-predictor-data-update.component.ts
+++ b/src/app/shared/shared-predictors-content/calculated-predictor-data-update/calculated-predictor-data-update.component.ts
@@ -354,15 +354,17 @@ export class CalculatedPredictorDataUpdateComponent {
   }
 
   async onStartMonthChange(month: number) {
-    if (this.startDate && month != null) {
-      this.startDate = new Date(this.startDate.getFullYear(), month, 1);
+    if (month != null) {
+      const year = this.startDate?.getFullYear() ?? this.today.getFullYear();
+      this.startDate = new Date(year, month, 1);
       await this.updateDataDateChange();
     }
   }
 
   async onStartYearChange(year: number) {
-    if (this.startDate && year != null) {
-      this.startDate = new Date(year, this.startDate.getMonth(), 1);
+    if (year != null) {
+      const month = this.startDate?.getMonth() ?? this.today.getMonth();
+      this.startDate = new Date(year, month, 1);
       await this.updateDataDateChange();
     }
   }

--- a/src/app/shared/shared-predictors-content/calculated-predictor-data-update/calculated-predictor-data-update.component.ts
+++ b/src/app/shared/shared-predictors-content/calculated-predictor-data-update/calculated-predictor-data-update.component.ts
@@ -370,15 +370,17 @@ export class CalculatedPredictorDataUpdateComponent {
   }
 
   async onEndMonthChange(month: number) {
-    if (this.endDate && month != null) {
-      this.endDate = new Date(this.endDate.getFullYear(), month, 1);
+    if (month != null) {
+      const year = this.endDate?.getFullYear() ?? this.today.getFullYear();
+      this.endDate = new Date(year, month, 1);
       await this.updateDataDateChange();
     }
   }
 
   async onEndYearChange(year: number) {
-    if (this.endDate && year != null) {
-      this.endDate = new Date(year, this.endDate.getMonth(), 1);
+    if (year != null) {
+      const month = this.endDate?.getMonth() ?? this.today.getMonth();
+      this.endDate = new Date(year, month, 1);
       await this.updateDataDateChange();
     }
   }

--- a/src/app/shared/shared-predictors-content/calculated-predictor-data-update/calculated-predictor-data-update.component.ts
+++ b/src/app/shared/shared-predictors-content/calculated-predictor-data-update/calculated-predictor-data-update.component.ts
@@ -20,6 +20,7 @@ import { getDegreeDayAmount } from 'src/app/shared/sharedHelperFunctions';
 import { PredictorDataHelperService } from 'src/app/shared/helper-services/predictor-data-helper.service';
 import { WeatherDataService } from 'src/app/weather-data/weather-data.service';
 import { getDateFromPredictorData } from '../../dateHelperFunctions';
+import { Month, Months } from '../../form-data/months';
 
 @Component({
   selector: 'app-calculated-predictor-data-update',
@@ -61,6 +62,13 @@ export class CalculatedPredictorDataUpdateComponent {
 
   displayUpdatesModal: boolean = false;
   checkForUpdates: boolean = false;
+
+  months: Array<Month> = Months;
+  today: Date = new Date();
+  yearOptions: Array<number> = Array.from(
+    { length: new Date().getFullYear() - 1999 },
+    (_, i) => new Date().getFullYear() - i
+  );
   constructor(private activatedRoute: ActivatedRoute, private predictorDbService: PredictorDbService,
     private predictorDataDbService: PredictorDataDbService,
     private sharedDataService: SharedDataService,
@@ -343,6 +351,34 @@ export class CalculatedPredictorDataUpdateComponent {
     //-1 on month
     this.startDate = new Date(Number(yearMonth[0]), Number(yearMonth[1]) - 1, 1);
     await this.updateDataDateChange();
+  }
+
+  async onStartMonthChange(month: number) {
+    if (this.startDate && month != null) {
+      this.startDate = new Date(this.startDate.getFullYear(), month, 1);
+      await this.updateDataDateChange();
+    }
+  }
+
+  async onStartYearChange(year: number) {
+    if (this.startDate && year != null) {
+      this.startDate = new Date(year, this.startDate.getMonth(), 1);
+      await this.updateDataDateChange();
+    }
+  }
+
+  async onEndMonthChange(month: number) {
+    if (this.endDate && month != null) {
+      this.endDate = new Date(this.endDate.getFullYear(), month, 1);
+      await this.updateDataDateChange();
+    }
+  }
+
+  async onEndYearChange(year: number) {
+    if (this.endDate && year != null) {
+      this.endDate = new Date(year, this.endDate.getMonth(), 1);
+      await this.updateDataDateChange();
+    }
   }
 
   openCheckForUpdatesModal() {


### PR DESCRIPTION
connects #2491 

This pull request introduces several improvements and new features to the meter management and data entry UI, as well as enhancements to status calculations and user feedback for meters that are no longer in use. The most notable changes are improved handling and display of "no longer in use" meters, more flexible date selection in forms, and enhanced navigation between meter data and settings.

**Meter status and handling improvements:**

* Meters marked as "no longer in use" are now excluded from group calculations in both `AnnualAccountAnalysisSummaryClass` and `AnalysisStatusCheck`, preventing them from affecting analysis results. The `MeterStatusCheck` class now tracks this status with a new `isMeterNoLongerInUse` property. [[1]](diffhunk://#diff-bdce21cff05541c4e2909dd1087dad44d72033932ed0d63abd68855c8045c33eL160-R160) [[2]](diffhunk://#diff-31875925cf2827d54219cf9ab10a37c8e0b968f401d8e82e6fc8fb3debcb5ae8L83-R88) [[3]](diffhunk://#diff-31875925cf2827d54219cf9ab10a37c8e0b968f401d8e82e6fc8fb3debcb5ae8L199-R199) [[4]](diffhunk://#diff-b3e8054081dea20ead1a13c2fa6fdd5734e680cb3327dbfd19b9441c2e33517dR26) [[5]](diffhunk://#diff-b3e8054081dea20ead1a13c2fa6fdd5734e680cb3327dbfd19b9441c2e33517dR41)
* The meter data table now displays a clear alert when a meter is no longer in use, including the last recorded data date, and provides a prompt to update the meter settings if needed.

**User interface and navigation enhancements:**

* Added "View Meter Data" buttons to meter edit and detail screens, allowing quick navigation from meter settings to the data table for easier data review and editing. [[1]](diffhunk://#diff-d5391b02c4ecaf314ef0518a3fd76778d1aa35c7119ffb9b1ed759c2ab73946fR10-R14) [[2]](diffhunk://#diff-e71836099ae3cbb987636841b7ca13c8170339c0f753a69475e78eb09555239fR183-R186) [[3]](diffhunk://#diff-ea1d98eb00594b6f342de6c519850c86502d04f4c2639b96c161167f38f6ffc0R4-R19) [[4]](diffhunk://#diff-19cc8a3dae9db732e158914c129a4e08263a7870b67676d4d8826a57f7578564R119-R122)
* The meter data table now includes a "Meter Settings" button, enabling users to quickly access and edit meter configuration from the data view.

**Form and date selection improvements:**

* Updated the "No Longer In Use" date selector in the meter edit form to use separate dropdowns for month and year, improving usability and consistency, with dynamic year options generated from 2000 to the current year. [[1]](diffhunk://#diff-5e30234583ca8af55ca4a037995462c5743be9b6b6bcbac9a2541fe1bb4a5d3fL353-R369) [[2]](diffhunk://#diff-580d62058487db66526c4aa3fb948f4b722086d8322fbde5732a4af28a3fdd99R67-R70)
* The calculated predictor data update component now uses month/year dropdowns for date ranges instead of free-form month input, with validation and improved UI for selecting date ranges. [[1]](diffhunk://#diff-7dfcd917eed9af076f20900af5f05390958baf096ac770b56c74e525e0529445L2-R55) [[2]](diffhunk://#diff-7e3d5e2f11ab247c6181e11b81c6a0fa633d899cde44206e64e025df106a0135R23) [[3]](diffhunk://#diff-7e3d5e2f11ab247c6181e11b81c6a0fa633d899cde44206e64e025df106a0135R65-R71) [[4]](diffhunk://#diff-7e3d5e2f11ab247c6181e11b81c6a0fa633d899cde44206e64e025df106a0135R356-R383)

**Styling and minor UI improvements:**

* Added a `.fw-inherit` CSS class for inheriting font size, used in help text and links within alerts for better visual consistency.

These changes collectively improve both the accuracy of analysis calculations and the user experience when managing meters and their data.