### PR TITLE
Issue 2256 - add warning message when there are no complete years with data

### DIFF
--- a/src/app/data-evaluation/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.html
+++ b/src/app/data-evaluation/facility/analysis/run-analysis/analysis-setup/analysis-setup.component.html
@@ -130,6 +130,11 @@
             </select>
           </div>
         </div>
+        @if (yearOptions().length == 0) {
+        <div class="alert alert-danger text-center p-1">
+          No valid baseline years available. Please check your data.
+        </div>
+        }
         @if (baselineYearWarning()) {
         <div class="alert alert-warning text-center p-1">
           {{baselineYearWarning()}}


### PR DESCRIPTION
connects #2256 

This pull request adds a user-friendly error message to the analysis setup interface to handle cases where no valid baseline years are available. This helps users quickly identify and resolve data issues during the setup process.

User experience improvements:

* Added an alert message to `analysis-setup.component.html` that displays when there are no valid baseline years, guiding users to check their data.