### PR TITLE
Issue 2514 - changes made in regression model year filters dropdown

### DIFF
--- a/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-selection.component.ts
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-selection.component.ts
@@ -139,7 +139,7 @@ export class RegressionModelSelectionComponent {
           this.selectedGroupId = selectedGroup.idbGroupId;
           const groupMeters = calanderizedMeters.filter(cMeter => cMeter.meter.groupId == selectedGroup.idbGroupId);
           const yearsWithFullData = getYearsWithFullData(groupMeters, facility);
-          this.yearOptionSelections.set(yearsWithFullData.map(year => ({ year, isChecked: true })));
+          this.yearOptionSelections.set(yearsWithFullData.map(year => ({ year, isChecked: year >=  this.analysisItem().baselineYear })));
         }
       }
     });


### PR DESCRIPTION
connects #2514 

This pull request makes a targeted improvement to how year options are selected by default in the `RegressionModelSelectionComponent`. Now, only years greater than or equal to the baseline year are checked by default, rather than all years.

Selection logic update:

* Updated the default selection logic in `RegressionModelSelectionComponent` so that only years greater than or equal to the baseline year are checked in `yearOptionSelections` (`regression-model-selection.component.ts`).