### PR TITLE
Issue 2256 - fixed water reduction goal bug

### DIFF
--- a/src/app/data-evaluation/account/account-analysis/account-analysis-dashboard/account-analysis-details-table/account-analysis-details-table.component.ts
+++ b/src/app/data-evaluation/account/account-analysis/account-analysis-dashboard/account-analysis-details-table/account-analysis-details-table.component.ts
@@ -76,7 +76,7 @@ export class AccountAnalysisDetailsTableComponent {
   baselineYearErrorMinEnergy: Signal<boolean> = computed(() => {
     const account = this.selectedAccount();
     const yearOptionsEnergy = this.yearOptionsEnergy();
-    if (yearOptionsEnergy && yearOptionsEnergy.length > 0 && account) {
+    if (yearOptionsEnergy && account.sustainabilityQuestions.energyReductionGoal && yearOptionsEnergy.length > 0 && account) {
       return yearOptionsEnergy[0] > account.sustainabilityQuestions.energyReductionBaselineYear;
     }
     return false;
@@ -84,7 +84,7 @@ export class AccountAnalysisDetailsTableComponent {
   baselineYearErrorMaxEnergy: Signal<boolean> = computed(() => {
     const account = this.selectedAccount();
     const yearOptionsEnergy = this.yearOptionsEnergy();
-    if (yearOptionsEnergy && yearOptionsEnergy.length > 0 && account) {
+    if (yearOptionsEnergy && account.sustainabilityQuestions.energyReductionGoal && yearOptionsEnergy.length > 0 && account) {
       return yearOptionsEnergy[yearOptionsEnergy.length - 1] < account.sustainabilityQuestions.energyReductionBaselineYear;
     }
     return false;
@@ -92,7 +92,7 @@ export class AccountAnalysisDetailsTableComponent {
   baselineYearErrorMinWater: Signal<boolean> = computed(() => {
     const account = this.selectedAccount();
     const yearOptionsWater = this.yearOptionsWater();
-    if (yearOptionsWater && yearOptionsWater.length > 0 && account) {
+    if (yearOptionsWater && account.sustainabilityQuestions.waterReductionGoal && yearOptionsWater.length > 0 && account) {
       return yearOptionsWater[0] > account.sustainabilityQuestions.waterReductionBaselineYear;
     }
     return false;
@@ -100,7 +100,7 @@ export class AccountAnalysisDetailsTableComponent {
   baselineYearErrorMaxWater: Signal<boolean> = computed(() => {
     const account = this.selectedAccount();
     const yearOptionsWater = this.yearOptionsWater();
-    if (yearOptionsWater && yearOptionsWater.length > 0 && account) {
+    if (yearOptionsWater && account.sustainabilityQuestions.waterReductionGoal && yearOptionsWater.length > 0 && account) {
       return yearOptionsWater[yearOptionsWater.length - 1] < account.sustainabilityQuestions.waterReductionBaselineYear;
     }
     return false;

--- a/src/app/data-evaluation/facility/analysis/analysis-dashboard/analysis-details-table/analysis-details-table.component.ts
+++ b/src/app/data-evaluation/facility/analysis/analysis-dashboard/analysis-details-table/analysis-details-table.component.ts
@@ -159,7 +159,7 @@ export class AnalysisDetailsTableComponent {
   baselineYearErrorMinEnergy: Signal<boolean> = computed(() => {
     const selectedFacility = this.selectedFacility();
     const yearOptionsEnergy = this.yearOptionsEnergy();
-    if (yearOptionsEnergy && yearOptionsEnergy.length > 0 && selectedFacility) {
+    if (yearOptionsEnergy && selectedFacility.sustainabilityQuestions.energyReductionGoal && yearOptionsEnergy.length > 0 && selectedFacility) {
       return yearOptionsEnergy[0] > selectedFacility.sustainabilityQuestions.energyReductionBaselineYear;
     }
     return false;
@@ -167,7 +167,7 @@ export class AnalysisDetailsTableComponent {
   baselineYearErrorMaxEnergy: Signal<boolean> = computed(() => {
     const selectedFacility = this.selectedFacility();
     const yearOptionsEnergy = this.yearOptionsEnergy();
-    if (yearOptionsEnergy && yearOptionsEnergy.length > 0 && selectedFacility) {
+    if (yearOptionsEnergy && selectedFacility.sustainabilityQuestions.energyReductionGoal && yearOptionsEnergy.length > 0 && selectedFacility) {
       return yearOptionsEnergy[yearOptionsEnergy.length - 1] < selectedFacility.sustainabilityQuestions.energyReductionBaselineYear;
     }
     return false;
@@ -175,7 +175,7 @@ export class AnalysisDetailsTableComponent {
   baselineYearErrorMinWater: Signal<boolean> = computed(() => {
     const selectedFacility = this.selectedFacility();
     const yearOptionsWater = this.yearOptionsWater();
-    if (yearOptionsWater && yearOptionsWater.length > 0 && selectedFacility) {
+    if (yearOptionsWater && selectedFacility.sustainabilityQuestions.waterReductionGoal && yearOptionsWater.length > 0 && selectedFacility) {
       return yearOptionsWater[0] > selectedFacility.sustainabilityQuestions.waterReductionBaselineYear;
     }
     return false;
@@ -183,7 +183,7 @@ export class AnalysisDetailsTableComponent {
   baselineYearErrorMaxWater: Signal<boolean> = computed(() => {
     const selectedFacility = this.selectedFacility();
     const yearOptionsWater = this.yearOptionsWater();
-    if (yearOptionsWater && yearOptionsWater.length > 0 && selectedFacility) {
+    if (yearOptionsWater && selectedFacility.sustainabilityQuestions.waterReductionGoal && yearOptionsWater.length > 0 && selectedFacility) {
       return yearOptionsWater[yearOptionsWater.length - 1] < selectedFacility.sustainabilityQuestions.waterReductionBaselineYear;
     }
     return false;


### PR DESCRIPTION
connects #2256 

This pull request updates the logic for displaying baseline year errors in both the account and facility analysis details tables. The main improvement is that baseline year error checks for energy and water are now only performed if the corresponding reduction goals are set, preventing unnecessary or incorrect error states when goals are not specified.

Logic updates for baseline year error checks:

* In `account-analysis-details-table.component.ts`, all baseline year error checks for energy and water now require that the relevant reduction goal (`energyReductionGoal` or `waterReductionGoal`) is set before evaluating the error condition.
* In `analysis-details-table.component.ts`, the same logic is applied at the facility level, ensuring baseline year errors are only checked if the facility has the appropriate reduction goal set.