### PR TITLE
Issue 2600 - added checkboxes to check/uncheck all items in visualization

### DIFF
--- a/src/app/data-evaluation/facility/visualization/correlation-plot-menu/correlation-plot-menu.component.html
+++ b/src/app/data-evaluation/facility/visualization/correlation-plot-menu/correlation-plot-menu.component.html
@@ -10,10 +10,9 @@
           <label class="col-3 col-form-label semibold" for="startDate">Start Date</label>
 
           <div class="col-3">
-            <select name="startMonth" [(ngModel)]="startMonth" class="form-select"
-              (change)="saveDateRange()">
+            <select name="startMonth" [(ngModel)]="startMonth" class="form-select" (change)="saveDateRange()">
               @for (month of months; track month) {
-                <option class="pe-2" [ngValue]="month.monthNumValue">
+              <option class="pe-2" [ngValue]="month.monthNumValue">
                 {{month.abbreviation}}</option>
               }
             </select>
@@ -21,8 +20,8 @@
           <div class="col-3">
             <select name="startYear" [(ngModel)]="startYear" class="form-select" (change)="saveDateRange()">
               @for (year of years; track year) {
-                <option class="pe-2" [ngValue]="year">{{year}}
-                </option>
+              <option class="pe-2" [ngValue]="year">{{year}}
+              </option>
               }
             </select>
           </div>
@@ -32,7 +31,7 @@
           <div class="col-3">
             <select name="endMonth" [(ngModel)]="endMonth" class="form-select" (change)="saveDateRange()">
               @for (month of months; track month) {
-                <option class="pe-2" [ngValue]="month.monthNumValue">
+              <option class="pe-2" [ngValue]="month.monthNumValue">
                 {{month.abbreviation}}</option>
               }
             </select>
@@ -40,8 +39,8 @@
           <div class="col-3">
             <select name="endYear" [(ngModel)]="endYear" class="form-select" (change)="saveDateRange()">
               @for (year of years; track year) {
-                <option class="pe-2" [ngValue]="year">{{year}}
-                </option>
+              <option class="pe-2" [ngValue]="year">{{year}}
+              </option>
               }
             </select>
           </div>
@@ -64,15 +63,13 @@
       <div class="col-3 justify-content-center">
         <label class="semibold">Boundary for display </label>
         <div class="form-check ms-2">
-          <input type="radio" class="form-check-input" name="energyIsSource"
-            [(ngModel)]="facility.energyIsSource" [value]="true" (change)="saveSiteOrSource()"
-            id="sourceEnergy">
+          <input type="radio" class="form-check-input" name="energyIsSource" [(ngModel)]="facility.energyIsSource"
+            [value]="true" (change)="saveSiteOrSource()" id="sourceEnergy">
           <label class="form-check-label" for="sourceEnergy">Source Energy</label>
         </div>
         <div class="form-check ms-2">
-          <input type="radio" class="form-check-input" name="energyIsSource"
-            [(ngModel)]="facility.energyIsSource" [value]="false" (change)="saveSiteOrSource()"
-            id="siteEnergy">
+          <input type="radio" class="form-check-input" name="energyIsSource" [(ngModel)]="facility.energyIsSource"
+            [value]="false" (change)="saveSiteOrSource()" id="siteEnergy">
           <label class="form-check-label" for="siteEnergy">Site Energy</label>
         </div>
 
@@ -81,338 +78,394 @@
     <div class="row">
       <div class="col-12">
         <hr>
-        </div>
       </div>
-      <!--Time Series-->
-      <div class="row">
-        <div class="col-12">
-          <h5>Time Series Options</h5>
-          <p>Select which axis you would like to represent utilities and predictors plotted over time. Items can
+    </div>
+    <!--Time Series-->
+    <div class="row">
+      <div class="col-12">
+        <h5>Time Series Options</h5>
+        <p>Select which axis you would like to represent utilities and predictors plotted over time. Items can
           only be plotted on one axis.</p>
