### PR TITLE
fixup(workspace): fixes to electron backups logic

### DIFF
--- a/src/app/core-components/electron-backup-file/electron-backup-file.component.html
+++ b/src/app/core-components/electron-backup-file/electron-backup-file.component.html
@@ -89,7 +89,7 @@
             Backup Timestamp: {{latestBackupFile.timeStamp | date:'medium'}}
           </p>
         }
-        @if (differingBackups || (account.archiveOption != 'always' && account.archiveOption != 'never') || forceModal) {
+        @if (showArchiveDecision) {
           <label class="semibold">
             Would you like to create a version history file of this account before uploading latest backup
           file? If selected, a copy of this account will be saved as a backup file with a time stamp. </label>

--- a/src/app/core-components/electron-backup-file/electron-backup-file.component.spec.ts
+++ b/src/app/core-components/electron-backup-file/electron-backup-file.component.spec.ts
@@ -82,7 +82,6 @@ describe('ElectronBackupFileComponent', () => {
       inspectCurrentAccountFile: vi.fn().mockResolvedValue(undefined),
       overwriteFile: vi.fn().mockResolvedValue(undefined)
     };
-
     TestBed.configureTestingModule({
       imports: [ElectronBackupFileTestModule],
       providers: [
@@ -134,6 +133,35 @@ describe('ElectronBackupFileComponent', () => {
     automaticBackupsService.latestBackupFile.next(buildPreparedBackupFile());
 
     expect(createArchiveSpy).not.toHaveBeenCalled();
+  });
+
+  it('keeps the archive prompt dismissed after automatic saves update the latest backup file', () => {
+    electronService.isElectron = true;
+    component.ngOnInit();
+    component.account = {
+      guid: 'account-a',
+      archiveOption: 'skip'
+    } as unknown as ElectronBackupFileComponent['account'];
+    component.archiveOption = 'skip';
+
+    automaticBackupsService.status.next('checking');
+    automaticBackupsService.latestBackupFile.next(buildPreparedBackupFile());
+    automaticBackupsService.status.next('ready');
+
+    expect(component.showModal).toBe(true);
+    expect(component.showArchiveDecision).toBe(true);
+
+    component.hideModal();
+
+    automaticBackupsService.status.next('saving');
+    automaticBackupsService.latestBackupFile.next({
+      ...buildPreparedBackupFile(),
+      dataBackupId: 'automatic-save-id'
+    });
+    automaticBackupsService.status.next('ready');
+
+    expect(component.showModal).toBe(false);
+    expect(component.showArchiveDecision).toBe(false);
   });
 
   it('renders a conflict message when the backup registry entry is missing', () => {

--- a/src/app/core-components/electron-backup-file/electron-backup-file.component.ts
+++ b/src/app/core-components/electron-backup-file/electron-backup-file.component.ts
@@ -40,6 +40,8 @@ export class ElectronBackupFileComponent {
   electronBackup: IdbElectronBackup;
   forceModal: boolean = false;
   backupStatus: AutomaticBackupStatus = 'disabled';
+  showArchiveDecision: boolean = false;
+  private pendingArchiveDecision: boolean = false;
   constructor(private electronService: ElectronService,
     private automaticBackupsService: AutomaticBackupsService,
     private toastNotificationService: ToastNotificationsService,
@@ -62,6 +64,7 @@ export class ElectronBackupFileComponent {
         //initialize account or account change
         if (val) {
           if (!this.account || (this.account.guid != val.guid)) {
+            this.pendingArchiveDecision = false;
             this.account = val;
             if (this.account) {
               this.electronBackup = this.automaticBackupsService.accountBackups.find(backup => {
@@ -76,6 +79,11 @@ export class ElectronBackupFileComponent {
 
       this.latestBackupFileSub = this.automaticBackupsService.latestBackupFile.subscribe(val => {
         this.latestBackupFile = val;
+        if (!val) {
+          this.pendingArchiveDecision = false;
+        } else if (this.backupStatus == 'checking') {
+          this.pendingArchiveDecision = true;
+        }
         if (val && this.archiveOption == 'always' && this.backupStatus == 'checking') {
           void this.createArchive();
         }
@@ -114,9 +122,11 @@ export class ElectronBackupFileComponent {
       });
       this.differingBackups = this.backupStatus === 'conflict';
       const needsArchiveDecision = this.archiveOption == 'skip' || this.archiveOption == 'justOnce';
-      this.showModal = this.differingBackups || needsArchiveDecision || this.forceModal;
+      this.showArchiveDecision = this.differingBackups || (needsArchiveDecision && this.pendingArchiveDecision) || this.forceModal;
+      this.showModal = this.differingBackups || this.showArchiveDecision || this.forceModal;
       this.cd.detectChanges();
     } else if (this.backupStatus === 'error' || this.backupStatus === 'disabled') {
+      this.showArchiveDecision = false;
       this.showModal = false;
       this.cd.detectChanges();
     }
@@ -124,6 +134,8 @@ export class ElectronBackupFileComponent {
 
   hideModal() {
     this.automaticBackupsService.clearReviewRequest();
+    this.pendingArchiveDecision = false;
+    this.showArchiveDecision = false;
     this.showModal = false;
   }
 


### PR DESCRIPTION
connects #2571 
This pull request updates the logic for prompting users to create an archive (version history file) before uploading a backup in the `ElectronBackupFileComponent`. The changes ensure that the archive prompt behaves correctly, especially after automatic saves, and introduces a more robust way to track when the archive decision is needed. The most important changes are:

**Archive Prompt Logic Improvements:**

* Added a new `showArchiveDecision` property and internal `pendingArchiveDecision` flag to control when the archive prompt should be shown, improving the accuracy of modal display logic. [[1]](diffhunk://#diff-413586bce06c6c9911eafe97454add4ff5a49feb41be47415d5a623edca32a66R43-R44) [[2]](diffhunk://#diff-413586bce06c6c9911eafe97454add4ff5a49feb41be47415d5a623edca32a66L117-R138)
* Updated the logic to reset `pendingArchiveDecision` when the account changes or when there is no latest backup file, ensuring the prompt does not persist incorrectly. [[1]](diffhunk://#diff-413586bce06c6c9911eafe97454add4ff5a49feb41be47415d5a623edca32a66R67) [[2]](diffhunk://#diff-413586bce06c6c9911eafe97454add4ff5a49feb41be47415d5a623edca32a66R82-R86)
* Modified the modal display condition in the template to use the new `showArchiveDecision` property for clarity and correctness.
* Ensured that hiding the modal also clears both `pendingArchiveDecision` and `showArchiveDecision`, fully dismissing the prompt.

**Testing Enhancements:**

* Added a unit test to verify that the archive prompt remains dismissed after automatic saves update the latest backup file, preventing the prompt from reappearing unnecessarily.

These changes improve the user experience by making the archive prompt more predictable and less intrusive during backup operations.