### PR TITLE
Issue 2539 - PPT not downloading bug fix

### DIFF
--- a/src/app/data-evaluation/account/account-reports/account-report-setup/data-overview-setup/data-overview-setup.component.ts
+++ b/src/app/data-evaluation/account/account-reports/account-report-setup/data-overview-setup/data-overview-setup.component.ts
@@ -39,11 +39,11 @@ export class DataOverviewSetupComponent {
     this.selectedReportSub = toObservable(this.accountWorkspaceStore.selectedAccountReport, { injector: this.injector }).subscribe(val => {
       if (!this.isFormChange) {
         this.reportSetup = val.dataOverviewReportSetup;
+        this.setShowWater();
       } else {
         this.isFormChange = false;
       }
     });
-    this.setShowWater();
   }
 
   ngOnDestroy() {
@@ -68,7 +68,7 @@ export class DataOverviewSetupComponent {
     let accountMeters: Array<IdbUtilityMeter> = [...this.accountWorkspaceStore.meters()];
     let waterMeter: IdbUtilityMeter = accountMeters.find(meter => { return meter.source == 'Water Intake' || meter.source == 'Water Discharge' });
     this.showWater = waterMeter != undefined;
-    if (!this.showWater && this.reportSetup.includeWaterSection) {
+    if (!this.showWater && this.reportSetup?.includeWaterSection) {
       this.reportSetup.includeWaterSection = false;
       this.save();
     }


### PR DESCRIPTION
connects #2595 

This pull request makes a couple of targeted improvements to the `DataOverviewSetupComponent` logic, mainly addressing the timing of the `setShowWater()` call and improving null safety when checking the `includeWaterSection` property. These changes help prevent potential errors and ensure the component's state is updated appropriately when the selected report changes.

Key changes:

**Component initialization and state management:**

* Moved the call to `setShowWater()` so it only runs after the `reportSetup` is updated from the selected report, preventing it from running during the initial setup and ensuring it uses the latest data.

**Null safety and property checks:**

* Added optional chaining (`?.`) to the check for `reportSetup.includeWaterSection` in `setShowWater()`, preventing errors if `reportSetup` is undefined.