### PR TITLE
Issue 2604 - add data check issues slides to account and facility savings report

### DIFF
--- a/src/app/data-evaluation/account/account-reports/account-savings-report/account-savings-report-ppt.adapter.ts
+++ b/src/app/data-evaluation/account/account-reports/account-savings-report/account-savings-report-ppt.adapter.ts
@@ -10,6 +10,9 @@ import { AccountSavingsReportSetup } from 'src/app/models/overview-report';
 import { PptDocument } from 'src/app/shared/ppt-report/models/ppt-document';
 import { PptSlide, TableSlide, ChartSlide, TableHeaderCell, getPptAxisSpec } from 'src/app/shared/ppt-report/models/ppt-slide';
 import { CustomNumberPipe } from 'src/app/shared/helper-pipes/custom-number.pipe';
+import { FacilityGroupAnalysisItem, RegressionModelsService } from 'src/app/shared/shared-analysis/calculations/regression-models.service';
+import { AccountWorkspaceQueryService } from 'src/app/account-workspace/account-workspace-query.service';
+import { FacilityModelingReportPptAdapter } from 'src/app/data-evaluation/facility/facility-reports/report-results/facility-modeling-report-results/facility-modeling-report-ppt.adapter';
 
 export interface AccountSavingsReportPptInput {
     report: IdbAccountReport;
@@ -33,9 +36,18 @@ export interface AccountSavingsReportPptInput {
 @Injectable({ providedIn: 'root' })
 export class AccountSavingsReportPptAdapter {
     customNumberPipe: CustomNumberPipe = inject(CustomNumberPipe);
+    accountWorkspaceQuery = inject(AccountWorkspaceQueryService);
+    regressionModelsService = inject(RegressionModelsService);
+    facilityModelingReportPptAdapter = inject(FacilityModelingReportPptAdapter);
 
     analysisTableColumns: AnalysisTableColumns;
     accountAnalysisItem: IdbAccountAnalysisItem;
+    facilityAnalysisItems: Array<IdbAnalysisItem> = [];
+    executiveSummaryItems: Array<FacilityGroupAnalysisItem> = [];
+    regressionGroupItems: Array<FacilityGroupAnalysisItem> = [];
+    criticalItems: Array<FacilityGroupAnalysisItem> = [];
+    moderateItems: Array<FacilityGroupAnalysisItem> = [];
+    minorItems: Array<FacilityGroupAnalysisItem> = [];
 
     buildDocument(data: AccountSavingsReportPptInput): PptDocument {
         const slides: PptSlide[] = [];
@@ -47,6 +59,31 @@ export class AccountSavingsReportPptAdapter {
             title: data.report.name,
             subtitle: data.account.name,
             date: new Date().toISOString(),
+        });
+
+        this.getDataCheckItems(data);
+        let dataCheckSlides: PptSlide[] = [];
+        if (this.criticalItems?.length > 0) {
+            dataCheckSlides.push(this.facilityModelingReportPptAdapter.buildCriticalIssuesSlides(this.criticalItems));
+        }
+        if (this.moderateItems?.length > 0) {
+            dataCheckSlides.push(this.facilityModelingReportPptAdapter.buildModerateIssuesSlides(this.moderateItems));
+        }
+        if (this.minorItems?.length > 0) {
+            dataCheckSlides.push(this.facilityModelingReportPptAdapter.buildMinorIssuesSlides(this.minorItems));
+        }
+        if (dataCheckSlides.length > 0) {
+            slides.push({
+                type: 'title',
+                title: 'Model Validation Check',
+                layout: 'section'
+            });
+            slides.push(...dataCheckSlides);
+        }
+        slides.push({
+            type: 'title',
+            title: 'Account Results',
+            layout: 'section'
         });
 
         if (data.setup.includeAnnualResults && (data.setup.includeAnnualResultsTable || data.setup.includeAnnualResultsGraph || data.setup.includeAccountMonthlyTable || data.setup.includeAccountMonthlyResults)) {
@@ -181,6 +218,39 @@ export class AccountSavingsReportPptAdapter {
             metadata: { title: data.report.name, subtitle: data.account.name },
             slides,
         };
+    }
+
+    getDataCheckItems(data: AccountSavingsReportPptInput) {
+        this.facilityAnalysisItems = data.facilitySummaries.map(fs => fs.analysisItem);
+        this.facilityAnalysisItems.forEach(facilityAnalysisItem => {
+            let facility: IdbFacility = this.accountWorkspaceQuery.getFacilityByGuid(facilityAnalysisItem.facilityId);
+            facilityAnalysisItem.groups.forEach(group => {
+                if (group.analysisType == 'regression') {
+                    let groupItem: FacilityGroupAnalysisItem = this.regressionModelsService.getGroupModelItem(group, facility, facilityAnalysisItem, data.report.reportYear);
+                    if (groupItem) {
+                        this.executiveSummaryItems.push(groupItem);
+                    }
+                } else if (group.analysisType != 'skip') {
+                    this.executiveSummaryItems.push({
+                        group: group,
+                        facilityId: facility.guid,
+                        baselineYear: facilityAnalysisItem.baselineYear,
+                        selectedModel: undefined
+                    });
+                }
+            });
+        });
+
+        this.regressionGroupItems = this.executiveSummaryItems.filter(item => item.group.analysisType == 'regression');
+        this.criticalItems = this.regressionGroupItems.filter(item => {
+            return (item.group.analysisType == 'regression' && !item.selectedModel.isValid);
+        });
+        this.moderateItems = this.regressionGroupItems.filter(item => {
+            return (item.group.analysisType == 'regression' && !item.selectedModel.SEPValidationPass && item.selectedModel.dataValidationNotes && item.selectedModel.dataValidationNotes.length > 0);
+        });
+        this.minorItems = this.regressionGroupItems.filter(item => {
+            return (item.group.analysisType == 'regression' && item.selectedModel.modelNotes && item.selectedModel.modelNotes.length > 0);
+        });
     }
 
     private buildAnnualConsumptionTable(summaries: Array<AnnualAnalysisSummary>, latestMonthSummary: MonthlyAnalysisSummaryData): TableSlide {

--- a/src/app/data-evaluation/facility/facility-reports/report-results/facility-savings-report-results/facility-savings-report-ppt.adapter.ts
+++ b/src/app/data-evaluation/facility/facility-reports/report-results/facility-savings-report-results/facility-savings-report-ppt.adapter.ts
@@ -7,6 +7,8 @@ import { PptDocument } from 'src/app/shared/ppt-report/models/ppt-document';
 import { PptSlide, TableSlide, ChartSlide, TableHeaderCell, getPptAxisSpec } from 'src/app/shared/ppt-report/models/ppt-slide';
 import { CustomNumberPipe } from 'src/app/shared/helper-pipes/custom-number.pipe';
 import { IdbFacilityReport, SavingsFacilityReportSettings } from 'src/app/models/idbModels/facilityReport';
+import { FacilityGroupAnalysisItem, RegressionModelsService } from 'src/app/shared/shared-analysis/calculations/regression-models.service';
+import { FacilityModelingReportPptAdapter } from '../facility-modeling-report-results/facility-modeling-report-ppt.adapter';
 
 export interface FacilitySavingsReportPptInput {
     facility: IdbFacility;
@@ -26,12 +28,19 @@ export interface FacilitySavingsReportPptInput {
 
 @Injectable({ providedIn: 'root' })
 export class FacilitySavingsReportPptAdapter {
-  private readonly accountWorkspaceQuery = inject(AccountWorkspaceQueryService);
+    private readonly accountWorkspaceQuery = inject(AccountWorkspaceQueryService);
     customNumberPipe: CustomNumberPipe = inject(CustomNumberPipe);
+    regressionModelsService = inject(RegressionModelsService);
+    facilityModelingReportPptAdapter = inject(FacilityModelingReportPptAdapter);
 
     analysisTableColumns: AnalysisTableColumns;
     analysisItem: IdbAnalysisItem;
     reportSettings: SavingsFacilityReportSettings;
+    executiveSummaryItems: Array<FacilityGroupAnalysisItem> = [];
+    regressionGroupItems: Array<FacilityGroupAnalysisItem> = [];
+    criticalIssues: Array<FacilityGroupAnalysisItem> = [];
+    moderateIssues: Array<FacilityGroupAnalysisItem> = [];
+    minorIssues: Array<FacilityGroupAnalysisItem> = [];
 
     buildDocument(data: FacilitySavingsReportPptInput): PptDocument {
         const slides: PptSlide[] = [];
@@ -44,6 +53,57 @@ export class FacilitySavingsReportPptAdapter {
             title: data.report.name,
             subtitle: data.facility.name,
             date: new Date().toISOString(),
+        });
+
+        this.analysisItem.groups.forEach(group => {
+            if (group.analysisType == 'regression') {
+                let groupItem: FacilityGroupAnalysisItem = this.regressionModelsService.getGroupModelItem(group, data.facility, this.analysisItem, this.reportSettings.endYear);
+                if (groupItem) {
+                    this.executiveSummaryItems.push(groupItem);
+                }
+            } else if (group.analysisType != 'skip') {
+                this.executiveSummaryItems.push({
+                    group: group,
+                    facilityId: data.facility.guid,
+                    baselineYear: this.analysisItem.baselineYear,
+                    selectedModel: undefined
+                });
+            }
+        });
+
+        this.regressionGroupItems = this.executiveSummaryItems.filter(item => item.group.analysisType == 'regression');
+        this.criticalIssues = this.regressionGroupItems.filter(item => {
+            return (item.group.analysisType == 'regression' && !item.selectedModel.isValid);
+        });
+        this.moderateIssues = this.regressionGroupItems.filter(item => {
+            return (item.group.analysisType == 'regression' && !item.selectedModel.SEPValidationPass && item.selectedModel.dataValidationNotes && item.selectedModel.dataValidationNotes.length > 0);
+        });
+        this.minorIssues = this.regressionGroupItems.filter(item => {
+            return (item.group.analysisType == 'regression' && item.selectedModel.modelNotes && item.selectedModel.modelNotes.length > 0);
+        });
+
+        let dataCheckSlides: PptSlide[] = [];
+        if (this.criticalIssues?.length > 0) {
+            dataCheckSlides.push(this.facilityModelingReportPptAdapter.buildCriticalIssuesSlides(this.criticalIssues));
+        }
+        if (this.moderateIssues?.length > 0) {
+            dataCheckSlides.push(this.facilityModelingReportPptAdapter.buildModerateIssuesSlides(this.moderateIssues));
+        }
+        if (this.minorIssues?.length > 0) {
+            dataCheckSlides.push(this.facilityModelingReportPptAdapter.buildMinorIssuesSlides(this.minorIssues));
+        }
+        if (dataCheckSlides.length > 0) {
+            slides.push({
+                type: 'title',
+                title: 'Model Validation Check',
+                layout: 'section'
+            });
+            slides.push(...dataCheckSlides);
+        }
+        slides.push({
+            type: 'title',
+            title: 'Facility Results',
+            layout: 'section'
         });
 
         if (this.reportSettings.facilityAnnualResults && ((this.reportSettings.facilityAnnualResultsTable) || (this.reportSettings.facilityMonthlyResults && (this.reportSettings.facilityMonthlyResultsTable || this.reportSettings.facilityMonthlyResultsGraphs || this.reportSettings.facilityTrailingTwelveMonthsConsumption || this.reportSettings.facilityTrailingTwelveMonthsSavings)))) {
@@ -516,7 +576,7 @@ export class FacilitySavingsReportPptAdapter {
 
     private buildMonthlySavingsChart(data: Array<MonthlyAnalysisSummaryData>): ChartSlide {
         const allValues = data.flatMap(m => [m.rolling12MonthImprovement ?? 0]).filter(v => isFinite(v) && !isNaN(v));
-        const axis = getPptAxisSpec(allValues, {isPercent: true});
+        const axis = getPptAxisSpec(allValues, { isPercent: true });
         return {
             type: 'chart',
             title: 'Monthly Facility Savings',


### PR DESCRIPTION
connects #2604 

This pull request enhances both the account-level and facility-level PowerPoint report adapters by adding a new "Model Validation Check" section to highlight data quality and regression model validation issues. The changes introduce logic to identify and categorize critical, moderate, and minor issues in regression analysis, and generate corresponding slides in the report for better visibility.

### Model Validation and Data Check Enhancements

* Added logic to both `AccountSavingsReportPptAdapter` and `FacilitySavingsReportPptAdapter` to extract and categorize regression model issues as critical, moderate, or minor, using the `RegressionModelsService`. These issues are now summarized and included in the report output. 
* Integrated the `FacilityModelingReportPptAdapter` to generate slides for each category of issues (critical, moderate, minor) and inserted a new "Model Validation Check" section into the slide deck if any issues are detected. 
### Dependency and Interface Updates

* Imported new dependencies (`FacilityGroupAnalysisItem`, `RegressionModelsService`, `FacilityModelingReportPptAdapter`) in both adapters to support the new validation logic and slide generation. 