### PR TITLE
Chore: Cleanup MacOS Certificate Setup and Release Targets

### DIFF
--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -79,9 +79,6 @@ jobs:
           APPLE_PROV_PROF_BASE64: ${{ secrets.APPLE_PROV_PROF_BASE64 }}
           APPLE_CERT_SECRET: ${{ secrets.APPLE_CERT_SECRET }}
           APPLE_KEYCHAIN_SECRET: ${{ secrets.APPLE_KEYCHAIN_SECRET }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_APP_SECRET: ${{ secrets.APPLE_APP_SECRET }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           CERT_A_PATH=$RUNNER_TEMP/app_certificate.p12
           PROV_PROF_PATH=$RUNNER_TEMP/AMO.provisionprofile

--- a/.github/workflows/release_desktop.yml
+++ b/.github/workflows/release_desktop.yml
@@ -76,7 +76,6 @@ jobs:
       - name: Cert setup
         env:
           APPLE_CERT_A_BASE64: ${{ secrets.APPLE_CERT_A_BASE64 }}
-          APPLE_CERT_I_BASE64: ${{ secrets.APPLE_CERT_I_BASE64 }}
           APPLE_PROV_PROF_BASE64: ${{ secrets.APPLE_PROV_PROF_BASE64 }}
           APPLE_CERT_SECRET: ${{ secrets.APPLE_CERT_SECRET }}
           APPLE_KEYCHAIN_SECRET: ${{ secrets.APPLE_KEYCHAIN_SECRET }}
@@ -85,12 +84,10 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           CERT_A_PATH=$RUNNER_TEMP/app_certificate.p12
-          CERT_I_PATH=$RUNNER_TEMP/ins_certificate.p12
           PROV_PROF_PATH=$RUNNER_TEMP/AMO.provisionprofile
           KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain
 
           echo -n "$APPLE_CERT_A_BASE64" | base64 --decode -o $CERT_A_PATH
-          echo -n "$APPLE_CERT_I_BASE64" | base64 --decode -o $CERT_I_PATH
           echo -n "$APPLE_PROV_PROF_BASE64" | base64 --decode -o $PROV_PROF_PATH
 
           security -v create-keychain -p "$APPLE_KEYCHAIN_SECRET" $KEYCHAIN_PATH
@@ -99,7 +96,6 @@ jobs:
           security -v unlock-keychain -p "$APPLE_KEYCHAIN_SECRET" $KEYCHAIN_PATH
 
           security -v import $CERT_A_PATH -P "$APPLE_CERT_SECRET" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
-          security -v import $CERT_I_PATH -P "$APPLE_CERT_SECRET" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$APPLE_KEYCHAIN_SECRET" $KEYCHAIN_PATH
 
           cp "$PROV_PROF_PATH" ./embedded.provisionprofile
@@ -252,6 +248,8 @@ jobs:
         # if: startsWith(github.ref, 'refs/tags/') # Uncomment if enabling tag gating
         with:
           name: VERIFI v${{ env.VERSION }}
+          tag_name: v${{ env.VERSION }}
+          target_commitish: master
           draft: true # Comment out if enabling tag gating and publishing via action
           generate_release_notes: true
           files: |


### PR DESCRIPTION
## Overview
Removal of an irrelevant, unused certificate that is not leveraged in the codesigning and notarization workflow for MacOS builds. Additionally piggybacking on a change to ensure that the `master` branch is the default target when producing draft releases for production builds.

## Changes
  - Remove apple installer certificate setup for desktop releases due to irrelevance in workflow/output
  - Piggyback change to ensure production branch is used for desktop release tagging