### PR TITLE
Issue 2501

### DIFF
--- a/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.ts
+++ b/src/app/data-evaluation/account/account-analysis/select-facility-analysis-items/select-facility-analysis-items.component.ts
@@ -13,6 +13,8 @@ import { IdbAccountReport } from 'src/app/models/idbModels/accountReport';
 import { AnalysisStatusCheck } from 'src/app/calculations/status-check-calculations/analysisStatusCheck';
 import { AccountStatusCheckService } from 'src/app/shared/helper-services/account-status-check.service';
 import { AccountStatusCheck } from 'src/app/calculations/status-check-calculations/accountStatusCheck';
+import { AccountdbService } from 'src/app/indexedDB/account-db.service';
+import { IdbAccount } from 'src/app/models/idbModels/account';
 
 interface FacilityListItem {
   facility: IdbFacility;
@@ -34,6 +36,7 @@ export class SelectFacilityAnalysisItemsComponent {
   private accountAnalysisService: AccountAnalysisService = inject(AccountAnalysisService);
   private accountReportDbService: AccountReportDbService = inject(AccountReportDbService);
   private accountStatusCheckService: AccountStatusCheckService = inject(AccountStatusCheckService);
+  private accountDbService: AccountdbService = inject(AccountdbService);
 
   selectedAnalysisItem: Signal<IdbAccountAnalysisItem> = toSignal(this.accountAnalysisDbService.selectedAnalysisItem);
   facilityAnalysisItems: Signal<Array<IdbAnalysisItem>> = toSignal(this.analysisDbService.facilityAnalysisItems);
@@ -42,15 +45,22 @@ export class SelectFacilityAnalysisItemsComponent {
   accountReports: Signal<Array<IdbAccountReport>> = toSignal(this.accountReportDbService.accountReports);
   hideInUseMessage: Signal<boolean> = toSignal(this.accountAnalysisService.hideInUseMessage);
   accountStatusCheck: Signal<AccountStatusCheck> = toSignal(this.accountStatusCheckService.accountStatusCheck);
+  account: Signal<IdbAccount> = toSignal(this.accountDbService.selectedAccount);
 
   facilityList: Signal<Array<FacilityListItem>> = computed(() => {
     const facilities = this.facilities();
     const facilityAnalysisItems = this.facilityAnalysisItems();
     const analysisItem = this.selectedAnalysisItem();
     const accountStatusCheck = this.accountStatusCheck();
+    const account = this.account();
     if (!facilities || !facilityAnalysisItems || !analysisItem || !accountStatusCheck) {
       return [];
     }
+
+    if(account && account.guid != analysisItem.accountId){
+      return [];
+    }
+    
     return analysisItem.facilityAnalysisItems.map(facilityItem => {
       const facility = facilities.find(fac => fac.guid === facilityItem.facilityId);
       const facilityStatusCheck = accountStatusCheck.getFacilityStatusCheckByFacilityId(facilityItem.facilityId);

--- a/src/app/indexedDB/db-changes.service.ts
+++ b/src/app/indexedDB/db-changes.service.ts
@@ -93,6 +93,17 @@ export class DbChangesService {
       }
     }
     this.facilityDbService.accountFacilities.next(accountFacilites);
+    // const selectedFacility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
+    // if (selectedFacility) {
+    //   const facilityInAccount = accountFacilites.find(fac => fac.guid === selectedFacility.guid);
+    //   if (!facilityInAccount) {
+    //     if (accountFacilites.length > 0) {
+    //       this.facilityDbService.selectedFacility.next(accountFacilites[0]);
+    //     }else{
+    //       this.facilityDbService.selectedFacility.next(null);
+    //     }
+    //   }
+    // }
     //set reports
     await this.setAccountReports(account);
     //set predictors

--- a/src/app/indexedDB/db-changes.service.ts
+++ b/src/app/indexedDB/db-changes.service.ts
@@ -93,17 +93,6 @@ export class DbChangesService {
       }
     }
     this.facilityDbService.accountFacilities.next(accountFacilites);
-    // const selectedFacility: IdbFacility = this.facilityDbService.selectedFacility.getValue();
-    // if (selectedFacility) {
-    //   const facilityInAccount = accountFacilites.find(fac => fac.guid === selectedFacility.guid);
-    //   if (!facilityInAccount) {
-    //     if (accountFacilites.length > 0) {
-    //       this.facilityDbService.selectedFacility.next(accountFacilites[0]);
-    //     }else{
-    //       this.facilityDbService.selectedFacility.next(null);
-    //     }
-    //   }
-    // }
     //set reports
     await this.setAccountReports(account);
     //set predictors

--- a/src/app/shared/helper-services/backup-data.service.ts
+++ b/src/app/shared/helper-services/backup-data.service.ts
@@ -455,7 +455,7 @@ export class BackupDataService {
       accountAnalysisItem.accountId = accountGUIDs.newId;
       accountAnalysisItem.facilityAnalysisItems.forEach(item => {
         item.facilityId = this.getNewId(item.facilityId, facilityGUIDs);
-        if (item.analysisItemId) {
+        if (item.analysisItemId && item.analysisItemId != 'skip') {
           item.analysisItemId = this.getNewId(item.analysisItemId, facilityAnalysisGUIDs);
         }
       });


### PR DESCRIPTION
connects #2501 

This pull request introduces improvements to the facility analysis item selection logic and backup data handling, as well as some minor code cleanups. The main focus is ensuring that only analysis items associated with the currently selected account are shown, and that backup data restores skip certain items as intended.

**Facility Analysis Item Selection Improvements:**

* [`select-facility-analysis-items.component.ts`](diffhunk://#diff-acfe9171a7755e4b084b20c5c66a1ee187feac44238b287f417be19d0d9be08cR16-R17): Now injects `AccountdbService` and tracks the selected account via a new `account` signal. The facility list computation was updated to only return items if the selected analysis item's `accountId` matches the selected account's `guid`, preventing mismatched data from appearing. [[1]](diffhunk://#diff-acfe9171a7755e4b084b20c5c66a1ee187feac44238b287f417be19d0d9be08cR16-R17) [[2]](diffhunk://#diff-acfe9171a7755e4b084b20c5c66a1ee187feac44238b287f417be19d0d9be08cR39) [[3]](diffhunk://#diff-acfe9171a7755e4b084b20c5c66a1ee187feac44238b287f417be19d0d9be08cR48-R63)

**Backup Data Handling:**

* [`backup-data.service.ts`](diffhunk://#diff-4906cee1b9d0b37dc46d3607b481ce0fb5fd940abaec7e39f51242151427552bL458-R458): The logic for restoring `analysisItemId` in facility analysis items now explicitly skips items where the ID is `'skip'`, preventing unwanted ID remapping.