### PR TITLE
Issue 2300 - create multiple weather predictors from predictor management page

### DIFF
--- a/src/app/account-workspace/handlers/analysis-command-handler.service.ts
+++ b/src/app/account-workspace/handlers/analysis-command-handler.service.ts
@@ -90,6 +90,44 @@ export class AnalysisCommandHandler {
     }
   }
 
+  async addAnalysisPredictors(newPredictors: IdbPredictor[]): Promise<void> {
+    if (!newPredictors || newPredictors.length === 0) {
+      return;
+    }
+
+    const facilityId = newPredictors[0].facilityId;
+    const facilityPredictors = newPredictors.filter(p => p.facilityId === facilityId);
+
+    const facilityAnalysisItems = this.accountWorkspaceStore.facilityAnalyses()
+      .filter(item => item.facilityId === facilityId);
+
+    for (const analysisItem of facilityAnalysisItems) {
+      const updated = {
+        ...analysisItem,
+        groups: analysisItem.groups.map(group => {
+          const existingById = new Set(group.predictorVariables.map(v => v.id));
+          const varsToAdd = facilityPredictors
+            .filter(p => !existingById.has(p.guid))
+            .map(p => ({
+              id: p.guid,
+              name: p.name,
+              production: p.production,
+              productionInAnalysis: p.productionInAnalysis,
+              regressionCoefficient: undefined,
+              unit: p.unit
+            }));
+
+          return {
+            ...group,
+            predictorVariables: [...group.predictorVariables, ...varsToAdd]
+          };
+        })
+      };
+
+      await firstValueFrom(this.analysisDb.updateWithObservable(updated));
+    }
+  }
+
   /**
    * Propagates a predictor's renamed/updated fields to every analysis group
    * and regression model that references it.

--- a/src/app/data-evaluation/facility/utility-data/predictors/edit-predictor/edit-predictor.component.ts
+++ b/src/app/data-evaluation/facility/utility-data/predictors/edit-predictor/edit-predictor.component.ts
@@ -3,7 +3,7 @@ import { AccountWorkspaceStore } from 'src/app/account-workspace/account-workspa
 import { Component, inject } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { firstValueFrom, from, map, Observable, of, switchAll, take } from 'rxjs';
+import { from, map, Observable, of, switchAll, take } from 'rxjs';
 import { LoadingService } from 'src/app/core-components/loading/loading.service';
 import { ToastNotificationsService } from 'src/app/core-components/toast-notifications/toast-notifications.service';
 import { WorkspaceCommandBoundary } from 'src/app/account-workspace/workspace-command-boundary.service';
@@ -117,18 +117,60 @@ export class EditPredictorComponent {
     let needsWeatherDataUpdate: boolean = this.editPredictorFormService.setPredictorDataFromForm(this.predictor, this.predictorForm);
     this.predictorForm.markAsPristine();
     const activeAccountGuid = this.accountWorkspaceStore.account()?.guid;
+
+    if (this.addOrEdit == 'add' && this.predictorForm.controls.predictorType.value === 'Weather') {
+      const selectedTypes = this.editPredictorFormService.getSelectedWeatherTypes(this.predictorForm);
+
+      await this.commandBoundary.execute(
+        { entityKind: 'predictor', changeKind: 'bulk', label: 'Create Weather Predictor' },
+        async () => {
+          const predictors: Array<IdbPredictor> = [];
+          for (const type of selectedTypes) {
+            const newPredictor = getNewIdbPredictor(this.facility.accountId, this.facility.guid);
+            newPredictor.name = this.editPredictorFormService.getWeatherNameForType(type, this.predictorForm);
+            newPredictor.unit = this.predictorForm.controls.unit.value;
+            newPredictor.description = this.predictorForm.controls.description.value;
+            newPredictor.production = this.predictorForm.controls.production.value;
+            newPredictor.predictorType = 'Weather';
+            newPredictor.weatherStationId = this.predictorForm.controls.weatherStationId.value;
+            newPredictor.weatherStationName = this.predictor.weatherStationName;
+
+            newPredictor.weatherDataType = type;
+            newPredictor.heatingBaseTemperature = this.predictorForm.controls.heatingBaseTemperature.value;
+            newPredictor.coolingBaseTemperature = this.predictorForm.controls.coolingBaseTemperature.value;
+
+            const addedPredictor = await this.predictorHandler.addPredictor(newPredictor, activeAccountGuid);
+            predictors.push(addedPredictor);
+
+            if (this.predictorForm.controls.createPredictorData.value) {
+              await this.addWeatherDataForPredictor(addedPredictor, activeAccountGuid);
+            }
+          }
+          await this.analysisHandler.addAnalysisPredictors(predictors);
+        }
+      );
+      this.loadingService.setLoadingStatus(false);
+      this.toastNotificationService.showToast('Weather Predictors Created!', undefined, undefined, false, 'alert-success');
+      this.cancel();
+      return;
+    }
+
     await this.commandBoundary.execute(
       { entityKind: 'predictor', changeKind: this.addOrEdit === 'add' ? 'add' : 'update', entityGuid: this.predictor.guid, label: 'Saving predictor' },
       async () => {
         if (this.addOrEdit == 'add') {
           await this.predictorHandler.addPredictor(this.predictor, this.accountWorkspaceStore.account()?.guid);
+          await this.analysisHandler.addAnalysisPredictor(this.predictor);
         } else {
           await this.predictorHandler.updatePredictor(this.predictor, activeAccountGuid);
-        }
-        if (this.predictor.predictorType == 'Weather') {
-          if (this.addOrEdit == 'edit' && needsWeatherDataUpdate) {
+
+          if (this.predictor.predictorType == 'Weather' && needsWeatherDataUpdate) {
             let predictorData: Array<IdbPredictorData> = this.accountWorkspaceQuery.getPredictorData(this.predictor.guid);
-            let predictorDates: Array<Date> = predictorData.map(pData => { return getDateFromPredictorData(pData) })
+            if (!predictorData || predictorData.length == 0) {
+              await this.analysisHandler.updateAnalysisPredictor(this.predictor);
+              return;
+            }
+            let predictorDates: Array<Date> = predictorData.map(pData => { return getDateFromPredictorData(pData) });
             let minDate: Date = _.min(predictorDates);
             let maxDate: Date = _.max(predictorDates);
             let parsedData: Array<WeatherDataReading> | 'error' = await this.weatherDataService.getHourlyData(this.predictor.weatherStationId, minDate, maxDate, ['humidity']);
@@ -149,13 +191,7 @@ export class EditPredictorComponent {
             } else {
               this.toastNotificationService.weatherDataErrorToast();
             }
-          } else if (this.addOrEdit == 'add' && this.predictorForm.controls.createPredictorData.value) {
-            await this.addWeatherData();
-          }
-        }
-        if (this.addOrEdit == 'add') {
-          await this.analysisHandler.addAnalysisPredictor(this.predictor);
-        } else {
+          } 
           await this.analysisHandler.updateAnalysisPredictor(this.predictor);
         }
       }
@@ -168,38 +204,6 @@ export class EditPredictorComponent {
   setLastMeterReading() {
     this.latestMeterReading = this.predictorDataHelperService.getLastMeterDate(this.facility);
     this.firstMeterReading = this.predictorDataHelperService.getFirstMeterDate(this.facility);
-  }
-
-  async addWeatherData() {
-    if (this.latestMeterReading && this.firstMeterReading) {
-      let startDate: Date = new Date(this.firstMeterReading);
-      let endDate: Date = new Date(this.latestMeterReading);
-      let parsedData: Array<WeatherDataReading> | 'error' = await this.weatherDataService.getHourlyData(this.predictor.weatherStationId, startDate, endDate, []);
-      if (parsedData != 'error') {
-        while (startDate <= endDate) {
-          if (this.destroyed) {
-            break;
-          }
-          let newDate: Date = new Date(startDate);
-          let month: Month = Months.find(m => m.monthNumValue == newDate.getMonth());
-          let dateString = month.abbreviation + ', ' + newDate.getFullYear();
-          this.loadingService.setLoadingMessage('Adding Weather Predictors: ' + dateString);
-          let degreeDays: Array<DetailDegreeDay> = getDetailedDataForMonth(parsedData, newDate.getMonth(), newDate.getFullYear(), this.predictor.heatingBaseTemperature, this.predictor.coolingBaseTemperature, this.predictor.weatherStationId, this.predictor.weatherStationName);
-          let hasErrors: DetailDegreeDay = degreeDays.find(degreeDay => {
-            return degreeDay.gapInData == true
-          });
-          let newPredictorData: IdbPredictorData = getNewIdbPredictorData(this.predictor);
-          newPredictorData.year = newDate.getFullYear();
-          newPredictorData.month = newDate.getMonth() + 1;
-          newPredictorData.amount = getDegreeDayAmount(degreeDays, this.predictor.weatherDataType);
-          newPredictorData.weatherDataWarning = hasErrors != undefined || degreeDays.length == 0;
-          await this.predictorHandler.addPredictorData(newPredictorData, this.accountWorkspaceStore.account()?.guid);
-        }
-        startDate.setMonth(startDate.getMonth() + 1);
-      } else {
-        this.toastNotificationService.weatherDataErrorToast();
-      }
-    }
   }
 
   canDeactivate(): Observable<boolean> {
@@ -217,5 +221,55 @@ export class EditPredictorComponent {
         take(1), switchAll());
     }
     return of(true);
+  }
+
+  async addWeatherDataForPredictor(targetPredictor: IdbPredictor, activeAccountGuid: string) {
+    if (this.latestMeterReading && this.firstMeterReading) {
+      let startDate: Date = new Date(this.firstMeterReading);
+      let endDate: Date = new Date(this.latestMeterReading);
+
+      let parsedData: Array<WeatherDataReading> | 'error' = await this.weatherDataService.getHourlyData(
+        targetPredictor.weatherStationId,
+        startDate,
+        endDate,
+        []
+      );
+
+      if (parsedData != 'error') {
+        while (startDate <= endDate) {
+          if (this.destroyed) {
+            break;
+          }
+
+          let newDate: Date = new Date(startDate);
+          let month: Month = Months.find(m => m.monthNumValue == newDate.getMonth());
+          let dateString = month.abbreviation + ', ' + newDate.getFullYear();
+          this.loadingService.setLoadingMessage('Adding Weather Predictors: ' + dateString);
+
+          let degreeDays: Array<DetailDegreeDay> = getDetailedDataForMonth(
+            parsedData,
+            newDate.getMonth(),
+            newDate.getFullYear(),
+            targetPredictor.heatingBaseTemperature,
+            targetPredictor.coolingBaseTemperature,
+            targetPredictor.weatherStationId,
+            targetPredictor.weatherStationName
+          );
+
+          let hasErrors: DetailDegreeDay = degreeDays.find(degreeDay => degreeDay.gapInData == true);
+
+          let newPredictorData: IdbPredictorData = getNewIdbPredictorData(targetPredictor);
+          newPredictorData.year = newDate.getFullYear();
+          newPredictorData.month = newDate.getMonth() + 1;
+          newPredictorData.amount = getDegreeDayAmount(degreeDays, targetPredictor.weatherDataType);
+          newPredictorData.weatherDataWarning = hasErrors != undefined || degreeDays.length == 0;
+
+          await this.predictorHandler.addPredictorData(newPredictorData, activeAccountGuid);
+          startDate.setMonth(startDate.getMonth() + 1);
+        }
+      } else {
+        this.toastNotificationService.weatherDataErrorToast();
+      }
+    }
   }
 }

--- a/src/app/data-evaluation/facility/utility-data/predictors/edit-predictor/edit-predictor.component.ts
+++ b/src/app/data-evaluation/facility/utility-data/predictors/edit-predictor/edit-predictor.component.ts
@@ -142,9 +142,7 @@ export class EditPredictorComponent {
             const addedPredictor = await this.predictorHandler.addPredictor(newPredictor, activeAccountGuid);
             predictors.push(addedPredictor);
 
-            if (this.predictorForm.controls.createPredictorData.value) {
-              await this.addWeatherDataForPredictor(addedPredictor, activeAccountGuid);
-            }
+            await this.addWeatherDataForPredictor(addedPredictor, activeAccountGuid);
           }
           await this.analysisHandler.addAnalysisPredictors(predictors);
         }
@@ -191,7 +189,7 @@ export class EditPredictorComponent {
             } else {
               this.toastNotificationService.weatherDataErrorToast();
             }
-          } 
+          }
           await this.analysisHandler.updateAnalysisPredictor(this.predictor);
         }
       }
@@ -224,10 +222,10 @@ export class EditPredictorComponent {
   }
 
   async addWeatherDataForPredictor(targetPredictor: IdbPredictor, activeAccountGuid: string) {
-    if (this.latestMeterReading && this.firstMeterReading) {
-      let startDate: Date = new Date(this.firstMeterReading);
-      let endDate: Date = new Date(this.latestMeterReading);
+    let startDate: Date = new Date(this.predictorForm.controls.startYear.value, this.predictorForm.controls.startMonth.value, 1);
+    let endDate: Date = new Date(this.predictorForm.controls.endYear.value, this.predictorForm.controls.endMonth.value, 1);
 
+    if (startDate && endDate && startDate <= endDate) {
       let parsedData: Array<WeatherDataReading> | 'error' = await this.weatherDataService.getHourlyData(
         targetPredictor.weatherStationId,
         startDate,

--- a/src/app/data-evaluation/facility/utility-data/predictors/predictors.component.html
+++ b/src/app/data-evaluation/facility/utility-data/predictors/predictors.component.html
@@ -14,7 +14,7 @@
         <a class="nav-link" routerLink="predictor/{{predictorItem.predictor.guid}}" [routerLinkActive]="['active']">
           <i class="fa fa-file-invoice"></i>
           {{predictorItem.predictor.name}}
-          @if (predictorItem.predictorStatusCheck.status != 'good') {
+          @if (predictorItem.predictorStatusCheck?.status != 'good') {
           <i class="fa fa-exclamation-triangle text-warning"></i>
           }
         </a>

--- a/src/app/data-evaluation/facility/utility-data/predictors/predictors.component.ts
+++ b/src/app/data-evaluation/facility/utility-data/predictors/predictors.component.ts
@@ -8,7 +8,7 @@ import { AccountStatusCheckService } from 'src/app/shared/helper-services/accoun
 
 interface PredictorListItem {
   predictor: IdbPredictor;
-  predictorStatusCheck: PredictorStatusCheck;
+  predictorStatusCheck?: PredictorStatusCheck;
 }
 
 @Component({

--- a/src/app/shared/shared-predictors-content/edit-predictor-form.service.ts
+++ b/src/app/shared/shared-predictors-content/edit-predictor-form.service.ts
@@ -74,7 +74,7 @@ export class EditPredictorFormService {
       weatherSelections?.setValidators([this.isAnyWeatherOptionSelected()]);
 
       const selectedTypes = this.getSelectedWeatherTypes(predictorForm);
-      if (selectedTypes.length === 1) {
+      if (selectedTypes.length > 0) {
         predictorForm.controls.weatherDataType.patchValue(selectedTypes[0], { emitEvent: false });
       }
 

--- a/src/app/shared/shared-predictors-content/edit-predictor-form.service.ts
+++ b/src/app/shared/shared-predictors-content/edit-predictor-form.service.ts
@@ -10,14 +10,15 @@ export class EditPredictorFormService {
   constructor(private formBuilder: FormBuilder) { }
 
   getFormFromPredictor(predictor: IdbPredictor): FormGroup {
+    const isWeather = predictor.predictorType == 'Weather';
     const weatherSelections = this.formBuilder.group({
-      cdd: [predictor.weatherDataType == 'CDD'],
-      hdd: [predictor.weatherDataType == 'HDD'],
-      relativeHumidity: [predictor.weatherDataType == 'relativeHumidity'],
-      dryBulbTemp: [predictor.weatherDataType == 'dryBulbTemp'],
-      wetBulbTemp: [predictor.weatherDataType == 'wetBulbTemp'],
-      dewPointTemp: [predictor.weatherDataType == 'dewPointTemp'],
-      precipitation: [predictor.weatherDataType == 'precipitation']
+      cdd: [isWeather && predictor.weatherDataType == 'CDD'],
+      hdd: [isWeather && predictor.weatherDataType == 'HDD'],
+      relativeHumidity: [isWeather && predictor.weatherDataType == 'relativeHumidity'],
+      dryBulbTemp: [isWeather && predictor.weatherDataType == 'dryBulbTemp'],
+      wetBulbTemp: [isWeather && predictor.weatherDataType == 'wetBulbTemp'],
+      dewPointTemp: [isWeather && predictor.weatherDataType == 'dewPointTemp'],
+      precipitation: [isWeather && predictor.weatherDataType == 'precipitation']
     });
     let predictorForm: FormGroup = this.formBuilder.group({
       'name': [predictor.name, [Validators.required]],

--- a/src/app/shared/shared-predictors-content/edit-predictor-form.service.ts
+++ b/src/app/shared/shared-predictors-content/edit-predictor-form.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { IdbPredictor } from 'src/app/models/idbModels/predictor';
+import { AbstractControl, FormBuilder, FormGroup, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
+import { IdbPredictor, WeatherDataType } from 'src/app/models/idbModels/predictor';
 
 @Injectable({
   providedIn: 'root'
@@ -10,8 +10,17 @@ export class EditPredictorFormService {
   constructor(private formBuilder: FormBuilder) { }
 
   getFormFromPredictor(predictor: IdbPredictor): FormGroup {
+    const weatherSelections = this.formBuilder.group({
+      cdd: [predictor.weatherDataType == 'CDD'],
+      hdd: [predictor.weatherDataType == 'HDD'],
+      relativeHumidity: [predictor.weatherDataType == 'relativeHumidity'],
+      dryBulbTemp: [predictor.weatherDataType == 'dryBulbTemp'],
+      wetBulbTemp: [predictor.weatherDataType == 'wetBulbTemp'],
+      dewPointTemp: [predictor.weatherDataType == 'dewPointTemp'],
+      precipitation: [predictor.weatherDataType == 'precipitation']
+    });
     let predictorForm: FormGroup = this.formBuilder.group({
-      'name': [predictor.name, [Validators.required ]],
+      'name': [predictor.name, [Validators.required]],
       'unit': [predictor.unit],
       'description': [predictor.description],
       'production': [predictor.production || false],
@@ -26,13 +35,14 @@ export class EditPredictorFormService {
       'heatingBaseTemperature': [predictor.heatingBaseTemperature],
       'coolingBaseTemperature': [predictor.coolingBaseTemperature],
       'weatherStationId': [predictor.weatherStationId],
+      'weatherSelections': weatherSelections,
       'createPredictorData': [true],
       //status settings
       'noLongerInUse': [predictor.noLongerInUse || false],
       'noLongerInUseMonth': [predictor.noLongerInUseMonth],
       'noLongerInUseYear': [predictor.noLongerInUseYear],
       'canBeNegative': [predictor.canBeNegative || false],
-      'ignoreDateStatusChecks': [predictor.ignoreDateStatusChecks || false]
+      'ignoreDateStatusChecks': [predictor.ignoreDateStatusChecks || false],
     });
     // this.setShowReferencePredictors()
     // this.setUnitOptions();
@@ -40,34 +50,45 @@ export class EditPredictorFormService {
     return predictorForm;
   }
 
+  isAnyWeatherOptionSelected(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const values = control.value || {};
+      return Object.values(values).some(Boolean) ? null : { noWeatherOptionSelected: true };
+    }
+  }
+
   setValidators(predictorForm: FormGroup) {
-    if (predictorForm.controls.predictorType.value == 'Standard') {
+    const isWeather = predictorForm.controls.predictorType.value == 'Weather';
+    const weatherSelections = predictorForm.get('weatherSelections');
+
+    if (!isWeather) {
+      weatherSelections?.setValidators([]);
       predictorForm.controls.heatingBaseTemperature.setValidators([]);
       predictorForm.controls.coolingBaseTemperature.setValidators([]);
       predictorForm.controls.weatherStationId.setValidators([]);
       predictorForm.controls.weatherDataType.setValidators([]);
-    } else if (predictorForm.controls.predictorType.value == 'Weather') {
-      predictorForm.controls.weatherStationId.setValidators([Validators.required]);
-      predictorForm.controls.weatherDataType.setValidators([Validators.required]);
-      if (predictorForm.controls.weatherDataType.value == 'HDD') {
-        predictorForm.controls.heatingBaseTemperature.setValidators([Validators.required]);
-        predictorForm.controls.coolingBaseTemperature.setValidators([]);
-      } else if (predictorForm.controls.weatherDataType.value == 'CDD') {
-        predictorForm.controls.heatingBaseTemperature.setValidators([]);
-        predictorForm.controls.coolingBaseTemperature.setValidators([Validators.required]);
-      } else {
-        predictorForm.controls.heatingBaseTemperature.setValidators([]);
-        predictorForm.controls.coolingBaseTemperature.setValidators([]);
-      }
     }
-    predictorForm.controls.heatingBaseTemperature.updateValueAndValidity();
-    predictorForm.controls.coolingBaseTemperature.updateValueAndValidity();
-    predictorForm.controls.weatherStationId.updateValueAndValidity();
-    predictorForm.controls.weatherDataType.updateValueAndValidity();
+    else {
+      predictorForm.controls.weatherStationId.setValidators([Validators.required]);
+      weatherSelections?.setValidators([this.isAnyWeatherOptionSelected()]);
+
+      const selectedTypes = this.getSelectedWeatherTypes(predictorForm);
+      if (selectedTypes.length === 1) {
+        predictorForm.controls.weatherDataType.patchValue(selectedTypes[0], { emitEvent: false });
+      }
+
+      predictorForm.controls.heatingBaseTemperature.setValidators(selectedTypes.includes('HDD') ? [Validators.required] : []);
+      predictorForm.controls.coolingBaseTemperature.setValidators(selectedTypes.includes('CDD') ? [Validators.required] : []);
+    }
+
+    predictorForm.controls.heatingBaseTemperature.updateValueAndValidity({ emitEvent: false });
+    predictorForm.controls.coolingBaseTemperature.updateValueAndValidity({ emitEvent: false });
+    predictorForm.controls.weatherStationId.updateValueAndValidity({ emitEvent: false });
+    predictorForm.controls.weatherDataType.updateValueAndValidity({ emitEvent: false });
+    weatherSelections?.updateValueAndValidity({ emitEvent: false });
   }
 
   setPredictorDataFromForm(predictor: IdbPredictor, predictorForm: FormGroup): boolean {
-    predictor.name = predictorForm.controls.name.value;
     predictor.unit = predictorForm.controls.unit.value;
     predictor.description = predictorForm.controls.description.value;
     predictor.production = predictorForm.controls.production.value;
@@ -79,11 +100,24 @@ export class EditPredictorFormService {
     // this.predictorData.mathAction = this.predictorForm.controls.name.value;
     // this.predictorData.mathAmount = this.predictorForm.controls.name.value;
 
+    const selectedWeatherTypes = this.getSelectedWeatherTypes(predictorForm);
     let weatherDataChange: boolean = false;
-    if (predictor.weatherDataType != predictorForm.controls.weatherDataType.value) {
-      weatherDataChange = true;
-      predictor.weatherDataType = predictorForm.controls.weatherDataType.value;
+    let nextWeatherType = predictorForm.controls.weatherDataType.value;
+    if (selectedWeatherTypes.length > 0) {
+      nextWeatherType = selectedWeatherTypes[0];
+      predictorForm.controls.weatherDataType.patchValue(nextWeatherType, { emitEvent: false });
     }
+    if (predictor.weatherDataType != nextWeatherType) {
+      weatherDataChange = true;
+      predictor.weatherDataType = nextWeatherType;
+    }
+
+    let name = predictorForm.controls.name.value;
+    if (predictorForm.controls.predictorType.value == 'Weather' && selectedWeatherTypes.length === 1) {
+      name = this.getWeatherNameForType(nextWeatherType, predictorForm);
+      predictorForm.controls.name.patchValue(name, { emitEvent: false });
+    }
+    predictor.name = name;
     if (predictor.heatingBaseTemperature != predictorForm.controls.heatingBaseTemperature.value) {
       weatherDataChange = true;
       predictor.heatingBaseTemperature = predictorForm.controls.heatingBaseTemperature.value;
@@ -103,5 +137,28 @@ export class EditPredictorFormService {
     predictor.canBeNegative = predictorForm.controls.canBeNegative.value;
     predictor.ignoreDateStatusChecks = predictorForm.controls.ignoreDateStatusChecks.value;
     return weatherDataChange;
+  }
+
+  getSelectedWeatherTypes(predictorForm: FormGroup): Array<WeatherDataType> {
+    const selections = predictorForm.get('weatherSelections')?.value || {};
+    const selected: Array<IdbPredictor['weatherDataType']> = [];
+    if (selections.cdd) selected.push('CDD');
+    if (selections.hdd) selected.push('HDD');
+    if (selections.relativeHumidity) selected.push('relativeHumidity');
+    if (selections.dryBulbTemp) selected.push('dryBulbTemp');
+    if (selections.wetBulbTemp) selected.push('wetBulbTemp');
+    if (selections.dewPointTemp) selected.push('dewPointTemp');
+    if (selections.precipitation) selected.push('precipitation');
+    return selected;
+  }
+
+  getWeatherNameForType(type: WeatherDataType, predictorForm: FormGroup): string {
+    if (type === 'CDD') return `CDD Generated (${predictorForm.controls.coolingBaseTemperature.value} \u00B0F)`;
+    if (type === 'HDD') return `HDD Generated (${predictorForm.controls.heatingBaseTemperature.value} \u00B0F)`;
+    if (type === 'relativeHumidity') return 'Relative Humidity';
+    if (type === 'dryBulbTemp') return 'Dry Bulb Temp';
+    if (type === 'wetBulbTemp') return 'Wet Bulb Temp';
+    if (type === 'dewPointTemp') return 'Dew Point Temp';
+    return 'Precipitation';
   }
 }

--- a/src/app/shared/shared-predictors-content/edit-predictor-form.service.ts
+++ b/src/app/shared/shared-predictors-content/edit-predictor-form.service.ts
@@ -116,13 +116,7 @@ export class EditPredictorFormService {
       weatherDataChange = true;
       predictor.weatherDataType = nextWeatherType;
     }
-
-    let name = predictorForm.controls.name.value;
-    if (predictorForm.controls.predictorType.value == 'Weather' && selectedWeatherTypes.length === 1) {
-      name = this.getWeatherNameForType(nextWeatherType, predictorForm);
-      predictorForm.controls.name.patchValue(name, { emitEvent: false });
-    }
-    predictor.name = name;
+    predictor.name = predictorForm.controls.name.value;
     if (predictor.heatingBaseTemperature != predictorForm.controls.heatingBaseTemperature.value) {
       weatherDataChange = true;
       predictor.heatingBaseTemperature = predictorForm.controls.heatingBaseTemperature.value;

--- a/src/app/shared/shared-predictors-content/edit-predictor-form.service.ts
+++ b/src/app/shared/shared-predictors-content/edit-predictor-form.service.ts
@@ -37,6 +37,10 @@ export class EditPredictorFormService {
       'coolingBaseTemperature': [predictor.coolingBaseTemperature],
       'weatherStationId': [predictor.weatherStationId],
       'weatherSelections': weatherSelections,
+      'startMonth': [null],
+      'startYear': [null],
+      'endMonth': [null],
+      'endYear': [null],
       'createPredictorData': [true],
       //status settings
       'noLongerInUse': [predictor.noLongerInUse || false],

--- a/src/app/shared/shared-predictors-content/edit-predictor-form/edit-predictor-form.component.css
+++ b/src/app/shared/shared-predictors-content/edit-predictor-form/edit-predictor-form.component.css
@@ -2,14 +2,46 @@ button span {
     color: white;
 }
 
-.float-right{
+.float-right {
     float: right;
 }
 
-.popup{
+.popup {
     top: 15px;
     left: 15px;
     right: 15px;
     bottom: 15px;
     width: auto;
+}
+
+.weather-alert {
+    margin-left: 15px;
+    margin-right: 15px;
+    border: 1px solid #d6dbe3;
+    border-left: 4px solid #6c757d;
+    background-color: #f8f9fb;
+    border-radius: 8px;
+    padding: 14px 16px;
+}
+
+.weather-alert-title {
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: #2f3a4a;
+    margin-bottom: 4px;
+}
+
+.weather-alert-subtitle {
+    color: #5c6675;
+    font-size: 1rem;
+    margin-bottom: 10px;
+}
+
+.predictor-row {
+    min-height: 38px;
+    padding: 6px 4px;
+}
+
+.predictor-row label {
+    color: #2b3442;
 }

--- a/src/app/shared/shared-predictors-content/edit-predictor-form/edit-predictor-form.component.css
+++ b/src/app/shared/shared-predictors-content/edit-predictor-form/edit-predictor-form.component.css
@@ -45,3 +45,7 @@ button span {
 .predictor-row label {
     color: #2b3442;
 }
+
+.weather-data-select {
+    width: 140px;
+}

--- a/src/app/shared/shared-predictors-content/edit-predictor-form/edit-predictor-form.component.html
+++ b/src/app/shared/shared-predictors-content/edit-predictor-form/edit-predictor-form.component.html
@@ -52,22 +52,7 @@
         </select>
       </div>
     </div>
-    <!--weather-->
     @if (predictorForm.controls.predictorType.value == 'Weather') {
-    <div class="col-lg-6 col-md-12 col-sm-12">
-      <label class="semibold" for="weatherDataType">Weather Predictor Type</label>
-      <div class="mb-3">
-        <select id="weatherDataType" class="form-select" formControlName="weatherDataType" (change)="setValidators()">
-          <option [value]="'HDD'">Heating Degree Days</option>
-          <option [value]="'CDD'">Cooling Degree Days</option>
-          <option [value]="'relativeHumidity'">Relative Humidity</option>
-          <option [value]="'dryBulbTemp'">Dry Bulb Temp</option>
-          <option [value]="'wetBulbTemp'">Wet Bulb Temp</option>
-          <option [value]="'dewPointTemp'">Dew Point Temp</option>
-          <option [value]="'precipitation'">Precipitation</option>
-        </select>
-      </div>
-    </div>
     <div class="col-lg-6 col-md-12 col-sm-12">
       <label class="semibold w-100" for="weatherStationId">Weather Station
         <a class="click-link float-right" (click)="openStationModal()">
@@ -86,40 +71,114 @@
         required</div>
       }
     </div>
-    @if (predictorForm.controls.weatherDataType.value == 'HDD') {
-    <div class="col-lg-6 col-md-12 col-sm-12">
-      <label class="semibold" for="heatingBaseTemperature">Heating Base Temperature</label>
-      <div class="mb-3 input-group">
-        <input id="heatingBaseTemperature" class="form-control" type="number" formControlName="heatingBaseTemperature"
-          onfocus="this.select();" name="heatingBaseTemperature">
-        <span class="input-group-text">
-          &#8457;
-        </span>
+
+    @if (predictorForm.get('weatherStationId')?.value) {
+    <div class="col-12">
+      <div class="alert alert-secondary weather-alert mt-5 mb-5">
+        <div class="weather-alert-title">
+          Weather Data Options
+        </div>
+        <div class="weather-alert-subtitle">
+          Select at least one weather data type below to create predictors using the selected weather station and
+          temperature thresholds.
+        </div>
+        <div class="d-flex flex-column mb-3 mt-3" formGroupName="weatherSelections">
+          @if(predictorForm.get('weatherSelections.cdd')?.value || predictorForm.get('weatherSelections.hdd')?.value) {
+          <div class="row justify-content-end">
+            <div class="col-6">
+              <span class="fst-italic fw-bold">Base Temperature</span>
+            </div>
+          </div>
+          }
+
+          <div class="row g-2 align-items-center mb-2 flex-nowrap predictor-row">
+            <div class="col-6">
+              <input type="checkbox" id="cdd" class="form-check-input" formControlName="cdd" (change)="onWeatherSelectionChange('cdd', $event)">
+              <label for="cdd" class="fw-bold ps-2">Cooling Degree Days</label>
+            </div>
+            @if(predictorForm.get('weatherSelections.cdd')?.value) {
+            <div class="col-6">
+              <div class="input-group">
+                <input type="number" class="form-control border-primary bg-light" name="cddBaseTemp"
+                  [formControl]="$any(predictorForm.get('coolingBaseTemperature'))">
+                <span class="input-group-text">&#8457;</span>
+              </div>
+            </div>
+            }
+          </div>
+
+          <div class="row g-2 align-items-center mb-2 flex-nowrap predictor-row">
+            <div class="col-6">
+              <input type="checkbox" id="hdd" class="form-check-input" formControlName="hdd" (change)="onWeatherSelectionChange('hdd', $event)">
+              <label for="hdd" class="fw-bold ps-2">Heating Degree Days</label>
+            </div>
+            @if(predictorForm.get('weatherSelections.hdd')?.value) {
+            <div class="col-6">
+              <div class="input-group">
+                <input type="number" class="form-control border-primary bg-light" name="hddBaseTemp"
+                  [formControl]="$any(predictorForm.get('heatingBaseTemperature'))">
+                <span class="input-group-text">&#8457;</span>
+              </div>
+            </div>
+            }
+          </div>
+
+          <div class="row g-2 align-items-center mb-2 flex-nowrap predictor-row">
+            <div class="col-12">
+              <input type="checkbox" id="relativeHumidity" class="form-check-input" formControlName="relativeHumidity"
+                (change)="onWeatherSelectionChange('relativeHumidity', $event)">
+              <label for="relativeHumidity" class="fw-bold ps-2">
+                Relative Humidity
+              </label>
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-center mb-2 flex-nowrap predictor-row">
+            <div class="col-12">
+              <input type="checkbox" id="dryBulbTemp" class="form-check-input" formControlName="dryBulbTemp"
+                (change)="onWeatherSelectionChange('dryBulbTemp', $event)">
+              <label for="dryBulbTemp" class="fw-bold ps-2">
+                Dry Bulb Temperature
+              </label>
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-center mb-2 flex-nowrap predictor-row">
+            <div class="col-12">
+              <input type="checkbox" id="wetBulbTemp" class="form-check-input" formControlName="wetBulbTemp"
+                (change)="onWeatherSelectionChange('wetBulbTemp', $event)">
+              <label for="wetBulbTemp" class="fw-bold ps-2">
+                Wet Bulb Temperature
+              </label>
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-center mb-2 flex-nowrap predictor-row">
+            <div class="col-12">
+              <input type="checkbox" id="dewPointTemp" class="form-check-input" formControlName="dewPointTemp"
+                (change)="onWeatherSelectionChange('dewPointTemp', $event)">
+              <label for="dewPointTemp" class="fw-bold ps-2">
+                Dew Point Temperature
+              </label>
+            </div>
+          </div>
+
+          <div class="row g-2 align-items-center mb-2 flex-nowrap predictor-row">
+            <div class="col-12">
+              <input type="checkbox" id="precipitation" class="form-check-input" formControlName="precipitation"
+                (change)="onWeatherSelectionChange('precipitation', $event)">
+              <label for="precipitation" class="fw-bold ps-2">
+                Precipitation
+              </label>
+            </div>
+          </div>
+        </div>
       </div>
-      @if (predictorForm.get('heatingBaseTemperature').hasError('required')) {
-      <div class="alert alert-danger">Heating base
-        temperature is
-        required</div>
-      }
     </div>
     }
-    @if (predictorForm.controls.weatherDataType.value == 'CDD') {
-    <div class="col-lg-6 col-md-12 col-sm-12">
-      <label class="semibold" for="coolingBaseTemperature">Cooling Base Temperature</label>
-      <div class="mb-3 input-group">
-        <input id="coolingBaseTemperature" class="form-control" type="number" formControlName="coolingBaseTemperature"
-          onfocus="this.select();" name="coolingBaseTemperature">
-        <span class="input-group-text">
-          &#8457;
-        </span>
-      </div>
-      @if (predictorForm.get('coolingBaseTemperature').hasError('required')) {
-      <div class="alert alert-danger">Cooling base
-        temperature is
-        required</div>
-      }
-    </div>
     }
+    <!--weather-->
+    @if (predictorForm.controls.predictorType.value == 'Weather') {
     @if (addOrEdit == 'add' && firstMeterReading && latestMeterReading) {
     <div class="col-lg-6 col-md-12 col-sm-12">
       <!-- <label class="semibold" for="createPredictorData">Create Predictor Entries</label> -->
@@ -145,8 +204,9 @@
       </div>
     </div>
     }
-    <!--Math/Conversion-->
-    <!-- <div class="col-lg-6 col-md-12 col-sm-12" *ngIf="showReferencePredictors">
+  </div>
+  <!--Math/Conversion-->
+  <!-- <div class="col-lg-6 col-md-12 col-sm-12" *ngIf="showReferencePredictors">
         <label class="semibold" for="referencePredictorId">Reference Predictor</label>
         <div class="mb-3">
           <select id="referencePredictorId" class="form-select" formControlName="referencePredictorId"
@@ -156,8 +216,8 @@
           </select>
         </div>
       </div> -->
-    <!--Conversion method not implemented yet-->
-    <!-- <ng-container *ngIf="predictorForm.controls.predictorType.value == 'Conversion'">
+  <!--Conversion method not implemented yet-->
+  <!-- <ng-container *ngIf="predictorForm.controls.predictorType.value == 'Conversion'">
       <div class="col-lg-6 col-md-12 col-sm-12">
         <label class="semibold" for="conversionType">Conversion Type</label>
         <div class="mb-3">
@@ -190,7 +250,7 @@
         </div>
       </div>
     </ng-container> -->
-    <!-- <ng-container *ngIf="predictorForm.controls.predictorType.value == 'Math'">
+  <!-- <ng-container *ngIf="predictorForm.controls.predictorType.value == 'Math'">
     <div class="col-lg-6 col-md-12 col-sm-12">
       <label class="semibold" for="mathAction">Math Action</label>
       <div class="mb-3">
@@ -228,6 +288,7 @@
       </div>
     </div>
   </ng-container> -->
+  <div class="row">
     <div class="col-12">
       <hr>
     </div>

--- a/src/app/shared/shared-predictors-content/edit-predictor-form/edit-predictor-form.component.html
+++ b/src/app/shared/shared-predictors-content/edit-predictor-form/edit-predictor-form.component.html
@@ -72,7 +72,7 @@
       }
     </div>
 
-    @if (predictorForm.get('weatherStationId')?.value) {
+    @if (predictorForm.get('weatherStationId')?.value && addOrEdit === 'add') {
     <div class="col-12">
       <div class="alert alert-secondary weather-alert mt-5 mb-5">
         <div class="weather-alert-title">
@@ -208,6 +208,46 @@
             </div>
           </div>
         </div>
+      </div>
+    </div>
+    }
+    }
+    @if (predictorForm.controls.predictorType.value == 'Weather' && addOrEdit == 'edit') {
+    <div class="col-lg-6 col-md-12 col-sm-12">
+      <label class="semibold" for="weatherDataType">Weather Predictor Type</label>
+      <div class="mb-3">
+        <select id="weatherDataType" class="form-select" formControlName="weatherDataType">
+          <option [value]="'HDD'">Heating Degree Days</option>
+          <option [value]="'CDD'">Cooling Degree Days</option>
+          <option [value]="'relativeHumidity'">Relative Humidity</option>
+          <option [value]="'dryBulbTemp'">Dry Bulb Temp</option>
+          <option [value]="'wetBulbTemp'">Wet Bulb Temp</option>
+          <option [value]="'dewPointTemp'">Dew Point Temp</option>
+          <option [value]="'precipitation'">Precipitation</option>
+        </select>
+      </div>
+    </div>
+    @if (predictorForm.controls.weatherDataType.value === 'HDD') {
+    <div class="col-lg-6 col-md-12 col-sm-12">
+      <label class="semibold" for="heatingBaseTemperature">Heating Base Temperature</label>
+      <div class="mb-3 input-group">
+        <input id="heatingBaseTemperature" class="form-control" type="number" formControlName="heatingBaseTemperature"
+          onfocus="this.select();" name="heatingBaseTemperature">
+        <span class="input-group-text">
+          &#8457;
+        </span>
+      </div>
+    </div>
+    }
+    @if (predictorForm.controls.weatherDataType.value === 'CDD') {
+    <div class="col-lg-6 col-md-12 col-sm-12">
+      <label class="semibold" for="coolingBaseTemperature">Cooling Base Temperature</label>
+      <div class="mb-3 input-group">
+        <input id="coolingBaseTemperature" class="form-control" type="number" formControlName="coolingBaseTemperature"
+          onfocus="this.select();" name="coolingBaseTemperature">
+        <span class="input-group-text">
+          &#8457;
+        </span>
       </div>
     </div>
     }
@@ -366,14 +406,14 @@
 }
 
 
-<div [ngClass]="{'windowOverlay': displaySationModal}"></div>
-<div class="popup" [class.open]="displaySationModal">
+<div [ngClass]="{'windowOverlay': displayStationModal}"></div>
+<div class="popup" [class.open]="displayStationModal">
   <div class="popup-header">
     Select Station
     <button class="item-right" (click)="cancelStationSelect()">x</button>
   </div>
   <div class="popup-body">
-    @if (displaySationModal) {
+    @if (displayStationModal) {
     <app-weather-station-modal [facility]="facility"
       (emitSelectStation)="selectStation($event)"></app-weather-station-modal>
     }

--- a/src/app/shared/shared-predictors-content/edit-predictor-form/edit-predictor-form.component.html
+++ b/src/app/shared/shared-predictors-content/edit-predictor-form/edit-predictor-form.component.html
@@ -82,6 +82,39 @@
           Select at least one weather data type below to create predictors using the selected weather station and
           temperature thresholds.
         </div>
+        <div class="d-flex flex-wrap justify-content-center align-items-end gap-5 mt-4">
+          <div class="d-flex flex-column align-items-center">
+            <label class="semibold d-block mb-1" for="startDateMonth">Start Date</label>
+            <div class="d-flex gap-2">
+              <select id="startMonth" class="form-select form-select-sm weather-data-select"
+                formControlName="startMonth">
+                @for (month of months; track month.monthNumValue) {
+                <option [ngValue]="month.monthNumValue">{{month.abbreviation}}</option>
+                }
+              </select>
+              <select id="startYear" class="form-select form-select-sm weather-data-select" formControlName="startYear">
+                @for (year of yearOptions; track year) {
+                <option [ngValue]="year">{{year}}</option>
+                }
+              </select>
+            </div>
+          </div>
+          <div class="d-flex flex-column align-items-center">
+            <label class="semibold d-block mb-1" for="endDateMonth">End Date</label>
+            <div class="d-flex gap-2">
+              <select id="endMonth" class="form-select form-select-sm weather-data-select" formControlName="endMonth">
+                @for (month of months; track month.monthNumValue) {
+                <option [ngValue]="month.monthNumValue">{{month.abbreviation}}</option>
+                }
+              </select>
+              <select id="endYear" class="form-select form-select-sm weather-data-select" formControlName="endYear">
+                @for (year of yearOptions; track year) {
+                <option [ngValue]="year">{{year}}</option>
+                }
+              </select>
+            </div>
+          </div>
+        </div>
         <div class="d-flex flex-column mb-3 mt-3" formGroupName="weatherSelections">
           @if(predictorForm.get('weatherSelections.cdd')?.value || predictorForm.get('weatherSelections.hdd')?.value) {
           <div class="row justify-content-end">
@@ -93,7 +126,8 @@
 
           <div class="row g-2 align-items-center mb-2 flex-nowrap predictor-row">
             <div class="col-6">
-              <input type="checkbox" id="cdd" class="form-check-input" formControlName="cdd" (change)="onWeatherSelectionChange('cdd', $event)">
+              <input type="checkbox" id="cdd" class="form-check-input" formControlName="cdd"
+                (change)="onWeatherSelectionChange('cdd', $event)">
               <label for="cdd" class="fw-bold ps-2">Cooling Degree Days</label>
             </div>
             @if(predictorForm.get('weatherSelections.cdd')?.value) {
@@ -109,7 +143,8 @@
 
           <div class="row g-2 align-items-center mb-2 flex-nowrap predictor-row">
             <div class="col-6">
-              <input type="checkbox" id="hdd" class="form-check-input" formControlName="hdd" (change)="onWeatherSelectionChange('hdd', $event)">
+              <input type="checkbox" id="hdd" class="form-check-input" formControlName="hdd"
+                (change)="onWeatherSelectionChange('hdd', $event)">
               <label for="hdd" class="fw-bold ps-2">Heating Degree Days</label>
             </div>
             @if(predictorForm.get('weatherSelections.hdd')?.value) {

--- a/src/app/shared/shared-predictors-content/edit-predictor-form/edit-predictor-form.component.ts
+++ b/src/app/shared/shared-predictors-content/edit-predictor-form/edit-predictor-form.component.ts
@@ -125,4 +125,26 @@ export class EditPredictorFormComponent {
       this.predictorForm.markAsDirty();
     }
   }
+
+  onWeatherSelectionChange(
+    key: 'cdd' | 'hdd' | 'relativeHumidity' | 'dryBulbTemp' | 'wetBulbTemp' | 'dewPointTemp' | 'precipitation',
+    event: Event
+  ) {
+    const checked = (event.target as HTMLInputElement).checked;
+    const group = this.predictorForm.get('weatherSelections') as FormGroup;
+    if (!group) return;
+
+    if (this.addOrEdit === 'edit' && checked) {
+      const keys = ['cdd', 'hdd', 'relativeHumidity', 'dryBulbTemp', 'wetBulbTemp', 'dewPointTemp', 'precipitation'];
+      for (const k of keys) {
+        if (k !== key) {
+          group.get(k)?.patchValue(false, { emitEvent: false });
+        }
+      }
+    }
+
+    group.get(key)?.patchValue(checked, { emitEvent: false });
+    this.setValidators();
+    this.predictorForm.markAsDirty();
+  }
 }

--- a/src/app/shared/shared-predictors-content/edit-predictor-form/edit-predictor-form.component.ts
+++ b/src/app/shared/shared-predictors-content/edit-predictor-form/edit-predictor-form.component.ts
@@ -1,7 +1,7 @@
 import { AccountWorkspaceStore } from 'src/app/account-workspace/account-workspace.store';
 import { Component, Input, inject } from '@angular/core';
 import { FormGroup } from '@angular/forms';
-import { IdbPredictor } from 'src/app/models/idbModels/predictor';
+import { IdbPredictor, WeatherDataType } from 'src/app/models/idbModels/predictor';
 import { WeatherStation } from 'src/app/models/degreeDays';
 import { Router } from '@angular/router';
 import { WeatherDataService } from 'src/app/weather-data/weather-data.service';
@@ -35,7 +35,7 @@ export class EditPredictorFormComponent {
   facility: IdbFacility;
 
 
-  displaySationModal: boolean = false;
+  displayStationModal: boolean = false;
   months: Array<Month> = Months;
   yearOptions: Array<number> = Array.from(
     { length: new Date().getFullYear() - 1999 },
@@ -46,6 +46,7 @@ export class EditPredictorFormComponent {
   endMonth: number;
   endYear: number;
   facilityPredictorData: Array<IdbPredictorData>;
+  selectedWeatherTypes: Array<WeatherDataType>;
 
   constructor(
     private router: Router,
@@ -59,6 +60,15 @@ export class EditPredictorFormComponent {
       this.facility = this.accountWorkspaceStore.facilities().find(facility => facility.guid === (this.predictor.facilityId));
     }
     this.setWeatherPredictorDates();
+    this.setValidators();
+    this.selectedWeatherTypes = this.editPredictorFormService.getSelectedWeatherTypes(this.predictorForm);
+    const disableWeatherType = this.addOrEdit === 'edit' && this.predictorForm.controls.predictorType.value === 'Weather';
+    if (disableWeatherType) {
+      this.predictorForm.controls.weatherDataType.patchValue(this.selectedWeatherTypes[0], { emitEvent: false });
+      this.predictorForm.controls.weatherDataType.disable({ emitEvent: false });
+    } else {
+      this.predictorForm.controls.weatherDataType.enable({ emitEvent: false });
+    }
   }
 
   setWeatherPredictorDates() {
@@ -108,7 +118,7 @@ export class EditPredictorFormComponent {
   }
 
   async goToWeatherData() {
-    this.displaySationModal = false;
+    this.displayStationModal = false;
     if (this.predictorForm.controls.weatherDataType.value == 'CDD') {
       this.weatherDataService.coolingTemp = this.predictorForm.controls.coolingBaseTemperature.value;
     } else if (this.predictorForm.controls.weatherDataType.value == 'HDD') {
@@ -140,11 +150,11 @@ export class EditPredictorFormComponent {
   }
 
   openStationModal() {
-    this.displaySationModal = true;
+    this.displayStationModal = true;
   }
 
   cancelStationSelect() {
-    this.displaySationModal = false;
+    this.displayStationModal = false;
   }
 
   selectStation(station: WeatherStation) {

--- a/src/app/shared/shared-predictors-content/edit-predictor-form/edit-predictor-form.component.ts
+++ b/src/app/shared/shared-predictors-content/edit-predictor-form/edit-predictor-form.component.ts
@@ -9,6 +9,8 @@ import { IdbFacility } from 'src/app/models/idbModels/facility';
 import { EditPredictorFormService } from '../edit-predictor-form.service';
 import { getWeatherSearchFromFacility } from '../../sharedHelperFunctions';
 import { Month, Months } from '../../form-data/months';
+import { IdbPredictorData } from 'src/app/models/idbModels/predictorData';
+import { AccountWorkspaceQueryService } from 'src/app/account-workspace/account-workspace-query.service';
 
 @Component({
   selector: 'app-edit-predictor-form',
@@ -18,6 +20,7 @@ import { Month, Months } from '../../form-data/months';
 })
 export class EditPredictorFormComponent {
   private readonly accountWorkspaceStore = inject(AccountWorkspaceStore);
+  private readonly accountWorkspaceQuery = inject(AccountWorkspaceQueryService);
   @Input({ required: true })
   predictorForm: FormGroup;
   @Input({ required: true })
@@ -34,6 +37,16 @@ export class EditPredictorFormComponent {
 
   displaySationModal: boolean = false;
   months: Array<Month> = Months;
+  yearOptions: Array<number> = Array.from(
+    { length: new Date().getFullYear() - 1999 },
+    (_, i) => new Date().getFullYear() - i
+  );
+  startMonth: number;
+  startYear: number;
+  endMonth: number;
+  endYear: number;
+  facilityPredictorData: Array<IdbPredictorData>;
+
   constructor(
     private router: Router,
     private weatherDataService: WeatherDataService,
@@ -45,6 +58,41 @@ export class EditPredictorFormComponent {
     if (!this.facility) {
       this.facility = this.accountWorkspaceStore.facilities().find(facility => facility.guid === (this.predictor.facilityId));
     }
+    this.setWeatherPredictorDates();
+  }
+
+  setWeatherPredictorDates() {
+    if (!this.predictorForm)
+      return;
+
+    const predictorData = this.predictor?.guid ? this.accountWorkspaceQuery.getPredictorData(this.predictor.guid) : [];
+
+    const fallBackPredictorData = this.accountWorkspaceQuery.getFacilityPredictorData(this.facility?.guid);
+    const sourceData = predictorData.length ? predictorData : fallBackPredictorData;
+    this.facilityPredictorData = sourceData;
+    if (!this.facilityPredictorData.length) {
+      this.predictorForm.patchValue(
+        { startMonth: null, startYear: null, endMonth: null, endYear: null },
+        { emitEvent: false }
+      );
+      return;
+    }
+    const sortedPredictorData = this.facilityPredictorData.sort((a, b) => {
+      const dateA = new Date(a.year, a.month - 1);
+      const dateB = new Date(b.year, b.month - 1);
+      return dateA.getTime() - dateB.getTime();
+    });
+    const first = sortedPredictorData[0];
+    const last = sortedPredictorData[sortedPredictorData.length - 1];
+    this.predictorForm.patchValue(
+      {
+        startMonth: first.month - 1,
+        startYear: first.year,
+        endMonth: last.month - 1,
+        endYear: last.year
+      },
+      { emitEvent: false }
+    );
   }
 
   changePredictorType() {


### PR DESCRIPTION
connects #2300 

This pull request introduces significant improvements to the weather predictor creation workflow, allowing users to select and create multiple weather predictors at once, and ensuring that related analyses and data are updated accordingly. The changes also enhance form validation and user experience when working with weather predictors.

**Key changes include:**

### Multi-Weather Predictor Creation & Integration

* Added support for selecting multiple weather data types when creating a weather predictor. The form now allows users to check multiple weather options, and the backend logic creates a separate predictor for each selected type. All new predictors are propagated to related analyses and predictor data is generated as needed. 
* Refactored the `EditPredictorFormService` to handle multiple weather selections, including new methods for retrieving selected types and generating appropriate predictor names. The form now includes a `weatherSelections` group and custom validation to ensure at least one weather type is selected. 

### Analysis and Data Handling

* Implemented `addAnalysisPredictors` in `AnalysisCommandHandler` to add multiple predictors to all relevant analysis groups, ensuring new predictors are available for analysis immediately after creation.
* Updated the workflow for adding weather data: when multiple predictors are created, data is generated for each one individually, using their specific parameters.

### Form Validation and UI Improvements

* Improved form validation logic to dynamically adjust requirements based on selected weather types (e.g., requiring base temperatures only for CDD/HDD). The form disables unnecessary validators for non-weather predictors.
* Enhanced the CSS for weather predictor sections, including new alert and row styles for better user feedback and visual organization.

### Code Cleanup

* Removed unused imports and redundant code related to the previous single-weather-type workflow. 

These changes streamline the process of adding weather predictors, improve data integrity across analyses, and provide a more flexible and user-friendly interface for managing weather-related predictors.