### PR TITLE
Issue 2498: remove auto selection of models

### DIFF
--- a/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-menu/regression-model-menu.component.html
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-menu/regression-model-menu.component.html
@@ -116,7 +116,7 @@
           @if (!_generatingModels) {
           <div class="p-0">
             @if (!_generatedModels || _generatedModels.length == 0) {
-            <button class="mt-0 btn action-btn" (click)="generateModels(true)">Generate
+            <button class="mt-0 btn action-btn" (click)="generateModels()">Generate
               Models</button>
             }
           </div>

--- a/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-menu/regression-model-menu.component.ts
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-menu/regression-model-menu.component.ts
@@ -380,7 +380,7 @@ export class RegressionModelMenuComponent {
     await this.saveItem(_group);
   }
 
-  async generateModels(autoSelect = false) {
+  async generateModels() {
     const group = _.cloneDeep(this.group());
     const _analysisItem = this.analysisItem();
     const _selectedFacility = this.selectedFacility();
@@ -399,7 +399,7 @@ export class RegressionModelMenuComponent {
       const generatedModels = await this.regressionModelsService.generateModels(
         group, _analysisItem, _selectedFacility, _meters, _meterData, _predictorData, assessmentReportVersion
       );
-      await this.handleGenerateResult(generatedModels, group, autoSelect, previousSelectedModelId, previousSelectedModel);
+      await this.handleGenerateResult(generatedModels, group, previousSelectedModelId, previousSelectedModel);
     } catch {
       this.modelingError.set(true);
       this.generatingModels.set(false);
@@ -409,14 +409,12 @@ export class RegressionModelMenuComponent {
   private async handleGenerateResult(
     generatedModels: Array<JStatRegressionModel>,
     group: AnalysisGroup,
-    autoSelect: boolean,
     previousSelectedModelId: string | undefined,
     previousSelectedModel: JStatRegressionModel | undefined
   ): Promise<void> {
     const { updatedGroup, newSelectedModel } = this.regressionModelsService.applyGeneratedModelsToGroup(
       group,
       generatedModels,
-      autoSelect,
       previousSelectedModelId,
       previousSelectedModel,
       this.selectedFacility(),

--- a/src/app/shared/shared-analysis/calculations/regression-models.service.ts
+++ b/src/app/shared/shared-analysis/calculations/regression-models.service.ts
@@ -85,7 +85,6 @@ export class RegressionModelsService {
   applyGeneratedModelsToGroup(
     group: AnalysisGroup,
     generatedModels: Array<JStatRegressionModel>,
-    autoSelect: boolean,
     previousSelectedModelId: string | undefined,
     previousSelectedModel: JStatRegressionModel | undefined,
     facility: IdbFacility,
@@ -107,14 +106,6 @@ export class RegressionModelsService {
     if (hadPreviousSelection) {
       updatedGroup = convertOrphanedGeneratedModelToUserDefined(updatedGroup, facility, fallbackYear);
       return { updatedGroup, newSelectedModel: undefined };
-    }
-
-    if (autoSelect) {
-      const bestModel = _.maxBy(generatedModels, 'adjust_R2');
-      if (bestModel) {
-        updatedGroup = this.applySelectedModelToGroup(updatedGroup, bestModel);
-        return { updatedGroup, newSelectedModel: bestModel };
-      }
     }
 
     return {


### PR DESCRIPTION
connects #2498 

This pull request removes the unused `autoSelect` parameter and its associated logic from the regression model generation flow. The changes simplify the process for generating regression models and applying them to groups by eliminating automatic model selection.

Key changes:

**Removal of autoSelect parameter and logic:**

* Removed the `autoSelect` parameter from the `generateModels` method in `RegressionModelMenuComponent` and all related method calls and signatures. [[1]](diffhunk://#diff-551281ad846a27e9cf0b556d79a41faa39ec1b5e3d669d9a0bcdce58ceebd2a8L383-R383) [[2]](diffhunk://#diff-551281ad846a27e9cf0b556d79a41faa39ec1b5e3d669d9a0bcdce58ceebd2a8L402-R402) [[3]](diffhunk://#diff-551281ad846a27e9cf0b556d79a41faa39ec1b5e3d669d9a0bcdce58ceebd2a8L412-L419) [[4]](diffhunk://#diff-13b87d8412ed66c2f4d7dc8f9370af345b4da09738568232a3b93c6d9501fbdaL88)
* Deleted the logic in `RegressionModelsService.applyGeneratedModelsToGroup` that would automatically select the best model based on `adjust_R2` if `autoSelect` was true. Now, generated models are applied without automatically selecting one.

**UI update:**

* Updated the "Generate Models" button in `regression-model-menu.component.html` to call `generateModels()` without any parameters, reflecting the simplified method signature.