-        </div>
-        <div class="col-12">
-          <div class="d-flex">
-            <div class="d-flex flex-column">
-              <label class="semibold">Plotted Left Y-Axis</label>
-              <div class="d-flex">
-                @if (correlationPlotOptions.asMeters) {
-                  <div class="p-2">
-                    <label>Meters</label>
-                    @for (timeSeriesMeterOption of correlationPlotOptions.timeSeriesMeterYAxis1Options; track timeSeriesMeterOption) {
-                      <div class="form-check ms-2"
-                        >
-                        <input class="form-check-input" type="checkbox"
-                          name="{{timeSeriesMeterOption.label+'TimeSeriesMeterYAxis1'}}"
-                          id="{{timeSeriesMeterOption.label+'TimeSeriesMeterYAxis1'}}"
-                          [(ngModel)]="timeSeriesMeterOption.selected" (change)="setTimeSeriesLeftAxis()">
-                        <label class="form-check-label"
-                        for="{{timeSeriesMeterOption.label+'TimeSeriesMeterYAxis1'}}">{{timeSeriesMeterOption.label}}</label>
-                      </div>
-                    }
-                  </div>
-                }
-                @if (!correlationPlotOptions.asMeters) {
-                  <div class="p-2">
-                    <label>Groups</label>
-                    @for (timeSeriesGroupOption of correlationPlotOptions.timeSeriesGroupYAxis1Options; track timeSeriesGroupOption) {
-                      <div class="form-check ms-2"
-                        >
-                        <input class="form-check-input" type="checkbox"
-                          name="{{timeSeriesGroupOption.label+'TimeSeriesGroupYAxis1'}}"
-                          id="{{timeSeriesGroupOption.label+'TimeSeriesGroupYAxis1'}}"
-                          [(ngModel)]="timeSeriesGroupOption.selected" (change)="setTimeSeriesLeftAxis()">
-                        <label class="form-check-label"
-                        for="{{timeSeriesGroupOption.label+'TimeSeriesGroupYAxis1'}}">{{timeSeriesGroupOption.label}}</label>
-                      </div>
-                    }
-                  </div>
-                }
-                <div class="p-2">
-                  <label>Predictors</label>
-                  @for (timeSeriesPredictor of correlationPlotOptions.timeSeriesPredictorYAxis1Options; track timeSeriesPredictor) {
-                    <div class="form-check ms-2"
-                      >
-                      <input class="form-check-input" type="checkbox"
-                        name="{{timeSeriesPredictor.label+'TimeSeriesPredictorYAxis1'}}"
-                        id="{{timeSeriesPredictor.label+'TimeSeriesPredictorYAxis1'}}"
-                        [(ngModel)]="timeSeriesPredictor.selected" (change)="setTimeSeriesLeftAxis()">
-                      <label class="form-check-label"
-                      for="{{timeSeriesPredictor.label+'TimeSeriesPredictorYAxis1'}}">{{timeSeriesPredictor.label}}</label>
-                    </div>
-                  }
-                </div>
-              </div>
-              <div class="p-2">
-                <div class="form-check">
-                  <input class="form-check-input" type="checkbox" type="checkbox"
-                    name="totalEnergyTimeSeriesYAxis1" id="totalEnergyTimeSeriesYAxis1"
-                    [(ngModel)]="correlationPlotOptions.totalEnergyTimeSeriesYAxis1"
-                    (change)="setTimeSeriesLeftAxis()">
-                  <label class="form-check-label" for="totalEnergyTimeSeriesYAxis1">Total Facility
-                  Energy</label>
-                </div>
-                <div class="form-check">
-                  <input class="form-check-input" type="checkbox" type="checkbox"
-                    name="totalSelectedEnergyTimeSeriesYAxis1" id="totalSelectedEnergyTimeSeriesYAxis1"
-                    [(ngModel)]="correlationPlotOptions.totalSelectedEnergyTimeSeriesYAxis1"
-                    (change)="setTimeSeriesLeftAxis()" [disabled]="disableY1SelectedTotal">
-                  <label class="form-check-label" for="totalSelectedEnergyTimeSeriesYAxis1">Total Selected
-                  Energy</label>
-                </div>
-              </div>
-            </div>
-
-
-            <div class="d-flex flex-column axis-group">
-              <label class="semibold">Plotted Right Y-Axis</label>
-              <div class="d-flex">
-                @if (correlationPlotOptions.asMeters) {
-                  <div class="p-2">
-                    <label>Meters</label>
-                    @for (timeSeriesMeterOption of correlationPlotOptions.timeSeriesMeterYAxis2Options; track timeSeriesMeterOption) {
-                      <div class="form-check ms-2"
-                        >
-                        <input class="form-check-input" type="checkbox"
-                          name="{{timeSeriesMeterOption.label+'TimeSeriesMeterYAxis2'}}"
-                          id="{{timeSeriesMeterOption.label+'TimeSeriesMeterYAxis2'}}"
-                          [(ngModel)]="timeSeriesMeterOption.selected"
-                          (change)="setTimeSeriesRightAxis()">
-                        <label class="form-check-label"
-                        for="{{timeSeriesMeterOption.label+'TimeSeriesMeterYAxis2'}}">{{timeSeriesMeterOption.label}}</label>
-                      </div>
-                    }
-                  </div>
-                }
-                @if (!correlationPlotOptions.asMeters) {
-                  <div class="p-2">
-                    <label>Groups</label>
-                    @for (timeSeriesGroupOption of correlationPlotOptions.timeSeriesGroupYAxis2Options; track timeSeriesGroupOption) {
-                      <div class="form-check ms-2"
-                        >
-                        <input class="form-check-input" type="checkbox"
-                          name="{{timeSeriesGroupOption.label+'TimeSeriesGroupYAxis2'}}"
-                          id="{{timeSeriesGroupOption.label+'TimeSeriesGroupYAxis2'}}"
-                          [(ngModel)]="timeSeriesGroupOption.selected"
-                          (change)="setTimeSeriesRightAxis()">
-                        <label class="form-check-label"
-                        for="{{timeSeriesGroupOption.label+'TimeSeriesGroupYAxis2'}}">{{timeSeriesGroupOption.label}}</label>
-                      </div>
-                    }
-                  </div>
-                }
-                <div class="p-2">
-                  <label>Predictors</label>
-                  @for (timeSeriesPredictor of correlationPlotOptions.timeSeriesPredictorYAxis2Options; track timeSeriesPredictor) {
-                    <div class="form-check ms-2"
-                      >
-                      <input class="form-check-input" type="checkbox"
-                        name="{{timeSeriesPredictor.label+'TimeSeriesPredictorYAxis2'}}"
-                        id="{{timeSeriesPredictor.label+'TimeSeriesPredictorYAxis2'}}"
-                        [(ngModel)]="timeSeriesPredictor.selected" (change)="setTimeSeriesRightAxis()">
-                      <label class="form-check-label"
-                      for="{{timeSeriesPredictor.label+'TimeSeriesPredictorYAxis2'}}">{{timeSeriesPredictor.label}}</label>
-                    </div>
-                  }
-                </div>
-              </div>
-              <div class="p-2">
-                <div class="form-check">
-                  <input class="form-check-input" type="checkbox" type="checkbox"
-                    name="totalEnergyTimeSeriesYAxis2" id="totalEnergyTimeSeriesYAxis2"
-                    [(ngModel)]="correlationPlotOptions.totalEnergyTimeSeriesYAxis2"
-                    (change)="setTimeSeriesRightAxis()">
-                  <label class="form-check-label" for="totalEnergyTimeSeriesYAxis2">Total Facility
-                  Energy</label>
-                </div>
-                <div class="form-check">
-                  <input class="form-check-input" type="checkbox" type="checkbox"
-                    name="totalSelectedEnergyTimeSeriesYAxis2" id="totalSelectedEnergyTimeSeriesYAxis2"
-                    [(ngModel)]="correlationPlotOptions.totalSelectedEnergyTimeSeriesYAxis2"
-                    (change)="setTimeSeriesRightAxis()" [disabled]="disableY2SelectedTotal">
-                  <label class="form-check-label" for="totalSelectedEnergyTimeSeriesYAxis2">Total Selected
-                  Energy</label>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
       </div>
