### PR TITLE
Issue 2514 - generate models for all years instead of starting from BL

### DIFF
--- a/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-selection.component.ts
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/group-analysis/regression-model-selection/regression-model-selection.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, effect, ElementRef, HostListener, inject, signal, Signal, ViewChild, WritableSignal } from '@angular/core';
+import { Component, computed, effect, ElementRef, HostListener, inject, signal, Signal, untracked, ViewChild, WritableSignal } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
 import { AccountdbService } from 'src/app/indexedDB/account-db.service';
 import { AnalysisDbService } from 'src/app/indexedDB/analysis-db.service';
@@ -139,7 +139,7 @@ export class RegressionModelSelectionComponent {
           this.selectedGroupId = selectedGroup.idbGroupId;
           const groupMeters = calanderizedMeters.filter(cMeter => cMeter.meter.groupId == selectedGroup.idbGroupId);
           const yearsWithFullData = getYearsWithFullData(groupMeters, facility);
-          this.yearOptionSelections.set(yearsWithFullData.map(year => ({ year, isChecked: year >=  this.analysisItem().baselineYear })));
+          this.yearOptionSelections.set(yearsWithFullData.map(year => ({ year, isChecked: year >= this.analysisItem().baselineYear })));
         }
       }
     });
@@ -164,6 +164,10 @@ export class RegressionModelSelectionComponent {
           }
           if (selectedModel.SEPValidation && !selectedModel.SEPValidation.every(SEPValidation => SEPValidation.isValid) && !this.showFailedValidationModel()) {
             this.showFailedValidationModel.set(true);
+          }
+          const yearOption = untracked(() => this.yearOptionSelections()).find(option => option.year === selectedModel.modelYear);
+          if (yearOption && !yearOption.isChecked) {
+            this.yearOptionSelections.update(selections => selections.map(s => s.year === selectedModel.modelYear ? { ...s, isChecked: true } : s));
           }
         }
       }

--- a/src/app/shared/shared-analysis/calculations/regression-models-calculator.ts
+++ b/src/app/shared/shared-analysis/calculations/regression-models-calculator.ts
@@ -37,7 +37,9 @@ export class RegressionModelsCalculator {
       let allMeterData: Array<MonthlyData> = groupMeters.flatMap(calanderizedMeter => { return calanderizedMeter.monthlyData });
 
       let models: Array<JStatRegressionModel> = new Array();
-      let startYear: number = getFiscalYear(baselineDate, facility);
+
+      const dataYears = _.uniq(allMeterData.map(d => getFiscalYear(new Date(d.date), facility)));
+      let startYear: number = dataYears.length > 0 ? Math.min(...dataYears) : baselineYear;
       while (startYear <= endYear) {
         let modelDateRange: { baselineDate: Date, endDate: Date } = this.getModelMonthlyStartAndEndDate(facility, startYear);
         allPredictorVariableCombos.forEach(variableIdCombo => {


### PR DESCRIPTION
connects #2514 

This pull request introduces improvements to the regression model selection and calculation logic, focusing on ensuring UI consistency and enhancing the determination of the baseline start year for regression models.

**Enhancements to regression model selection and calculation:**

*Regression Model Selection UI:*
- Ensures that when a regression model is selected, the corresponding year option is automatically checked in the UI, even if it was previously unchecked. This uses the `untracked` function to avoid triggering unnecessary reactivity.

*Regression Models Calculation Logic:*
- Updates the calculation of the regression model's baseline start year to dynamically determine the earliest year present in the meter data, rather than relying solely on a static baseline year. This makes the model selection more robust to variations in available data.

*Code Maintenance:*
- Adds the `untracked` import from Angular signals to support the UI logic change.