-
-      <!--VARIANCE OPTIONS-->
-      <div class="row">
-        <div class="col-12">
-          <hr>
-          </div>
-          <div class="col-12">
-            <h5>R<sup>2</sup> Variance Options</h5>
-            <p>Select the utility and predictor combinations to include in an R<sup>2</sup> variance heatmap.</p>
-          </div>
-          <div class="col-12">
-            <label class="semibold">Included Variables</label>
-          </div>
-          <div class="col-12">
+      <div class="col-12">
+        <div class="d-flex">
+          <div class="d-flex flex-column">
+            <label class="semibold">Plotted Left Y-Axis</label>
             <div class="d-flex">
               @if (correlationPlotOptions.asMeters) {
-                <div class="p-2">
-                  <label>Meters</label>
-                  @for (r2MeterOption of correlationPlotOptions.r2MeterOptions; track r2MeterOption) {
-                    <div class="form-check ms-2"
-                      >
-                      <input class="form-check-input" type="checkbox" name="{{r2MeterOption.label+'Meter'}}"
-                        id="{{r2MeterOption.label+'Meter'}}" [(ngModel)]="r2MeterOption.selected"
-                        (change)="savePlotOptions()">
-                      <label class="form-check-label"
-                      for="{{r2MeterOption.label+'Meter'}}">{{r2MeterOption.label}}</label>
-                    </div>
-                  }
+              <div class="p-2">
+                <div class="form-check mb-1">
+                  <input class="form-check-input" type="checkbox" name="timeSeriesMetersLeftLabelCheckbox"
+                    id="timeSeriesMetersLeftLabelCheckbox"
+                    [ngModel]="areAllSelected(correlationPlotOptions.timeSeriesMeterYAxis1Options)"
+                    (ngModelChange)="toggleAll(correlationPlotOptions.timeSeriesMeterYAxis1Options, $event, 'left')">
+                  <label class="form-check-label" for="timeSeriesMetersLeftLabelCheckbox">Meters</label>
                 </div>
+                @for (timeSeriesMeterOption of correlationPlotOptions.timeSeriesMeterYAxis1Options; track
+                timeSeriesMeterOption) {
+                <div class="form-check ms-2">
+                  <input class="form-check-input" type="checkbox"
+                    name="{{timeSeriesMeterOption.label+'TimeSeriesMeterYAxis1'}}"
+                    id="{{timeSeriesMeterOption.label+'TimeSeriesMeterYAxis1'}}"
+                    [(ngModel)]="timeSeriesMeterOption.selected" (change)="setTimeSeriesLeftAxis()">
+                  <label class="form-check-label"
+                    for="{{timeSeriesMeterOption.label+'TimeSeriesMeterYAxis1'}}">{{timeSeriesMeterOption.label}}</label>
+                </div>
+                }
+              </div>
               }
               @if (!correlationPlotOptions.asMeters) {
-                <div class="p-2">
-                  <label>Groups</label>
-                  @for (r2GroupOption of correlationPlotOptions.r2GroupOptions; track r2GroupOption) {
-                    <div class="form-check ms-2"
-                      >
-                      <input class="form-check-input" type="checkbox" name="{{r2GroupOption.label+'Group'}}"
-                        id="{{r2GroupOption.label+'Group'}}" [(ngModel)]="r2GroupOption.selected"
-                        (change)="savePlotOptions()">
-                      <label class="form-check-label"
-                      for="{{r2GroupOption.label+'Group'}}">{{r2GroupOption.label}}</label>
-                    </div>
-                  }
+              <div class="p-2">
+                <div class="form-check mb-1">
+                  <input class="form-check-input" type="checkbox" name="timeSeriesGroupsLeftLabelCheckbox"
+                    id="timeSeriesGroupsLeftLabelCheckbox"
+                    [ngModel]="areAllSelected(correlationPlotOptions.timeSeriesGroupYAxis1Options)"
+                    (ngModelChange)="toggleAll(correlationPlotOptions.timeSeriesGroupYAxis1Options, $event, 'left')">
+                  <label class="form-check-label" for="timeSeriesGroupsLeftLabelCheckbox">Groups</label>
                 </div>
+                @for (timeSeriesGroupOption of correlationPlotOptions.timeSeriesGroupYAxis1Options; track
+                timeSeriesGroupOption) {
+                <div class="form-check ms-2">
+                  <input class="form-check-input" type="checkbox"
+                    name="{{timeSeriesGroupOption.label+'TimeSeriesGroupYAxis1'}}"
+                    id="{{timeSeriesGroupOption.label+'TimeSeriesGroupYAxis1'}}"
+                    [(ngModel)]="timeSeriesGroupOption.selected" (change)="setTimeSeriesLeftAxis()">
+                  <label class="form-check-label"
+                    for="{{timeSeriesGroupOption.label+'TimeSeriesGroupYAxis1'}}">{{timeSeriesGroupOption.label}}</label>
+                </div>
+                }
+              </div>
               }
               <div class="p-2">
-                <label>Predictors</label>
-                @for (r2Predictor of correlationPlotOptions.r2PredictorOptions; track r2Predictor) {
-                  <div class="form-check ms-2"
-                    >
-                    <input class="form-check-input" type="checkbox" name="{{r2Predictor.label+'predictor'}}"
-                      id="{{r2Predictor.label+'predictor'}}" [(ngModel)]="r2Predictor.selected"
-                      (change)="savePlotOptions()">
-                    <label class="form-check-label"
-                    for="{{r2Predictor.label+'predictor'}}">{{r2Predictor.label}}</label>
-                  </div>
+                <div class="form-check mb-1">
+                  <input class="form-check-input" type="checkbox" name="timeSeriesPredictorsLeftLabelCheckbox"
+                    id="timeSeriesPredictorsLeftLabelCheckbox"
+                    [ngModel]="areAllSelected(correlationPlotOptions.timeSeriesPredictorYAxis1Options)"
+                    (ngModelChange)="toggleAll(correlationPlotOptions.timeSeriesPredictorYAxis1Options, $event, 'left')">
+                  <label class="form-check-label" for="timeSeriesPredictorsLeftLabelCheckbox">Predictors</label>
+                </div>
+                @for (timeSeriesPredictor of correlationPlotOptions.timeSeriesPredictorYAxis1Options; track
+                timeSeriesPredictor) {
+                <div class="form-check ms-2">
+                  <input class="form-check-input" type="checkbox"
+                    name="{{timeSeriesPredictor.label+'TimeSeriesPredictorYAxis1'}}"
+                    id="{{timeSeriesPredictor.label+'TimeSeriesPredictorYAxis1'}}"
+                    [(ngModel)]="timeSeriesPredictor.selected" (change)="setTimeSeriesLeftAxis()">
+                  <label class="form-check-label"
+                    for="{{timeSeriesPredictor.label+'TimeSeriesPredictorYAxis1'}}">{{timeSeriesPredictor.label}}</label>
+                </div>
                 }
+              </div>
+            </div>
+            <div class="p-2">
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" type="checkbox" name="totalEnergyTimeSeriesYAxis1"
+                  id="totalEnergyTimeSeriesYAxis1" [(ngModel)]="correlationPlotOptions.totalEnergyTimeSeriesYAxis1"
+                  (change)="setTimeSeriesLeftAxis()">
+                <label class="form-check-label" for="totalEnergyTimeSeriesYAxis1">Total Facility
+                  Energy</label>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" type="checkbox"
+                  name="totalSelectedEnergyTimeSeriesYAxis1" id="totalSelectedEnergyTimeSeriesYAxis1"
+                  [(ngModel)]="correlationPlotOptions.totalSelectedEnergyTimeSeriesYAxis1"
+                  (change)="setTimeSeriesLeftAxis()" [disabled]="disableY1SelectedTotal">
+                <label class="form-check-label" for="totalSelectedEnergyTimeSeriesYAxis1">Total Selected
+                  Energy</label>
+              </div>
+            </div>
+          </div>
+
+
+          <div class="d-flex flex-column axis-group">
+            <label class="semibold">Plotted Right Y-Axis</label>
+            <div class="d-flex">
+              @if (correlationPlotOptions.asMeters) {
+              <div class="p-2">
+                <div class="form-check mb-1">
+                  <input class="form-check-input" type="checkbox" name="timeSeriesMetersRightLabelCheckbox"
+                    id="timeSeriesMetersRightLabelCheckbox"
+                    [ngModel]="areAllSelected(correlationPlotOptions.timeSeriesMeterYAxis2Options)"
+                    (ngModelChange)="toggleAll(correlationPlotOptions.timeSeriesMeterYAxis2Options, $event, 'right')">
+                  <label class="form-check-label" for="timeSeriesMetersRightLabelCheckbox">Meters</label>
+                </div>
+                @for (timeSeriesMeterOption of correlationPlotOptions.timeSeriesMeterYAxis2Options; track
+                timeSeriesMeterOption) {
+                <div class="form-check ms-2">
+                  <input class="form-check-input" type="checkbox"
+                    name="{{timeSeriesMeterOption.label+'TimeSeriesMeterYAxis2'}}"
+                    id="{{timeSeriesMeterOption.label+'TimeSeriesMeterYAxis2'}}"
+                    [(ngModel)]="timeSeriesMeterOption.selected" (change)="setTimeSeriesRightAxis()">
+                  <label class="form-check-label"
+                    for="{{timeSeriesMeterOption.label+'TimeSeriesMeterYAxis2'}}">{{timeSeriesMeterOption.label}}</label>
+                </div>
+                }
+              </div>
+              }
+              @if (!correlationPlotOptions.asMeters) {
+              <div class="p-2">
+                <div class="form-check mb-1">
+                  <input class="form-check-input" type="checkbox" name="timeSeriesGroupsRightLabelCheckbox"
+                    id="timeSeriesGroupsRightLabelCheckbox"
+                    [ngModel]="areAllSelected(correlationPlotOptions.timeSeriesGroupYAxis2Options)"
+                    (ngModelChange)="toggleAll(correlationPlotOptions.timeSeriesGroupYAxis2Options, $event, 'right')">
+                  <label class="form-check-label" for="timeSeriesGroupsRightLabelCheckbox">Groups</label>
+                </div>
+                @for (timeSeriesGroupOption of correlationPlotOptions.timeSeriesGroupYAxis2Options; track
+                timeSeriesGroupOption) {
+                <div class="form-check ms-2">
+                  <input class="form-check-input" type="checkbox"
+                    name="{{timeSeriesGroupOption.label+'TimeSeriesGroupYAxis2'}}"
+                    id="{{timeSeriesGroupOption.label+'TimeSeriesGroupYAxis2'}}"
+                    [(ngModel)]="timeSeriesGroupOption.selected" (change)="setTimeSeriesRightAxis()">
+                  <label class="form-check-label"
+                    for="{{timeSeriesGroupOption.label+'TimeSeriesGroupYAxis2'}}">{{timeSeriesGroupOption.label}}</label>
+                </div>
+                }
+              </div>
+              }
+              <div class="p-2">
+                <div class="form-check mb-1">
+                  <input class="form-check-input" type="checkbox" name="timeSeriesPredictorsRightLabelCheckbox"
+                    id="timeSeriesPredictorsRightLabelCheckbox"
+                    [ngModel]="areAllSelected(correlationPlotOptions.timeSeriesPredictorYAxis2Options)"
+                    (ngModelChange)="toggleAll(correlationPlotOptions.timeSeriesPredictorYAxis2Options, $event, 'right')">
+                  <label class="form-check-label" for="timeSeriesPredictorsRightLabelCheckbox">Predictors</label>
+                </div>
+                @for (timeSeriesPredictor of correlationPlotOptions.timeSeriesPredictorYAxis2Options; track
+                timeSeriesPredictor) {
+                <div class="form-check ms-2">
+                  <input class="form-check-input" type="checkbox"
+                    name="{{timeSeriesPredictor.label+'TimeSeriesPredictorYAxis2'}}"
+                    id="{{timeSeriesPredictor.label+'TimeSeriesPredictorYAxis2'}}"
+                    [(ngModel)]="timeSeriesPredictor.selected" (change)="setTimeSeriesRightAxis()">
+                  <label class="form-check-label"
+                    for="{{timeSeriesPredictor.label+'TimeSeriesPredictorYAxis2'}}">{{timeSeriesPredictor.label}}</label>
+                </div>
+                }
+              </div>
+            </div>
+            <div class="p-2">
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" type="checkbox" name="totalEnergyTimeSeriesYAxis2"
+                  id="totalEnergyTimeSeriesYAxis2" [(ngModel)]="correlationPlotOptions.totalEnergyTimeSeriesYAxis2"
+                  (change)="setTimeSeriesRightAxis()">
+                <label class="form-check-label" for="totalEnergyTimeSeriesYAxis2">Total Facility
+                  Energy</label>
+              </div>
+              <div class="form-check">
+                <input class="form-check-input" type="checkbox" type="checkbox"
+                  name="totalSelectedEnergyTimeSeriesYAxis2" id="totalSelectedEnergyTimeSeriesYAxis2"
+                  [(ngModel)]="correlationPlotOptions.totalSelectedEnergyTimeSeriesYAxis2"
+                  (change)="setTimeSeriesRightAxis()" [disabled]="disableY2SelectedTotal">
+                <label class="form-check-label" for="totalSelectedEnergyTimeSeriesYAxis2">Total Selected
+                  Energy</label>
               </div>
             </div>
           </div>
         </div>
-        <!--Correlation options-->
+      </div>
+    </div>
 
-        <div class="row">
-          <div class="col-12">
-            <hr>
+    <!--VARIANCE OPTIONS-->
+    <div class="row">
+      <div class="col-12">
+        <hr>
+      </div>
+      <div class="col-12">
+        <h5>R<sup>2</sup> Variance Options</h5>
+        <p>Select the utility and predictor combinations to include in an R<sup>2</sup> variance heatmap.</p>
+      </div>
+      <div class="col-12">
+        <label class="semibold">Included Variables</label>
+      </div>
+      <div class="col-12">
+        <div class="d-flex">
+          @if (correlationPlotOptions.asMeters) {
+          <div class="p-2">
+            <div class="form-check mb-1">
+              <input class="form-check-input" type="checkbox" name="r2MetersLabelCheckbox" id="r2MetersLabelCheckbox"
+                [ngModel]="areAllSelected(correlationPlotOptions.r2MeterOptions)"
+                (ngModelChange)="toggleAll(correlationPlotOptions.r2MeterOptions, $event)">
+              <label class="form-check-label" for="r2MetersLabelCheckbox">Meters</label>
             </div>
-            <div class="d-flex flex-wrap">
-              <div class="d-flex flex-column">
-                <h5>Data Correlation Options</h5>
-                <p class="help-text">
-                  Correlation plots will be generated for all x/y variable combinations that are selected.
-                </p>
-                <div class="d-flex">
-                  <div class="d-flex flex-column">
-                    <label class="semibold">Plotted on Y-Axis</label>
-                    <div class="d-flex">
-                      @if (correlationPlotOptions.asMeters) {
-                        <div class="p-2">
-                          <label>Meters</label>
-                          @for (xAxisOption of correlationPlotOptions.yAxisMeterOptions; track xAxisOption) {
-                            <div class="form-check ms-2"
-                              >
-                              <input class="form-check-input" type="checkbox" name="{{xAxisOption.label+'y'}}"
-                                id="{{xAxisOption.label+'y'}}" [(ngModel)]="xAxisOption.selected"
-                                (change)="savePlotOptions()">
-                              <label class="form-check-label"
-                              for="{{xAxisOption.label+'y'}}">{{xAxisOption.label}}</label>
-                            </div>
-                          }
-                        </div>
-                      }
-                      @if (!correlationPlotOptions.asMeters) {
-                        <div class="p-2">
-                          <label>Groups</label>
-                          @for (xAxisOption of correlationPlotOptions.yAxisGroupOptions; track xAxisOption) {
-                            <div class="form-check ms-2"
-                              >
-                              <input class="form-check-input" type="checkbox" name="{{xAxisOption.label+'y'}}"
-                                id="{{xAxisOption.label+'y'}}" [(ngModel)]="xAxisOption.selected"
-                                (change)="savePlotOptions()">
-                              <label class="form-check-label"
-                              for="{{xAxisOption.label+'y'}}">{{xAxisOption.label}}</label>
-                            </div>
-                          }
-                        </div>
-                      }
-                      <div class="p-2">
-                        <label>Predictors</label>
-                        @for (xAxisOption of correlationPlotOptions.yAxisPredictorOptions; track xAxisOption) {
-                          <div class="form-check ms-2"
-                            >
-                            <input class="form-check-input" type="checkbox" name="{{xAxisOption.label+'y'}}"
-                              id="{{xAxisOption.label+'y'}}" [(ngModel)]="xAxisOption.selected"
-                              (change)="savePlotOptions()">
-                            <label class="form-check-label"
-                            for="{{xAxisOption.label+'y'}}">{{xAxisOption.label}}</label>
-                          </div>
-                        }
-                      </div>
-                    </div>
-                  </div>
-                  <div class="d-flex flex-column axis-group">
-                    <label class="semibold">Plotted on X-Axis</label>
-                    <div class="d-flex">
-                      @if (correlationPlotOptions.asMeters) {
-                        <div class="p-2">
-                          <label>Meters</label>
-                          @for (xAxisOption of correlationPlotOptions.xAxisMeterOptions; track xAxisOption) {
-                            <div class="form-check ms-2"
-                              >
-                              <input class="form-check-input" type="checkbox" name="{{xAxisOption.label}}"
-                                id="{{xAxisOption.label}}" [(ngModel)]="xAxisOption.selected"
-                                (change)="savePlotOptions()">
-                              <label class="form-check-label"
-                              for="{{xAxisOption.label}}">{{xAxisOption.label}}</label>
-                            </div>
-                          }
-                        </div>
-                      }
-                      @if (!correlationPlotOptions.asMeters) {
-                        <div class="p-2">
-                          <label>Groups</label>
-                          @for (xAxisOption of correlationPlotOptions.xAxisGroupOptions; track xAxisOption) {
-                            <div class="form-check ms-2"
-                              >
-                              <input class="form-check-input" type="checkbox" name="{{xAxisOption.label}}"
-                                id="{{xAxisOption.label}}" [(ngModel)]="xAxisOption.selected"
-                                (change)="savePlotOptions()">
-                              <label class="form-check-label"
-                              for="{{xAxisOption.label}}">{{xAxisOption.label}}</label>
-                            </div>
-                          }
-                        </div>
-                      }
-                      <div class="p-2">
-                        <label>Predictors</label>
-                        @for (xAxisOption of correlationPlotOptions.xAxisPredictorOptions; track xAxisOption) {
-                          <div class="form-check ms-2"
-                            >
-                            <input class="form-check-input" type="checkbox" name="{{xAxisOption.label}}"
-                              id="{{xAxisOption.label}}" [(ngModel)]="xAxisOption.selected"
-                              (change)="savePlotOptions()">
-                            <label class="form-check-label"
-                            for="{{xAxisOption.label}}">{{xAxisOption.label}}</label>
-                          </div>
-                        }
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <!-- <div class="m-2 p-2 alert alert-info">
-                Correlation plots will be generated for all x/y variable combinations that are selected.
-              </div> -->
+            @for (r2MeterOption of correlationPlotOptions.r2MeterOptions; track r2MeterOption) {
+            <div class="form-check ms-2">
+              <input class="form-check-input" type="checkbox" name="{{r2MeterOption.label+'Meter'}}"
+                id="{{r2MeterOption.label+'Meter'}}" [(ngModel)]="r2MeterOption.selected" (change)="savePlotOptions()">
+              <label class="form-check-label" for="{{r2MeterOption.label+'Meter'}}">{{r2MeterOption.label}}</label>
             </div>
+            }
+          </div>
+          }
+          @if (!correlationPlotOptions.asMeters) {
+          <div class="p-2">
+            <div class="form-check mb-1">
+              <input class="form-check-input" type="checkbox" name="r2GroupsLabelCheckbox" id="r2GroupsLabelCheckbox"
+                [ngModel]="areAllSelected(correlationPlotOptions.r2GroupOptions)"
+                (ngModelChange)="toggleAll(correlationPlotOptions.r2GroupOptions, $event)">
+              <label class="form-check-label" for="r2GroupsLabelCheckbox">Groups</label>
+            </div>
+            @for (r2GroupOption of correlationPlotOptions.r2GroupOptions; track r2GroupOption) {
+            <div class="form-check ms-2">
+              <input class="form-check-input" type="checkbox" name="{{r2GroupOption.label+'Group'}}"
+                id="{{r2GroupOption.label+'Group'}}" [(ngModel)]="r2GroupOption.selected" (change)="savePlotOptions()">
+              <label class="form-check-label" for="{{r2GroupOption.label+'Group'}}">{{r2GroupOption.label}}</label>
+            </div>
+            }
+          </div>
+          }
+          <div class="p-2">
+            <div class="form-check mb-1">
+              <input class="form-check-input" type="checkbox" name="r2PredictorsLabelCheckbox"
+                id="r2PredictorsLabelCheckbox" [ngModel]="areAllSelected(correlationPlotOptions.r2PredictorOptions)"
+                (ngModelChange)="toggleAll(correlationPlotOptions.r2PredictorOptions, $event)">
+              <label class="form-check-label" for="r2PredictorsLabelCheckbox">Predictors</label>
+            </div>
+            @for (r2Predictor of correlationPlotOptions.r2PredictorOptions; track r2Predictor) {
+            <div class="form-check ms-2">
+              <input class="form-check-input" type="checkbox" name="{{r2Predictor.label+'predictor'}}"
+                id="{{r2Predictor.label+'predictor'}}" [(ngModel)]="r2Predictor.selected" (change)="savePlotOptions()">
+              <label class="form-check-label" for="{{r2Predictor.label+'predictor'}}">{{r2Predictor.label}}</label>
+            </div>
+            }
           </div>
         </div>
-      </form>
+      </div>
     </div>
+    <!--Correlation options-->
+
+    <div class="row">
+      <div class="col-12">
+        <hr>
+      </div>
+      <div class="d-flex flex-wrap">
+        <div class="d-flex flex-column">
+          <h5>Data Correlation Options</h5>
+          <p class="help-text">
+            Correlation plots will be generated for all x/y variable combinations that are selected.
+          </p>
+          <div class="d-flex">
+            <div class="d-flex flex-column">
+              <label class="semibold">Plotted on Y-Axis</label>
+              <div class="d-flex">
+                @if (correlationPlotOptions.asMeters) {
+                <div class="p-2">
+                  <div class="form-check mb-1">
+                    <input class="form-check-input" type="checkbox" name="correlationMetersYLabelCheckbox"
+                      id="correlationMetersYLabelCheckbox"
+                      [ngModel]="areAllSelected(correlationPlotOptions.yAxisMeterOptions)"
+                      (ngModelChange)="toggleAll(correlationPlotOptions.yAxisMeterOptions, $event)">
+                    <label class="form-check-label" for="correlationMetersYLabelCheckbox">Meters</label>
+                  </div>
+                  @for (xAxisOption of correlationPlotOptions.yAxisMeterOptions; track xAxisOption) {
+                  <div class="form-check ms-2">
+                    <input class="form-check-input" type="checkbox" name="{{xAxisOption.label+'y'}}"
+                      id="{{xAxisOption.label+'y'}}" [(ngModel)]="xAxisOption.selected" (change)="savePlotOptions()">
+                    <label class="form-check-label" for="{{xAxisOption.label+'y'}}">{{xAxisOption.label}}</label>
+                  </div>
+                  }
+                </div>
+                }
+                @if (!correlationPlotOptions.asMeters) {
+                <div class="p-2">
+                  <div class="form-check mb-1">
+                    <input class="form-check-input" type="checkbox" name="correlationGroupsYLabelCheckbox"
+                      id="correlationGroupsYLabelCheckbox"
+                      [ngModel]="areAllSelected(correlationPlotOptions.yAxisGroupOptions)"
+                      (ngModelChange)="toggleAll(correlationPlotOptions.yAxisGroupOptions, $event)">
+                    <label class="form-check-label" for="correlationGroupsYLabelCheckbox">Groups</label>
+                  </div>
+                  @for (xAxisOption of correlationPlotOptions.yAxisGroupOptions; track xAxisOption) {
+                  <div class="form-check ms-2">
+                    <input class="form-check-input" type="checkbox" name="{{xAxisOption.label+'y'}}"
+                      id="{{xAxisOption.label+'y'}}" [(ngModel)]="xAxisOption.selected" (change)="savePlotOptions()">
+                    <label class="form-check-label" for="{{xAxisOption.label+'y'}}">{{xAxisOption.label}}</label>
+                  </div>
+                  }
+                </div>
+                }
+                <div class="p-2">
+                  <div class="form-check mb-1">
+                    <input class="form-check-input" type="checkbox" name="correlationPredictorsYLabelCheckbox"
+                      id="correlationPredictorsYLabelCheckbox"
+                      [ngModel]="areAllSelected(correlationPlotOptions.yAxisPredictorOptions)"
+                      (ngModelChange)="toggleAll(correlationPlotOptions.yAxisPredictorOptions, $event)">
+                    <label class="form-check-label" for="correlationPredictorsYLabelCheckbox">Predictors</label>
+                  </div>
+                  @for (xAxisOption of correlationPlotOptions.yAxisPredictorOptions; track xAxisOption) {
+                  <div class="form-check ms-2">
+                    <input class="form-check-input" type="checkbox" name="{{xAxisOption.label+'y'}}"
+                      id="{{xAxisOption.label+'y'}}" [(ngModel)]="xAxisOption.selected" (change)="savePlotOptions()">
+                    <label class="form-check-label" for="{{xAxisOption.label+'y'}}">{{xAxisOption.label}}</label>
+                  </div>
+                  }
+                </div>
+              </div>
+            </div>
+            <div class="d-flex flex-column axis-group">
+              <label class="semibold">Plotted on X-Axis</label>
+              <div class="d-flex">
+                @if (correlationPlotOptions.asMeters) {
+                <div class="p-2">
+                  <div class="form-check mb-1">
+                    <input class="form-check-input" type="checkbox" name="correlationMetersXLabelCheckbox"
+                      id="correlationMetersXLabelCheckbox"
+                      [ngModel]="areAllSelected(correlationPlotOptions.xAxisMeterOptions)"
+                      (ngModelChange)="toggleAll(correlationPlotOptions.xAxisMeterOptions, $event)">
+                    <label class="form-check-label" for="correlationMetersXLabelCheckbox">Meters</label>
+                  </div>
+                  @for (xAxisOption of correlationPlotOptions.xAxisMeterOptions; track xAxisOption) {
+                  <div class="form-check ms-2">
+                    <input class="form-check-input" type="checkbox" name="{{xAxisOption.label}}"
+                      id="{{xAxisOption.label}}" [(ngModel)]="xAxisOption.selected" (change)="savePlotOptions()">
+                    <label class="form-check-label" for="{{xAxisOption.label}}">{{xAxisOption.label}}</label>
+                  </div>
+                  }
+                </div>
+                }
+                @if (!correlationPlotOptions.asMeters) {
+                <div class="p-2">
+                  <div class="form-check mb-1">
+                    <input class="form-check-input" type="checkbox" name="correlationGroupsXLabelCheckbox"
+                      id="correlationGroupsXLabelCheckbox"
+                      [ngModel]="areAllSelected(correlationPlotOptions.xAxisGroupOptions)"
+                      (ngModelChange)="toggleAll(correlationPlotOptions.xAxisGroupOptions, $event)">
+                    <label class="form-check-label" for="correlationGroupsXLabelCheckbox">Groups</label>
+                  </div>
+                  @for (xAxisOption of correlationPlotOptions.xAxisGroupOptions; track xAxisOption) {
+                  <div class="form-check ms-2">
+                    <input class="form-check-input" type="checkbox" name="{{xAxisOption.label}}"
+                      id="{{xAxisOption.label}}" [(ngModel)]="xAxisOption.selected" (change)="savePlotOptions()">
+                    <label class="form-check-label" for="{{xAxisOption.label}}">{{xAxisOption.label}}</label>
+                  </div>
+                  }
+                </div>
+                }
+                <div class="p-2">
+                  <div class="form-check mb-1">
+                    <input class="form-check-input" type="checkbox" name="correlationPredictorsXLabelCheckbox"
+                      id="correlationPredictorsXLabelCheckbox"
+                      [ngModel]="areAllSelected(correlationPlotOptions.xAxisPredictorOptions)"
+                      (ngModelChange)="toggleAll(correlationPlotOptions.xAxisPredictorOptions, $event)">
+                    <label class="form-check-label" for="correlationPredictorsXLabelCheckbox">Predictors</label>
+                  </div>
+                  @for (xAxisOption of correlationPlotOptions.xAxisPredictorOptions; track xAxisOption) {
+                  <div class="form-check ms-2">
+                    <input class="form-check-input" type="checkbox" name="{{xAxisOption.label}}"
+                      id="{{xAxisOption.label}}" [(ngModel)]="xAxisOption.selected" (change)="savePlotOptions()">
+                    <label class="form-check-label" for="{{xAxisOption.label}}">{{xAxisOption.label}}</label>
+                  </div>
+                  }
+                </div>
+              </div>
+            </div>
+          </div>
+          <!-- <div class="m-2 p-2 alert alert-info">
+                Correlation plots will be generated for all x/y variable combinations that are selected.
+              </div> -->
+        </div>
+      </div>
+    </div>
+  </form>
+</div>

--- a/src/app/data-evaluation/facility/visualization/correlation-plot-menu/correlation-plot-menu.component.ts
+++ b/src/app/data-evaluation/facility/visualization/correlation-plot-menu/correlation-plot-menu.component.ts
@@ -11,10 +11,10 @@ import * as _ from 'lodash';
 import { IdbFacility } from 'src/app/models/idbModels/facility';
 
 @Component({
-    selector: 'app-correlation-plot-menu',
-    templateUrl: './correlation-plot-menu.component.html',
-    styleUrls: ['./correlation-plot-menu.component.css'],
-    standalone: false
+  selector: 'app-correlation-plot-menu',
+  templateUrl: './correlation-plot-menu.component.html',
+  styleUrls: ['./correlation-plot-menu.component.css'],
+  standalone: false
 })
 export class CorrelationPlotMenuComponent {
   private readonly accountWorkspaceStore = inject(AccountWorkspaceStore);
@@ -82,8 +82,10 @@ export class CorrelationPlotMenuComponent {
 
   async saveSiteOrSource() {
     await this.commandBoundary.execute(
-      { entityKind: 'facility', changeKind: 'update', entityGuid: this.facility.guid, label: 'Updating facility' ,
-        publication: { mode: 'patch', buildPatch: value => ({ collections: [{ collection: 'facilities', upsert: [value] }] }) }},
+      {
+        entityKind: 'facility', changeKind: 'update', entityGuid: this.facility.guid, label: 'Updating facility',
+        publication: { mode: 'patch', buildPatch: value => ({ collections: [{ collection: 'facilities', upsert: [value] }] }) }
+      },
       () => this.facilityHandler.update({ ...this.facility }, this.accountWorkspaceStore.account()?.guid)
     );
   }
@@ -206,6 +208,24 @@ export class CorrelationPlotMenuComponent {
     let allYears: Array<number> = combinedMonthlyData.flatMap(monthlyData => { return monthlyData.year });
     allYears = _.uniq(allYears);
     this.years = allYears;
+  }
+
+  areAllSelected(options: Array<AxisOption>): boolean {
+    return options.length > 0 && options.every(o => o.selected);
+  }
+
+  toggleAll(options: Array<AxisOption>, selected: boolean, axis?: 'left' | 'right') {
+    options.forEach(option => option.selected = selected);
+
+    if (axis == 'left') {
+      this.setTimeSeriesLeftAxis();
+      return;
+    }
+    if (axis == 'right') {
+      this.setTimeSeriesRightAxis();
+      return;
+    }
+    this.savePlotOptions();
   }
 }
 


### PR DESCRIPTION
connects #2600 

This pull request updates the `correlation-plot-menu.component.html` to improve the usability of the correlation plot menu by adding "select all" checkboxes for various groups of options (Meters, Groups, Predictors) in multiple sections. The changes allow users to easily select or deselect all related checkboxes at once, streamlining the user experience when configuring plots.

Key improvements include:

**Bulk Selection Functionality:**
* Added "select all" checkboxes for Meters, Groups, and Predictors in the Time Series, R² Variance, and Data Correlation options sections, enabling users to quickly select or deselect all related items. 

**UI Consistency and Readability:**
* Replaced plain labels with form-check labels and grouped checkboxes for better consistency and accessibility across the UI. 

**Minor Formatting and Cleanup:**
* Minor formatting adjustments for improved code readability, such as consistent indentation and consolidation of input attributes onto single lines. 

These changes enhance the overall user experience by making it much easier to manage multiple plot configuration options at once.