### PR TITLE
Issue 2639

### DIFF
--- a/src/app/shared/settings-forms/account-settings-form.service.spec.ts
+++ b/src/app/shared/settings-forms/account-settings-form.service.spec.ts
@@ -1,0 +1,170 @@
+import { TestBed } from '@angular/core/testing';
+import { FormBuilder } from '@angular/forms';
+import { DEFAULT_DATA_STALENESS_MONTHS } from '@domain/calculations/status-check-calculations/statusCheckModels';
+import { IdbAccount } from '@data/models/idbModels/account';
+import { AccountSettingsFormService } from './account-settings-form.service';
+
+describe('AccountSettingsFormService', () => {
+  let service: AccountSettingsFormService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [FormBuilder, AccountSettingsFormService]
+    });
+    service = TestBed.inject(AccountSettingsFormService);
+  });
+
+  it('maps account profile fields without changing identifiers', () => {
+    const account = accountFixture();
+    const form = service.getGeneralInformationForm(account);
+
+    form.patchValue({
+      name: ' Updated Account ',
+      country: 'CA',
+      city: 'Toronto',
+      contactEmail: 'energy@example.com'
+    });
+
+    const updated = service.updateAccountFromGeneralInformationForm(form, { ...account });
+
+    expect(updated.guid).toBe('account-a');
+    expect(updated.name).toBe('Updated Account');
+    expect(updated.country).toBe('CA');
+    expect(updated.city).toBe('Toronto');
+    expect(updated.contactEmail).toBe('energy@example.com');
+  });
+
+  it('normalizes missing optional account settings for older records', () => {
+    const olderAccount = {
+      ...accountFixture(),
+      assessmentReportVersion: undefined,
+      displayEmissions: undefined,
+      dataStalenessSettings: undefined
+    } as unknown as IdbAccount;
+
+    const unitsForm = service.getUnitsForm(olderAccount);
+    const goalsForm = service.getSustainabilityQuestionsForm(olderAccount);
+    const stalenessForm = service.getStalenessForm(olderAccount.dataStalenessSettings);
+
+    expect(unitsForm.controls['assessmentReportVersion']).toBeUndefined();
+    expect(unitsForm.controls['displayEmissions']).toBeUndefined();
+    expect(goalsForm.controls['assessmentReportVersion'].value).toBe('AR6');
+    expect(goalsForm.controls['displayEmissions'].value).toBe(false);
+    expect(stalenessForm.controls['enabled'].value).toBe(true);
+    expect(stalenessForm.controls['thresholdMonths'].value).toBe(DEFAULT_DATA_STALENESS_MONTHS);
+  });
+
+  it('sets unit presets and identifies custom unit selections', () => {
+    const form = service.getUnitsForm(accountFixture());
+
+    form.controls['unitsOfMeasure'].setValue('Metric');
+    service.setUnitsOfMeasure(form);
+
+    expect(form.controls['energyUnit'].value).toBe('MMBtu');
+    expect(form.controls['volumeLiquidUnit'].value).toBe('m3');
+    expect(form.controls['volumeGasUnit'].value).toBe('m3');
+    expect(form.controls['massUnit'].value).toBe('kg');
+
+    form.controls['energyUnit'].setValue('kWh');
+    service.checkCustom(form);
+
+    expect(form.controls['unitsOfMeasure'].value).toBe('Custom');
+  });
+
+  it('writes sustainability, financial, and staleness fields back to account copies', () => {
+    const account = accountFixture();
+    const goalsForm = service.getSustainabilityQuestionsForm(account);
+    const financialForm = service.getFiscalYearForm(account);
+    const stalenessForm = service.getStalenessForm(account.dataStalenessSettings);
+
+    goalsForm.patchValue({
+      displayEmissions: true,
+      assessmentReportVersion: 'AR5',
+      isBetterPlantsPartner: true,
+      waterReductionGoal: true,
+      waterReductionPercent: 12
+    });
+    financialForm.patchValue({
+      fiscalYear: 'nonCalendarYear',
+      fiscalYearMonth: 6,
+      fiscalYearCalendarEnd: false
+    });
+    stalenessForm.patchValue({
+      enabled: false,
+      thresholdMonths: 18
+    });
+
+    const updated = service.updateAccountFromStalenessForm(
+      stalenessForm,
+      service.updateAccountFromFiscalForm(
+        financialForm,
+        service.updateAccountFromSustainabilityQuestionsForm(goalsForm, { ...account })
+      )
+    );
+
+    expect(updated.displayEmissions).toBe(true);
+    expect(updated.assessmentReportVersion).toBe('AR5');
+    expect(updated.isBetterPlantsPartner).toBe(true);
+    expect(updated.sustainabilityQuestions.waterReductionGoal).toBe(true);
+    expect(updated.sustainabilityQuestions.waterReductionPercent).toBe(12);
+    expect(updated.fiscalYear).toBe('nonCalendarYear');
+    expect(updated.fiscalYearMonth).toBe(6);
+    expect(updated.fiscalYearCalendarEnd).toBe(false);
+    expect(updated.dataStalenessSettings).toEqual({ enabled: false, thresholdMonths: 18 });
+  });
+});
+
+function accountFixture(): IdbAccount {
+  return {
+    guid: 'account-a',
+    name: 'Account A',
+    country: 'US',
+    city: 'Knoxville',
+    state: 'TN',
+    zip: '37932',
+    address: '1 Main St',
+    naics1: '31',
+    naics2: undefined,
+    naics3: undefined,
+    size: 0,
+    notes: '',
+    color: undefined,
+    contactName: '',
+    contactEmail: '',
+    contactPhone: '',
+    unitsOfMeasure: 'Imperial',
+    energyUnit: 'MMBtu',
+    electricityUnit: 'kWh',
+    volumeLiquidUnit: 'gal',
+    volumeGasUnit: 'SCF',
+    massUnit: 'lb',
+    energyIsSource: true,
+    fiscalYear: 'calendarYear',
+    fiscalYearMonth: 0,
+    fiscalYearCalendarEnd: true,
+    archiveOption: 'skip',
+    assessmentReportVersion: 'AR6',
+    displayEmissions: false,
+    sustainabilityQuestions: {
+      energyReductionGoal: true,
+      energyReductionPercent: 25,
+      energyReductionBaselineYear: 2020,
+      energyReductionTargetYear: 2030,
+      energyIsAbsolute: false,
+      greenhouseReductionGoal: false,
+      greenhouseReductionPercent: 0,
+      greenhouseReductionBaselineYear: 2020,
+      greenhouseReductionTargetYear: 2030,
+      greenhouseIsAbsolute: true,
+      waterReductionGoal: false,
+      waterReductionPercent: 0,
+      waterReductionBaselineYear: 2020,
+      waterReductionTargetYear: 2030,
+      waterIsAbsolute: false
+    },
+    dataStalenessSettings: {
+      enabled: true,
+      thresholdMonths: DEFAULT_DATA_STALENESS_MONTHS
+    }
+  } as IdbAccount;
+}

--- a/src/app/shared/settings-forms/account-settings-form.service.ts
+++ b/src/app/shared/settings-forms/account-settings-form.service.ts
@@ -1,0 +1,248 @@
+import { Injectable } from '@angular/core';
+import { FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
+import { DEFAULT_DATA_STALENESS_MONTHS, DataStalenessMonths } from '@domain/calculations/status-check-calculations/statusCheckModels';
+import { AccountAndFacility, DataStalenessSettings } from '@data/models/idbModels/accountAndFacility';
+import { AssessmentReportVersion, IdbAccount } from '@data/models/idbModels/account';
+import { IdbFacility } from '@data/models/idbModels/facility';
+import { SustainabilityQuestions } from '@data/models/sustainabilityQuestions';
+import { EnergyUnitOptions, MassUnitOptions, UnitOption, VolumeGasOptions, VolumeLiquidOptions } from '@shared/unitOptions';
+
+export type AccountSettingsForm = FormGroup<Record<string, FormControl<unknown>>>;
+
+@Injectable({ providedIn: 'root' })
+export class AccountSettingsFormService {
+  constructor(private readonly formBuilder: FormBuilder) { }
+
+  getGeneralInformationForm(generalInformation: AccountAndFacility): FormGroup {
+    return this.formBuilder.group({
+      name: [generalInformation.name, [Validators.required, Validators.maxLength(42)]],
+      country: [generalInformation.country],
+      city: [generalInformation.city],
+      state: [generalInformation.state],
+      zip: [generalInformation.zip],
+      address: [generalInformation.address],
+      naics1: [generalInformation.naics1],
+      naics2: [generalInformation.naics2],
+      naics3: [generalInformation.naics3],
+      size: [generalInformation.size],
+      notes: [generalInformation.notes],
+      color: [generalInformation.color],
+      contactName: [generalInformation.contactName],
+      contactEmail: [generalInformation.contactEmail],
+      contactPhone: [generalInformation.contactPhone]
+    });
+  }
+
+  updateAccountFromGeneralInformationForm(form: FormGroup, account: IdbAccount): IdbAccount {
+    account.name = String(form.controls['name'].value || '').trim();
+    account.country = form.controls['country'].value;
+    account.city = form.controls['city'].value;
+    account.state = form.controls['state'].value;
+    account.zip = form.controls['zip'].value;
+    account.address = form.controls['address'].value;
+    account.naics1 = form.controls['naics1'].value;
+    account.naics2 = form.controls['naics2'].value;
+    account.naics3 = form.controls['naics3'].value;
+    account.notes = form.controls['notes'].value;
+    account.color = form.controls['color'].value;
+    account.contactName = form.controls['contactName'].value;
+    account.contactEmail = form.controls['contactEmail'].value;
+    account.contactPhone = form.controls['contactPhone'].value;
+    return account;
+  }
+
+  getUnitsForm(account: IdbAccount): FormGroup {
+    return this.formBuilder.group({
+      unitsOfMeasure: [account.unitsOfMeasure, [Validators.required]],
+      energyUnit: [account.energyUnit, [Validators.required]],
+      massUnit: [account.massUnit, [Validators.required]],
+      volumeLiquidUnit: [account.volumeLiquidUnit, [Validators.required]],
+      volumeGasUnit: [account.volumeGasUnit, [Validators.required]],
+      energyIsSource: [account.energyIsSource],
+      eGridSubregion: [account.eGridSubregion],
+      electricityUnit: [account.electricityUnit]
+    });
+  }
+
+  updateAccountFromUnitsForm(form: FormGroup, account: IdbAccount): IdbAccount {
+    account.unitsOfMeasure = form.controls['unitsOfMeasure'].value;
+    account.energyUnit = form.controls['energyUnit'].value;
+    account.massUnit = form.controls['massUnit'].value;
+    account.volumeLiquidUnit = form.controls['volumeLiquidUnit'].value;
+    account.volumeGasUnit = form.controls['volumeGasUnit'].value;
+    account.energyIsSource = form.controls['energyIsSource'].value;
+    account.eGridSubregion = form.controls['eGridSubregion'].value;
+    account.electricityUnit = form.controls['electricityUnit'].value;
+    return account;
+  }
+
+  getFiscalYearForm(account: IdbAccount): FormGroup {
+    return this.formBuilder.group({
+      fiscalYear: [account.fiscalYear || 'calendarYear'],
+      fiscalYearMonth: [account.fiscalYearMonth ?? 0],
+      fiscalYearCalendarEnd: [account.fiscalYearCalendarEnd ?? true]
+    });
+  }
+
+  updateAccountFromFiscalForm(form: FormGroup, account: IdbAccount): IdbAccount {
+    account.fiscalYear = form.controls['fiscalYear'].value;
+    account.fiscalYearMonth = form.controls['fiscalYearMonth'].value;
+    account.fiscalYearCalendarEnd = form.controls['fiscalYearCalendarEnd'].value;
+    return account;
+  }
+
+  updateFacilityFromFiscalForm(form: FormGroup, facility: IdbFacility): IdbFacility {
+    facility.fiscalYear = form.controls['fiscalYear'].value;
+    facility.fiscalYearMonth = form.controls['fiscalYearMonth'].value;
+    facility.fiscalYearCalendarEnd = form.controls['fiscalYearCalendarEnd'].value;
+    return facility;
+  }
+
+  getSustainabilityQuestionsForm(account: IdbAccount): FormGroup {
+    const questions = this.normalizeSustainabilityQuestions(account.sustainabilityQuestions);
+    return this.formBuilder.group({
+      displayEmissions: [!!account.displayEmissions],
+      assessmentReportVersion: [account.assessmentReportVersion || 'AR6'],
+      isBetterPlantsPartner: [!!account.isBetterPlantsPartner],
+      energyReductionGoal: [questions.energyReductionGoal],
+      energyReductionPercent: [questions.energyReductionPercent],
+      energyReductionBaselineYear: [questions.energyReductionBaselineYear],
+      energyReductionTargetYear: [questions.energyReductionTargetYear],
+      energyIsAbsolute: [questions.energyIsAbsolute],
+      greenhouseReductionGoal: [questions.greenhouseReductionGoal],
+      greenhouseReductionPercent: [questions.greenhouseReductionPercent],
+      greenhouseReductionBaselineYear: [questions.greenhouseReductionBaselineYear],
+      greenhouseReductionTargetYear: [questions.greenhouseReductionTargetYear],
+      greenhouseIsAbsolute: [questions.greenhouseIsAbsolute],
+      waterReductionGoal: [questions.waterReductionGoal],
+      waterReductionPercent: [questions.waterReductionPercent],
+      waterReductionBaselineYear: [questions.waterReductionBaselineYear],
+      waterReductionTargetYear: [questions.waterReductionTargetYear],
+      waterIsAbsolute: [questions.waterIsAbsolute]
+    });
+  }
+
+  updateAccountFromSustainabilityQuestionsForm(form: FormGroup, account: IdbAccount): IdbAccount {
+    account.displayEmissions = !!form.controls['displayEmissions'].value;
+    account.assessmentReportVersion = (form.controls['assessmentReportVersion'].value || 'AR6') as AssessmentReportVersion;
+    account.sustainabilityQuestions = {
+      energyReductionGoal: !!form.controls['energyReductionGoal'].value,
+      energyReductionPercent: Number(form.controls['energyReductionPercent'].value || 0),
+      energyReductionBaselineYear: Number(form.controls['energyReductionBaselineYear'].value || this.currentYear()),
+      energyReductionTargetYear: Number(form.controls['energyReductionTargetYear'].value || this.currentYear() + 10),
+      energyIsAbsolute: !!form.controls['energyIsAbsolute'].value,
+      greenhouseReductionGoal: !!form.controls['greenhouseReductionGoal'].value,
+      greenhouseReductionPercent: Number(form.controls['greenhouseReductionPercent'].value || 0),
+      greenhouseReductionBaselineYear: Number(form.controls['greenhouseReductionBaselineYear'].value || this.currentYear()),
+      greenhouseReductionTargetYear: Number(form.controls['greenhouseReductionTargetYear'].value || this.currentYear() + 10),
+      greenhouseIsAbsolute: !!form.controls['greenhouseIsAbsolute'].value,
+      waterReductionGoal: !!form.controls['waterReductionGoal'].value,
+      waterReductionPercent: Number(form.controls['waterReductionPercent'].value || 0),
+      waterReductionBaselineYear: Number(form.controls['waterReductionBaselineYear'].value || this.currentYear()),
+      waterReductionTargetYear: Number(form.controls['waterReductionTargetYear'].value || this.currentYear() + 10),
+      waterIsAbsolute: !!form.controls['waterIsAbsolute'].value
+    };
+    account.isBetterPlantsPartner = !!form.controls['isBetterPlantsPartner'].value;
+    return account;
+  }
+
+  getStalenessForm(settings: DataStalenessSettings | undefined): FormGroup {
+    const current = this.normalizeDataStalenessSettings(settings);
+    return this.formBuilder.group({
+      enabled: [current.enabled],
+      thresholdMonths: [current.thresholdMonths]
+    });
+  }
+
+  updateAccountFromStalenessForm(form: FormGroup, account: IdbAccount): IdbAccount {
+    account.dataStalenessSettings = {
+      enabled: !!form.controls['enabled'].value,
+      thresholdMonths: form.controls['thresholdMonths'].value as DataStalenessMonths
+    };
+    return account;
+  }
+
+  setUnitsOfMeasure(form: FormGroup): FormGroup {
+    if (form.controls['unitsOfMeasure'].value === 'Imperial') {
+      form.controls['energyUnit'].setValue('kWh');
+      form.controls['volumeLiquidUnit'].setValue('ft3');
+      form.controls['volumeGasUnit'].setValue('SCF');
+      form.controls['massUnit'].setValue('lb');
+    } else if (form.controls['unitsOfMeasure'].value === 'Metric') {
+      form.controls['energyUnit'].setValue('MMBtu');
+      form.controls['volumeLiquidUnit'].setValue('m3');
+      form.controls['volumeGasUnit'].setValue('m3');
+      form.controls['massUnit'].setValue('kg');
+    }
+    return form;
+  }
+
+  checkCustom(form: FormGroup): FormGroup {
+    const selectedEnergyOption = EnergyUnitOptions.find(option => option.value === form.controls['energyUnit'].value);
+    const selectedVolumeGasOption = VolumeGasOptions.find(option => option.value === form.controls['volumeGasUnit'].value);
+    const selectedVolumeLiquidOption = VolumeLiquidOptions.find(option => option.value === form.controls['volumeLiquidUnit'].value);
+    const selectedMassOption = MassUnitOptions.find(option => option.value === form.controls['massUnit'].value);
+    if (selectedEnergyOption && selectedVolumeGasOption && selectedVolumeLiquidOption && selectedMassOption) {
+      this.patchUnitsOfMeasure(form, selectedEnergyOption, selectedVolumeLiquidOption, selectedVolumeGasOption, selectedMassOption);
+    }
+    return form;
+  }
+
+  normalizeDataStalenessSettings(settings: DataStalenessSettings | undefined): DataStalenessSettings {
+    return {
+      enabled: settings?.enabled ?? true,
+      thresholdMonths: settings?.thresholdMonths ?? DEFAULT_DATA_STALENESS_MONTHS
+    };
+  }
+
+  normalizeSustainabilityQuestions(questions: SustainabilityQuestions | undefined): SustainabilityQuestions {
+    const currentYear = this.currentYear();
+    return {
+      energyReductionGoal: questions?.energyReductionGoal ?? true,
+      energyReductionPercent: questions?.energyReductionPercent ?? 25,
+      energyReductionBaselineYear: questions?.energyReductionBaselineYear ?? currentYear,
+      energyReductionTargetYear: questions?.energyReductionTargetYear ?? Math.min(currentYear + 10, 2050),
+      energyIsAbsolute: questions?.energyIsAbsolute ?? false,
+      greenhouseReductionGoal: questions?.greenhouseReductionGoal ?? false,
+      greenhouseReductionPercent: questions?.greenhouseReductionPercent ?? 0,
+      greenhouseReductionBaselineYear: questions?.greenhouseReductionBaselineYear ?? currentYear,
+      greenhouseReductionTargetYear: questions?.greenhouseReductionTargetYear ?? Math.min(currentYear + 10, 2050),
+      greenhouseIsAbsolute: questions?.greenhouseIsAbsolute ?? true,
+      waterReductionGoal: questions?.waterReductionGoal ?? false,
+      waterReductionPercent: questions?.waterReductionPercent ?? 0,
+      waterReductionBaselineYear: questions?.waterReductionBaselineYear ?? currentYear,
+      waterReductionTargetYear: questions?.waterReductionTargetYear ?? Math.min(currentYear + 10, 2050),
+      waterIsAbsolute: questions?.waterIsAbsolute ?? false
+    };
+  }
+
+  private patchUnitsOfMeasure(
+    form: FormGroup,
+    selectedEnergyOption: UnitOption,
+    selectedVolumeLiquidOption: UnitOption,
+    selectedVolumeGasOption: UnitOption,
+    selectedMassOption: UnitOption
+  ): void {
+    if (
+      selectedEnergyOption.unitsOfMeasure === 'Metric'
+      && selectedVolumeLiquidOption.unitsOfMeasure === 'Metric'
+      && selectedVolumeGasOption.unitsOfMeasure === 'Metric'
+      && selectedMassOption.unitsOfMeasure === 'Metric'
+    ) {
+      form.controls['unitsOfMeasure'].patchValue('Metric');
+    } else if (
+      selectedEnergyOption.unitsOfMeasure === 'Imperial'
+      && selectedVolumeLiquidOption.unitsOfMeasure === 'Imperial'
+      && selectedVolumeGasOption.unitsOfMeasure === 'Imperial'
+      && selectedMassOption.unitsOfMeasure === 'Imperial'
+    ) {
+      form.controls['unitsOfMeasure'].patchValue('Imperial');
+    } else {
+      form.controls['unitsOfMeasure'].patchValue('Custom');
+    }
+  }
+
+  private currentYear(): number {
+    return new Date().getFullYear();
+  }
+}

--- a/src/app/v1/account/home/account-home.component.css
+++ b/src/app/v1/account/home/account-home.component.css
@@ -5,22 +5,6 @@
   padding: clamp(1rem, 3vw, 1.5rem);
 }
 
-.v1-home h1,
-.v1-home p {
-  margin: 0;
-}
-
-.v1-home h1 {
-  color: var(--v1-text);
-  font-size: 1.8rem;
-  line-height: 1.15;
-}
-
-.v1-home__summary {
-  max-width: 44rem;
-  color: var(--v1-muted);
-}
-
 .v1-home__metrics {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));

--- a/src/app/v1/account/home/account-home.component.html
+++ b/src/app/v1/account/home/account-home.component.html
@@ -2,12 +2,14 @@
   @if (navigation.account(); as account) {
     @let content = navigation.panelContent();
 
-    <p class="v1-eyebrow">Account Home</p>
-    <h1 id="v1-account-home-title">{{ account.name }}</h1>
-    <p class="v1-home__summary">
-      Account workspace shell is ready. The migrated Home page starts here while detailed setup, data, analysis, and
-      report workflows remain in current VERIFI.
-    </p>
+    <header class="v1-section-header">
+      <p class="v1-eyebrow">Account Home</p>
+      <h1 id="v1-account-home-title">{{ account.name }}</h1>
+      <p class="v1-section-header__summary">
+        Account workspace shell is ready. The migrated Home page starts here while detailed setup, data, analysis, and
+        report workflows remain in current VERIFI.
+      </p>
+    </header>
 
     <div class="v1-home__metrics" aria-label="Account summary">
       <article>

--- a/src/app/v1/account/settings/account-settings-detail.base.ts
+++ b/src/app/v1/account/settings/account-settings-detail.base.ts
@@ -1,0 +1,143 @@
+import { Directive, OnDestroy, inject } from '@angular/core';
+import { AbstractControl, FormGroup } from '@angular/forms';
+import { ApplicationLifecycleService } from '@app/application-lifecycle/application-lifecycle.service';
+import { AccountCommandHandler } from '@data/account-workspace/handlers/account-command-handler.service';
+import { AccountWorkspaceStore } from '@data/account-workspace/account-workspace.store';
+import { WorkspaceCommandBoundary } from '@data/account-workspace/workspace-command-boundary.service';
+import { IdbAccount } from '@data/models/idbModels/account';
+
+export type AccountSettingsDetail = 'profile' | 'units' | 'goals' | 'financial' | 'staleness' | 'backup';
+export type AccountSettingsSaveState = 'idle' | 'saving' | 'saved' | 'error';
+
+export const ACCOUNT_SETTINGS_DETAILS: ReadonlyArray<AccountSettingsDetail> = [
+  'profile',
+  'units',
+  'goals',
+  'financial',
+  'staleness',
+  'backup'
+];
+
+const SAVE_DEBOUNCE_MS = 600;
+
+@Directive()
+export abstract class AccountSettingsDetailBase implements OnDestroy {
+  protected readonly workspace = inject(AccountWorkspaceStore);
+  protected readonly commandBoundary = inject(WorkspaceCommandBoundary);
+  protected readonly accountHandler = inject(AccountCommandHandler);
+  protected readonly lifecycle = inject(ApplicationLifecycleService);
+
+  readonly account = this.workspace.account;
+  readonly canWrite = this.workspace.canWrite;
+
+  saveState: AccountSettingsSaveState = 'idle';
+  saveMessage = '';
+  saveError = '';
+
+  protected skipNextWorkspaceRefresh = false;
+  private debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  private idleTimer: ReturnType<typeof setTimeout> | undefined;
+
+  ngOnDestroy(): void {
+    this.clearDebounce();
+    this.clearIdleTimer();
+  }
+
+  protected scheduleSave(save: () => Promise<void>): void {
+    this.clearDebounce();
+    this.debounceTimer = setTimeout(() => {
+      void save();
+    }, SAVE_DEBOUNCE_MS);
+  }
+
+  protected flushSave(save: () => Promise<void>): void {
+    if (!this.debounceTimer) {
+      return;
+    }
+    this.clearDebounce();
+    void save();
+  }
+
+  protected async saveAccount(label: string, buildAccount: (account: IdbAccount) => IdbAccount): Promise<void> {
+    const account = this.account();
+    if (!account || !this.canWrite()) {
+      return;
+    }
+    const updatedAccount = buildAccount(structuredClone(account));
+    await this.runSave(label, async () => {
+      await this.commandBoundary.execute(
+        {
+          entityKind: 'account',
+          changeKind: 'update',
+          entityGuid: updatedAccount.guid,
+          label,
+          publication: { mode: 'patch', buildPatch: value => ({ account: value }) }
+        },
+        () => this.accountHandler.update({ ...updatedAccount }, updatedAccount.guid)
+      );
+      await this.lifecycle.refreshAccountCatalog();
+    });
+  }
+
+  protected async runSave(label: string, save: () => Promise<void>): Promise<void> {
+    this.clearIdleTimer();
+    this.saveState = 'saving';
+    this.saveError = '';
+    this.saveMessage = label;
+    try {
+      this.skipNextWorkspaceRefresh = true;
+      await save();
+      this.saveMessage = 'Saved';
+      this.saveState = 'saved';
+      this.idleTimer = setTimeout(() => {
+        this.saveState = 'idle';
+      }, 2500);
+    } catch (error) {
+      this.skipNextWorkspaceRefresh = false;
+      this.saveMessage = '';
+      this.saveError = 'Changes could not be saved. Please try again.';
+      this.saveState = 'error';
+      console.warn('v1 account settings save failed.', error);
+    }
+  }
+
+  protected setFormEnabled(form: FormGroup | undefined, enabled: boolean): void {
+    if (!form) {
+      return;
+    }
+    if (enabled && form.disabled) {
+      form.enable({ emitEvent: false });
+    } else if (!enabled && form.enabled) {
+      form.disable({ emitEvent: false });
+    }
+  }
+
+  protected setControlEnabled(control: AbstractControl | undefined, enabled: boolean): void {
+    if (!control) {
+      return;
+    }
+    if (enabled && control.disabled) {
+      control.enable({ emitEvent: false });
+    } else if (!enabled && control.enabled) {
+      control.disable({ emitEvent: false });
+    }
+  }
+
+  protected setControlsEnabled(form: FormGroup | undefined, controlNames: string[], enabled: boolean): void {
+    controlNames.forEach(controlName => this.setControlEnabled(form?.controls[controlName], enabled));
+  }
+
+  private clearDebounce(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = undefined;
+    }
+  }
+
+  private clearIdleTimer(): void {
+    if (this.idleTimer) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = undefined;
+    }
+  }
+}

--- a/src/app/v1/account/settings/account-settings-detail.base.ts
+++ b/src/app/v1/account/settings/account-settings-detail.base.ts
@@ -6,7 +6,7 @@ import { AccountWorkspaceStore } from '@data/account-workspace/account-workspace
 import { WorkspaceCommandBoundary } from '@data/account-workspace/workspace-command-boundary.service';
 import { IdbAccount } from '@data/models/idbModels/account';
 
-export type AccountSettingsDetail = 'profile' | 'units' | 'goals' | 'financial' | 'staleness' | 'backup';
+export type AccountSettingsDetail = 'profile' | 'units' | 'goals' | 'financial' | 'staleness' | 'backup' | 'delete';
 export type AccountSettingsSaveState = 'idle' | 'saving' | 'saved' | 'error';
 
 export const ACCOUNT_SETTINGS_DETAILS: ReadonlyArray<AccountSettingsDetail> = [
@@ -15,7 +15,8 @@ export const ACCOUNT_SETTINGS_DETAILS: ReadonlyArray<AccountSettingsDetail> = [
   'goals',
   'financial',
   'staleness',
-  'backup'
+  'backup',
+  'delete'
 ];
 
 const SAVE_DEBOUNCE_MS = 600;

--- a/src/app/v1/account/settings/account-settings.component.css
+++ b/src/app/v1/account/settings/account-settings.component.css
@@ -97,6 +97,14 @@
   color: var(--v1-danger);
 }
 
+.v1-settings-panel--danger {
+  border-left-color: var(--v1-danger);
+}
+
+.v1-settings-panel--danger .v1-settings-panel__heading p {
+  color: var(--v1-danger);
+}
+
 .v1-settings-grid {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
@@ -230,6 +238,15 @@
 
 .v1-settings-card h3 {
   font-size: 1rem;
+}
+
+.v1-settings-card--danger {
+  border-color: color-mix(in srgb, var(--v1-danger) 45%, var(--v1-border));
+  background: color-mix(in srgb, var(--v1-danger) 7%, var(--v1-content-block));
+}
+
+.v1-settings-card--danger > .fa {
+  color: var(--v1-danger);
 }
 
 .v1-settings-actions {

--- a/src/app/v1/account/settings/account-settings.component.css
+++ b/src/app/v1/account/settings/account-settings.component.css
@@ -1,0 +1,258 @@
+:host {
+  display: block;
+  min-width: 0;
+}
+
+.v1-account-settings {
+  display: grid;
+  gap: 1rem;
+  /* max-width: 70rem; */
+  padding: clamp(1rem, 3vw, 1.5rem);
+}
+
+.v1-account-settings__tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .35rem;
+  padding: .35rem;
+  border: 1px solid var(--v1-border);
+  border-radius: var(--v1-radius);
+  background: var(--v1-panel);
+}
+
+.v1-account-settings__tabs a {
+  min-height: var(--v1-control-height-sm);
+  padding: .35rem .7rem;
+  border: 1px solid transparent;
+  border-radius: var(--v1-radius-sm);
+  color: var(--v1-muted);
+  font-weight: 900;
+  text-decoration: none;
+}
+
+.v1-account-settings__tabs a.active,
+.v1-account-settings__tabs a:hover,
+.v1-account-settings__tabs a:focus-visible {
+  border-color: color-mix(in srgb, var(--v1-account) 32%, var(--v1-border));
+  background: var(--v1-surface);
+  color: var(--v1-account);
+}
+
+.v1-settings-panel {
+  display: grid;
+  gap: 1rem;
+  min-width: 0;
+  padding: 1rem;
+  border: 1px solid var(--v1-border);
+  border-left: 3px solid var(--v1-account);
+  border-radius: var(--v1-radius);
+  background: var(--v1-surface);
+}
+
+.v1-settings-panel__heading {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin: -1rem -1rem 0;
+  padding: .8rem 1rem;
+  border-bottom: 1px solid var(--v1-border);
+  border-radius: 5px 5px 0 0;
+  background: var(--v1-surface-muted);
+}
+
+.v1-settings-panel__heading h2,
+.v1-settings-panel__heading p {
+  margin: 0;
+}
+
+.v1-settings-panel__heading h2 {
+  font-size: 1.2rem;
+}
+
+.v1-settings-panel__heading p,
+.v1-settings-panel__status,
+.v1-settings-panel label > span,
+.v1-settings-panel legend,
+.v1-settings-panel small {
+  color: var(--v1-muted);
+  font-size: .78rem;
+  font-weight: 900;
+}
+
+.v1-settings-panel__heading p {
+  color: var(--v1-primary);
+  text-transform: uppercase;
+}
+
+.v1-settings-panel__status {
+  display: inline-flex;
+  gap: .35rem;
+  align-items: center;
+  min-height: var(--v1-control-height-sm);
+  color: var(--v1-success);
+}
+
+.v1-settings-panel__status--error {
+  color: var(--v1-danger);
+}
+
+.v1-settings-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: .85rem;
+}
+
+.v1-settings-grid--2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.v1-settings-grid--3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.v1-settings-grid--4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.v1-settings-panel label {
+  display: grid;
+  gap: .35rem;
+  min-width: 0;
+}
+
+.v1-settings-panel input,
+.v1-settings-panel select,
+.v1-settings-panel textarea {
+  width: 100%;
+  min-height: var(--v1-control-height-sm);
+  padding: .32rem .55rem;
+  border: 1px solid var(--v1-control-border);
+  border-radius: var(--v1-radius-sm);
+  background: var(--v1-control-surface);
+  color: var(--v1-text);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, var(--v1-surface) 70%, transparent);
+}
+
+.v1-settings-panel textarea {
+  min-height: 6rem;
+  resize: vertical;
+}
+
+.v1-settings-panel input:disabled,
+.v1-settings-panel select:disabled,
+.v1-settings-panel textarea:disabled,
+.v1-settings-panel button:disabled {
+  cursor: not-allowed;
+  opacity: var(--v1-disabled-opacity);
+}
+
+.v1-settings-panel em {
+  color: var(--v1-danger);
+  font-size: .78rem;
+  font-style: normal;
+  font-weight: 900;
+}
+
+.v1-settings-panel fieldset {
+  display: grid;
+  gap: .45rem;
+  min-width: 0;
+  margin: 0;
+  padding: .8rem;
+  border: 1px solid var(--v1-border);
+  border-radius: var(--v1-radius);
+}
+
+.v1-settings-panel legend {
+  float: none;
+  width: auto;
+  margin: 0;
+  padding: 0 .25rem;
+}
+
+.v1-settings-choice {
+  display: flex !important;
+  gap: .45rem !important;
+  align-items: center;
+  margin: 0;
+}
+
+.v1-settings-choice input {
+  width: 1rem;
+  min-height: 1rem;
+  padding: 0;
+  background: var(--v1-control-surface);
+  box-shadow: none;
+}
+
+.v1-settings-choice--block,
+.v1-settings-card {
+  padding: .8rem;
+  border: 1px solid color-mix(in srgb, var(--v1-border) 86%, var(--v1-text));
+  border-radius: var(--v1-radius);
+  background: var(--v1-content-block);
+}
+
+.v1-settings-goal,
+.v1-settings-card {
+  display: grid;
+  gap: .75rem;
+}
+
+.v1-settings-panel .input-group {
+  width: 100%;
+}
+
+.v1-settings-panel .input-group > .form-control {
+  width: 1%;
+  min-width: 0;
+  flex: 1 1 auto;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.v1-settings-panel .input-group-text {
+  min-height: var(--v1-control-height-sm);
+  padding: .32rem .6rem;
+  border-left: 0;
+  border-color: var(--v1-control-border);
+  border-radius: 0 var(--v1-radius-sm) var(--v1-radius-sm) 0;
+  background: var(--v1-control-addon-surface);
+  color: var(--v1-muted);
+  font-weight: 900;
+}
+
+.v1-settings-card h3,
+.v1-settings-card p {
+  margin: 0;
+}
+
+.v1-settings-card h3 {
+  font-size: 1rem;
+}
+
+.v1-settings-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .5rem;
+}
+
+@media (max-width: 980px) {
+  .v1-settings-grid--3,
+  .v1-settings-grid--4 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 700px) {
+  .v1-settings-panel__heading {
+    display: grid;
+  }
+
+  .v1-settings-grid--2,
+  .v1-settings-grid--3,
+  .v1-settings-grid--4 {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/src/app/v1/account/settings/account-settings.component.html
+++ b/src/app/v1/account/settings/account-settings.component.html
@@ -1,0 +1,27 @@
+@let currentAccount = account();
+
+<section class="v1-account-settings" aria-labelledby="v1-account-settings-title">
+  <header class="v1-section-header">
+    <div>
+      <p class="v1-eyebrow">Account settings</p>
+      <h1 id="v1-account-settings-title">{{ currentAccount?.name || 'Account settings' }}</h1>
+    </div>
+  </header>
+
+  @if (!currentAccount) {
+    <article class="v1-empty-state" role="status">
+      <span class="fa fa-building-circle-exclamation" aria-hidden="true"></span>
+      <h2>No account loaded</h2>
+      <p>Open an account workspace to edit account settings.</p>
+    </article>
+  } @else {
+    @if (!canWrite()) {
+      <div class="v1-alert v1-alert--warning" role="status">
+        <span class="fa fa-lock" aria-hidden="true"></span>
+        <span>Settings are unavailable while the workspace is loading or switching.</span>
+      </div>
+    }
+
+    <router-outlet></router-outlet>
+  }
+</section>

--- a/src/app/v1/account/settings/account-settings.component.spec.ts
+++ b/src/app/v1/account/settings/account-settings.component.spec.ts
@@ -1,0 +1,402 @@
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
+import { vi } from 'vitest';
+import { ApplicationLifecycleService } from '@app/application-lifecycle/application-lifecycle.service';
+import { AccountCommandHandler } from '@data/account-workspace/handlers/account-command-handler.service';
+import { FacilityCommandHandler } from '@data/account-workspace/handlers/facility-command-handler.service';
+import { AccountWorkspaceStore } from '@data/account-workspace/account-workspace.store';
+import { WorkspaceCommandBoundary } from '@data/account-workspace/workspace-command-boundary.service';
+import { BackupExportCoordinator } from '@data/backup/backup-export-coordinator.service';
+import { BackupImportCoordinator } from '@data/backup/backup-import-coordinator.service';
+import { BackupFile } from '@data/models/backup-file';
+import { IdbAccount } from '@data/models/idbModels/account';
+import { IdbFacility } from '@data/models/idbModels/facility';
+import { AutomaticBackupsService } from '@platform/electron/automatic-backups.service';
+import { ElectronBackupFileGateway } from '@platform/electron/electron-backup-file.gateway';
+import { EGridService } from '@shared/helper-services/e-grid.service';
+import { AccountSettingsFormService } from '@shared/settings-forms/account-settings-form.service';
+import { AccountSettingsComponent } from './account-settings.component';
+import { AccountSettingsModule } from './account-settings.module';
+import { AccountSettingsBackupComponent } from './backup/account-settings-backup.component';
+import { AccountSettingsFinancialComponent } from './financial/account-settings-financial.component';
+import { AccountSettingsGoalsComponent } from './goals/account-settings-goals.component';
+import { AccountSettingsProfileComponent } from './profile/account-settings-profile.component';
+import { AccountSettingsUnitsComponent } from './units/account-settings-units.component';
+import { WorkspaceNavigationService } from '../../shell/workspace-navigation.service';
+import { V1Routes } from '../../v1.routes';
+
+describe('Account settings routed components', () => {
+  let account: ReturnType<typeof signal<IdbAccount | undefined>>;
+  let facilities: ReturnType<typeof signal<IdbFacility[]>>;
+  let canWrite: ReturnType<typeof signal<boolean>>;
+  let commandBoundary: { execute: ReturnType<typeof vi.fn> };
+  let accountHandler: { update: ReturnType<typeof vi.fn> };
+  let facilityHandler: { update: ReturnType<typeof vi.fn> };
+  let lifecycle: { refreshAccountCatalog: ReturnType<typeof vi.fn> };
+  let backupExportCoordinator: {
+    exportActiveAccount: ReturnType<typeof vi.fn>;
+    buildActiveAccountBackup: ReturnType<typeof vi.fn>;
+  };
+  let backupGateway: {
+    isAvailable: boolean;
+    chooseSavePath: ReturnType<typeof vi.fn>;
+    write: ReturnType<typeof vi.fn>;
+  };
+  let automaticBackups: {
+    status: BehaviorSubject<string>;
+    saving: BehaviorSubject<boolean>;
+    addOrUpdateFile: ReturnType<typeof vi.fn>;
+    inspectCurrentAccountFile: ReturnType<typeof vi.fn>;
+  };
+  let navigation: { openAccount: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    account = signal(accountFixture());
+    facilities = signal([facilityFixture('facility-a'), facilityFixture('facility-b')]);
+    canWrite = signal(true);
+    commandBoundary = {
+      execute: vi.fn(async (_metadata, operation: () => Promise<unknown>) => ({ value: await operation(), change: {} }))
+    };
+    accountHandler = {
+      update: vi.fn(async updated => updated)
+    };
+    facilityHandler = {
+      update: vi.fn(async updated => updated)
+    };
+    lifecycle = {
+      refreshAccountCatalog: vi.fn(async () => undefined)
+    };
+    backupExportCoordinator = {
+      exportActiveAccount: vi.fn(async () => backupFile()),
+      buildActiveAccountBackup: vi.fn(() => backupFile())
+    };
+    backupGateway = {
+      isAvailable: false,
+      chooseSavePath: vi.fn(async () => '/tmp/account-backup.json'),
+      write: vi.fn(async () => undefined)
+    };
+    automaticBackups = {
+      status: new BehaviorSubject('disabled'),
+      saving: new BehaviorSubject(false),
+      addOrUpdateFile: vi.fn(async () => undefined),
+      inspectCurrentAccountFile: vi.fn(async () => undefined)
+    };
+    navigation = {
+      openAccount: vi.fn(async () => undefined)
+    };
+
+    TestBed.configureTestingModule({
+      imports: [
+        RouterModule.forRoot([]),
+        AccountSettingsModule
+      ],
+      providers: [
+        AccountSettingsFormService,
+        {
+          provide: AccountWorkspaceStore,
+          useValue: {
+            account,
+            facilities,
+            canWrite,
+            hasPending: signal(false),
+            customEmissions: signal([])
+          }
+        },
+        { provide: WorkspaceCommandBoundary, useValue: commandBoundary },
+        { provide: AccountCommandHandler, useValue: accountHandler },
+        { provide: FacilityCommandHandler, useValue: facilityHandler },
+        { provide: ApplicationLifecycleService, useValue: lifecycle },
+        { provide: BackupExportCoordinator, useValue: backupExportCoordinator },
+        { provide: ElectronBackupFileGateway, useValue: backupGateway },
+        { provide: AutomaticBackupsService, useValue: automaticBackups },
+        { provide: WorkspaceNavigationService, useValue: navigation },
+        { provide: BackupImportCoordinator, useValue: { prepareTextBackup: vi.fn(), importNewAccount: vi.fn() } },
+        { provide: EGridService, useValue: { subRegionsByZipcode: [{ zip: '37932', subregions: ['SRTV'] }] } }
+      ]
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps the parent settings shell focused on layout and routed detail outlet', () => {
+    const fixture = TestBed.createComponent(AccountSettingsComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Account A');
+    expect(fixture.nativeElement.querySelector('router-outlet')).toBeTruthy();
+    expect(fixture.nativeElement.textContent).not.toContain('Corporate information');
+
+    account.set(undefined);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('No account loaded');
+  });
+
+  it('defines account settings details as child routes of the settings shell', () => {
+    const accountRoute = V1Routes[0].children?.find(route => route.path === 'workspace/account/:accountGuid');
+    const settingsRoute = accountRoute?.children?.find(route => route.path === 'settings');
+    const childPaths = settingsRoute?.children?.map(route => route.path);
+
+    expect(settingsRoute?.component).toBe(AccountSettingsComponent);
+    expect(childPaths).toEqual(['', 'profile', 'units', 'goals', 'financial', 'staleness', 'backup', '**']);
+  });
+
+  it('autosaves profile text locally after a debounce', async () => {
+    vi.useFakeTimers();
+    const fixture = createDetail(AccountSettingsProfileComponent);
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input[formControlName="name"]');
+    input.value = 'Updated Account';
+    input.dispatchEvent(new Event('input'));
+
+    expect(commandBoundary.execute).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(accountHandler.update).toHaveBeenCalledWith(expect.objectContaining({ name: 'Updated Account' }), 'account-a');
+    expect(fixture.componentInstance.saveState).toBe('saved');
+  });
+
+  it('keeps profile text inputs enabled while autosave is saving', async () => {
+    vi.useFakeTimers();
+    let releaseSave: () => void;
+    const saveHasStarted = new Promise<void>(resolveStarted => {
+      commandBoundary.execute.mockImplementationOnce(async (_metadata, operation: () => Promise<unknown>) => {
+        resolveStarted();
+        await new Promise<void>(resolve => {
+          releaseSave = resolve;
+        });
+        return { value: await operation(), change: {} };
+      });
+    });
+    const fixture = createDetail(AccountSettingsProfileComponent);
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input[formControlName="name"]');
+    input.focus();
+    input.value = 'Edited While Saving';
+    input.dispatchEvent(new Event('input'));
+
+    await vi.advanceTimersByTimeAsync(600);
+    await saveHasStarted;
+    fixture.detectChanges(false);
+
+    expect(fixture.componentInstance.saveState).toBe('saving');
+    expect(input.disabled).toBe(false);
+    expect(document.activeElement).toBe(input);
+
+    releaseSave!();
+    await vi.advanceTimersByTimeAsync(0);
+  });
+
+  it('shows profile validation locally instead of saving a blank account name', async () => {
+    vi.useFakeTimers();
+    const fixture = createDetail(AccountSettingsProfileComponent);
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input[formControlName="name"]');
+    input.value = ' ';
+    input.dispatchEvent(new Event('input'));
+
+    await vi.advanceTimersByTimeAsync(600);
+    fixture.detectChanges();
+
+    expect(commandBoundary.execute).not.toHaveBeenCalled();
+    expect(fixture.nativeElement.textContent).toContain('Name is required');
+  });
+
+  it('keeps local profile form edits visible when persistence fails', async () => {
+    const fixture = createDetail(AccountSettingsProfileComponent);
+    commandBoundary.execute.mockRejectedValueOnce(new Error('persist failed'));
+    fixture.componentInstance.form.controls['name'].setValue('Unsaved Account');
+
+    await fixture.componentInstance.saveProfile();
+    fixture.detectChanges(false);
+
+    expect(fixture.componentInstance.form.controls['name'].value).toBe('Unsaved Account');
+    expect(fixture.componentInstance.saveState).toBe('error');
+    expect(fixture.componentInstance.saveError).toContain('Changes could not be saved');
+  });
+
+  it('disables detail forms from canWrite state', () => {
+    const fixture = createDetail(AccountSettingsProfileComponent);
+
+    canWrite.set(false);
+    fixture.detectChanges(false);
+
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input[formControlName="name"]');
+    expect(input.disabled).toBe(true);
+  });
+
+  it('shows assess other impacts in goals instead of units', () => {
+    const unitsFixture = createDetail(AccountSettingsUnitsComponent);
+    const goalsFixture = createDetail(AccountSettingsGoalsComponent);
+
+    expect(unitsFixture.nativeElement.textContent).not.toContain('Assess other impacts of operations');
+    expect(goalsFixture.nativeElement.textContent).toContain('Assess other impacts of operations');
+    expect(goalsFixture.componentInstance.form.controls['displayEmissions'].value).toBe(false);
+  });
+
+  it('updates facilities from the routed financial settings component', async () => {
+    const fixture = createDetail(AccountSettingsFinancialComponent);
+    fixture.componentInstance.form.patchValue({
+      fiscalYear: 'nonCalendarYear',
+      fiscalYearMonth: 6,
+      fiscalYearCalendarEnd: false
+    });
+
+    await fixture.componentInstance.saveFinancial();
+
+    expect(accountHandler.update).toHaveBeenCalledWith(
+      expect.objectContaining({ fiscalYear: 'nonCalendarYear', fiscalYearMonth: 6, fiscalYearCalendarEnd: false }),
+      'account-a'
+    );
+    expect(facilityHandler.update).toHaveBeenCalledTimes(2);
+    expect(commandBoundary.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        publication: expect.objectContaining({ mode: 'patch' })
+      }),
+      expect.any(Function)
+    );
+  });
+
+  it('owns backup confirmation and import panel in the routed backup component', async () => {
+    const fixture = createDetail(AccountSettingsBackupComponent);
+
+    buttonByText(fixture, 'Backup account').click();
+    fixture.detectChanges(false);
+
+    expect(backupExportCoordinator.exportActiveAccount).not.toHaveBeenCalled();
+    expect(fixture.nativeElement.textContent).toContain('Download JSON backup');
+
+    await fixture.componentInstance.confirmBackupDownload();
+    fixture.detectChanges(false);
+
+    expect(backupExportCoordinator.exportActiveAccount).toHaveBeenCalledWith({ downloadAsZip: false });
+
+    buttonByText(fixture, 'Import backup').click();
+    fixture.detectChanges(false);
+
+    expect(fixture.nativeElement.textContent).toContain('Upload Account Backup');
+  });
+
+  it('keeps automatic backup visible in web and enabled when the desktop gateway is available', () => {
+    let fixture = createDetail(AccountSettingsBackupComponent);
+
+    expect(fixture.nativeElement.textContent).toContain('Automatic account backup');
+    expect(fixture.nativeElement.textContent).toContain('Available in the desktop application');
+    expect(buttonByText(fixture, 'Select backup file').disabled).toBe(true);
+
+    fixture.destroy();
+    backupGateway.isAvailable = true;
+    fixture = createDetail(AccountSettingsBackupComponent);
+
+    expect(buttonByText(fixture, 'Select backup file').disabled).toBe(false);
+  });
+});
+
+function createDetail<T>(component: new (...args: any[]) => T): ComponentFixture<T> {
+  const fixture = TestBed.createComponent(component);
+  fixture.detectChanges();
+  return fixture;
+}
+
+function buttonByText<T>(fixture: ComponentFixture<T>, text: string): HTMLButtonElement {
+  return Array.from<HTMLButtonElement>(fixture.nativeElement.querySelectorAll('button'))
+    .find(button => button.textContent?.includes(text))!;
+}
+
+function accountFixture(): IdbAccount {
+  return {
+    guid: 'account-a',
+    name: 'Account A',
+    country: 'US',
+    city: 'Knoxville',
+    state: 'TN',
+    zip: '37932',
+    address: '1 Main St',
+    naics1: '31',
+    naics2: undefined,
+    naics3: undefined,
+    size: 0,
+    notes: '',
+    color: undefined,
+    contactName: '',
+    contactEmail: '',
+    contactPhone: '',
+    unitsOfMeasure: 'Imperial',
+    energyUnit: 'MMBtu',
+    electricityUnit: 'kWh',
+    volumeLiquidUnit: 'gal',
+    volumeGasUnit: 'SCF',
+    massUnit: 'lb',
+    energyIsSource: true,
+    fiscalYear: 'calendarYear',
+    fiscalYearMonth: 0,
+    fiscalYearCalendarEnd: true,
+    archiveOption: 'skip',
+    assessmentReportVersion: 'AR6',
+    displayEmissions: false,
+    sustainabilityQuestions: {
+      energyReductionGoal: true,
+      energyReductionPercent: 25,
+      energyReductionBaselineYear: 2020,
+      energyReductionTargetYear: 2030,
+      energyIsAbsolute: false,
+      greenhouseReductionGoal: false,
+      greenhouseReductionPercent: 0,
+      greenhouseReductionBaselineYear: 2020,
+      greenhouseReductionTargetYear: 2030,
+      greenhouseIsAbsolute: true,
+      waterReductionGoal: false,
+      waterReductionPercent: 0,
+      waterReductionBaselineYear: 2020,
+      waterReductionTargetYear: 2030,
+      waterIsAbsolute: false
+    },
+    dataStalenessSettings: {
+      enabled: true,
+      thresholdMonths: 3
+    }
+  } as IdbAccount;
+}
+
+function facilityFixture(guid: string): IdbFacility {
+  return {
+    guid,
+    accountId: 'account-a',
+    name: guid,
+    fiscalYear: 'calendarYear',
+    fiscalYearMonth: 0,
+    fiscalYearCalendarEnd: true
+  } as IdbFacility;
+}
+
+function backupFile(): BackupFile {
+  return {
+    origin: 'VERIFI',
+    backupFileType: 'Account',
+    dataVersion: 2,
+    dataBackupId: 'backup-id',
+    timeStamp: new Date('2026-08-26T12:00:00.000Z'),
+    account: accountFixture(),
+    facilities: [],
+    facility: undefined as unknown as BackupFile['facility'],
+    meters: [],
+    meterData: [],
+    groups: [],
+    accountReports: [],
+    accountAnalysisItems: [],
+    facilityAnalysisItems: [],
+    predictorData: [],
+    predictorDataV2: [],
+    predictors: [],
+    customEmissionsItems: [],
+    customFuels: [],
+    customGWPs: [],
+    facilityReports: [],
+    facilityEnergyUseGroups: [],
+    facilityEnergyUseEquipment: []
+  };
+}

--- a/src/app/v1/account/settings/account-settings.component.spec.ts
+++ b/src/app/v1/account/settings/account-settings.component.spec.ts
@@ -20,6 +20,7 @@ import { AccountSettingsFormService } from '@shared/settings-forms/account-setti
 import { AccountSettingsComponent } from './account-settings.component';
 import { AccountSettingsModule } from './account-settings.module';
 import { AccountSettingsBackupComponent } from './backup/account-settings-backup.component';
+import { AccountSettingsDeleteComponent } from './delete/account-settings-delete.component';
 import { AccountSettingsFinancialComponent } from './financial/account-settings-financial.component';
 import { AccountSettingsGoalsComponent } from './goals/account-settings-goals.component';
 import { AccountSettingsProfileComponent } from './profile/account-settings-profile.component';
@@ -34,7 +35,10 @@ describe('Account settings routed components', () => {
   let commandBoundary: { execute: ReturnType<typeof vi.fn> };
   let accountHandler: { update: ReturnType<typeof vi.fn> };
   let facilityHandler: { update: ReturnType<typeof vi.fn> };
-  let lifecycle: { refreshAccountCatalog: ReturnType<typeof vi.fn> };
+  let lifecycle: {
+    refreshAccountCatalog: ReturnType<typeof vi.fn>;
+    handleMarkedAccountDeletion: ReturnType<typeof vi.fn>;
+  };
   let backupExportCoordinator: {
     exportActiveAccount: ReturnType<typeof vi.fn>;
     buildActiveAccountBackup: ReturnType<typeof vi.fn>;
@@ -50,7 +54,10 @@ describe('Account settings routed components', () => {
     addOrUpdateFile: ReturnType<typeof vi.fn>;
     inspectCurrentAccountFile: ReturnType<typeof vi.fn>;
   };
-  let navigation: { openAccount: ReturnType<typeof vi.fn> };
+  let navigation: {
+    openAccount: ReturnType<typeof vi.fn>;
+    showWelcome: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     vi.spyOn(console, 'warn').mockImplementation(() => undefined);
@@ -67,7 +74,8 @@ describe('Account settings routed components', () => {
       update: vi.fn(async updated => updated)
     };
     lifecycle = {
-      refreshAccountCatalog: vi.fn(async () => undefined)
+      refreshAccountCatalog: vi.fn(async () => undefined),
+      handleMarkedAccountDeletion: vi.fn(async () => [])
     };
     backupExportCoordinator = {
       exportActiveAccount: vi.fn(async () => backupFile()),
@@ -85,7 +93,8 @@ describe('Account settings routed components', () => {
       inspectCurrentAccountFile: vi.fn(async () => undefined)
     };
     navigation = {
-      openAccount: vi.fn(async () => undefined)
+      openAccount: vi.fn(async () => undefined),
+      showWelcome: vi.fn()
     };
 
     TestBed.configureTestingModule({
@@ -144,7 +153,7 @@ describe('Account settings routed components', () => {
     const childPaths = settingsRoute?.children?.map(route => route.path);
 
     expect(settingsRoute?.component).toBe(AccountSettingsComponent);
-    expect(childPaths).toEqual(['', 'profile', 'units', 'goals', 'financial', 'staleness', 'backup', '**']);
+    expect(childPaths).toEqual(['', 'profile', 'units', 'goals', 'financial', 'staleness', 'backup', 'delete', '**']);
   });
 
   it('autosaves profile text locally after a debounce', async () => {
@@ -293,6 +302,27 @@ describe('Account settings routed components', () => {
     fixture = createDetail(AccountSettingsBackupComponent);
 
     expect(buttonByText(fixture, 'Select backup file').disabled).toBe(false);
+  });
+
+  it('confirms before deleting an account from the routed delete component', async () => {
+    const fixture = createDetail(AccountSettingsDeleteComponent);
+
+    buttonByText(fixture, 'Delete account').click();
+    fixture.detectChanges(false);
+
+    expect(accountHandler.update).not.toHaveBeenCalled();
+    expect(fixture.nativeElement.textContent).toContain('This action cannot be undone');
+
+    lifecycle.handleMarkedAccountDeletion.mockImplementationOnce(async () => {
+      account.set(undefined);
+      return [];
+    });
+    await fixture.componentInstance.confirmDeleteAccount();
+    fixture.detectChanges(false);
+
+    expect(accountHandler.update).toHaveBeenCalledWith(expect.objectContaining({ deleteAccount: true }), 'account-a');
+    expect(lifecycle.handleMarkedAccountDeletion).toHaveBeenCalledWith('account-a');
+    expect(navigation.showWelcome).toHaveBeenCalled();
   });
 });
 

--- a/src/app/v1/account/settings/account-settings.component.spec.ts
+++ b/src/app/v1/account/settings/account-settings.component.spec.ts
@@ -277,7 +277,6 @@ describe('Account settings routed components', () => {
     fixture.detectChanges(false);
 
     expect(backupExportCoordinator.exportActiveAccount).not.toHaveBeenCalled();
-    expect(fixture.nativeElement.textContent).toContain('Download JSON backup');
 
     await fixture.componentInstance.confirmBackupDownload();
     fixture.detectChanges(false);
@@ -311,7 +310,6 @@ describe('Account settings routed components', () => {
     fixture.detectChanges(false);
 
     expect(accountHandler.update).not.toHaveBeenCalled();
-    expect(fixture.nativeElement.textContent).toContain('This action cannot be undone');
 
     lifecycle.handleMarkedAccountDeletion.mockImplementationOnce(async () => {
       account.set(undefined);

--- a/src/app/v1/account/settings/account-settings.component.ts
+++ b/src/app/v1/account/settings/account-settings.component.ts
@@ -1,0 +1,15 @@
+import { Component, inject } from '@angular/core';
+import { AccountWorkspaceStore } from '@data/account-workspace/account-workspace.store';
+
+@Component({
+  selector: 'app-account-settings-page',
+  templateUrl: './account-settings.component.html',
+  styleUrls: ['./account-settings.component.css'],
+  standalone: false
+})
+export class AccountSettingsComponent {
+  private readonly workspace = inject(AccountWorkspaceStore);
+
+  readonly account = this.workspace.account;
+  readonly canWrite = this.workspace.canWrite;
+}

--- a/src/app/v1/account/settings/account-settings.module.ts
+++ b/src/app/v1/account/settings/account-settings.module.ts
@@ -1,0 +1,32 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { ImportAccountBackupComponent } from '../../welcome/import-account-backup/import-account-backup.component';
+import { AccountSettingsComponent } from './account-settings.component';
+import { AccountSettingsBackupComponent } from './backup/account-settings-backup.component';
+import { AccountSettingsFinancialComponent } from './financial/account-settings-financial.component';
+import { AccountSettingsGoalsComponent } from './goals/account-settings-goals.component';
+import { AccountSettingsProfileComponent } from './profile/account-settings-profile.component';
+import { AccountSettingsStalenessComponent } from './staleness/account-settings-staleness.component';
+import { AccountSettingsUnitsComponent } from './units/account-settings-units.component';
+
+@NgModule({
+  declarations: [
+    AccountSettingsComponent,
+    AccountSettingsProfileComponent,
+    AccountSettingsUnitsComponent,
+    AccountSettingsGoalsComponent,
+    AccountSettingsFinancialComponent,
+    AccountSettingsStalenessComponent,
+    AccountSettingsBackupComponent
+  ],
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    RouterModule,
+    ImportAccountBackupComponent
+  ],
+  exports: [AccountSettingsComponent]
+})
+export class AccountSettingsModule { }

--- a/src/app/v1/account/settings/account-settings.module.ts
+++ b/src/app/v1/account/settings/account-settings.module.ts
@@ -5,6 +5,7 @@ import { RouterModule } from '@angular/router';
 import { ImportAccountBackupComponent } from '../../welcome/import-account-backup/import-account-backup.component';
 import { AccountSettingsComponent } from './account-settings.component';
 import { AccountSettingsBackupComponent } from './backup/account-settings-backup.component';
+import { AccountSettingsDeleteComponent } from './delete/account-settings-delete.component';
 import { AccountSettingsFinancialComponent } from './financial/account-settings-financial.component';
 import { AccountSettingsGoalsComponent } from './goals/account-settings-goals.component';
 import { AccountSettingsProfileComponent } from './profile/account-settings-profile.component';
@@ -19,7 +20,8 @@ import { AccountSettingsUnitsComponent } from './units/account-settings-units.co
     AccountSettingsGoalsComponent,
     AccountSettingsFinancialComponent,
     AccountSettingsStalenessComponent,
-    AccountSettingsBackupComponent
+    AccountSettingsBackupComponent,
+    AccountSettingsDeleteComponent
   ],
   imports: [
     CommonModule,

--- a/src/app/v1/account/settings/backup/account-settings-backup.component.html
+++ b/src/app/v1/account/settings/backup/account-settings-backup.component.html
@@ -102,34 +102,36 @@
   </section>
 }
 
-@if (showBackupConfirm && currentAccount) {
-  <button type="button" class="v1-modal-backdrop" aria-label="Cancel account backup" [disabled]="isBackingUp"
-    (click)="cancelBackupConfirm()"></button>
-  <section class="v1-modal" role="dialog" aria-modal="true" aria-labelledby="v1-backup-confirm-title">
-    <header class="v1-modal__header">
-      <h2 id="v1-backup-confirm-title">Backup {{ currentAccount.name }}</h2>
-      <button type="button" class="v1-icon-btn" aria-label="Cancel account backup" [disabled]="isBackingUp"
-        (click)="cancelBackupConfirm()">
-        <span class="fa fa-xmark" aria-hidden="true"></span>
-      </button>
-    </header>
-    <div class="v1-modal__body">
-      <p>Download a JSON backup for this account, including facilities, meters, predictors, analyses, reports, and account settings.</p>
-    </div>
-    <footer class="v1-modal__footer">
-      <button type="button" class="v1-btn v1-btn--quiet" [disabled]="isBackingUp" (click)="cancelBackupConfirm()">Cancel</button>
-      <button type="button" class="v1-btn v1-btn--primary" [disabled]="isBackingUp" (click)="confirmBackupDownload()">
-        @if (isBackingUp) {
-          <span class="fa fa-circle-notch fa-spin" aria-hidden="true"></span>
-          Preparing
-        } @else {
-          Download JSON backup
-          <span class="fa fa-download" aria-hidden="true"></span>
-        }
-      </button>
-    </footer>
-  </section>
-}
+<ng-template #backupConfirmModal>
+  <div class="v1-modal-layer">
+    <button type="button" class="v1-modal-backdrop" aria-label="Cancel account backup" [disabled]="isBackingUp"
+      (click)="cancelBackupConfirm()"></button>
+    <section class="v1-modal" role="dialog" aria-modal="true" aria-labelledby="v1-backup-confirm-title">
+      <header class="v1-modal__header">
+        <h2 id="v1-backup-confirm-title">Backup {{ account()?.name }}</h2>
+        <button type="button" class="v1-icon-btn" aria-label="Cancel account backup" [disabled]="isBackingUp"
+          (click)="cancelBackupConfirm()">
+          <span class="fa fa-xmark" aria-hidden="true"></span>
+        </button>
+      </header>
+      <div class="v1-modal__body">
+        <p>Download a JSON backup for this account, including facilities, meters, predictors, analyses, reports, and account settings.</p>
+      </div>
+      <footer class="v1-modal__footer">
+        <button type="button" class="v1-btn v1-btn--quiet" [disabled]="isBackingUp" (click)="cancelBackupConfirm()">Cancel</button>
+        <button type="button" class="v1-btn v1-btn--primary" [disabled]="isBackingUp" (click)="confirmBackupDownload()">
+          @if (isBackingUp) {
+            <span class="fa fa-circle-notch fa-spin" aria-hidden="true"></span>
+            Preparing
+          } @else {
+            Download JSON backup
+            <span class="fa fa-download" aria-hidden="true"></span>
+          }
+        </button>
+      </footer>
+    </section>
+  </div>
+</ng-template>
 
 @if (showImportPanel) {
   <app-import-account-backup-panel

--- a/src/app/v1/account/settings/backup/account-settings-backup.component.html
+++ b/src/app/v1/account/settings/backup/account-settings-backup.component.html
@@ -1,0 +1,139 @@
+@let currentAccount = account();
+
+@if (form && currentAccount) {
+  <section class="v1-settings-panel" aria-label="Backup and import" [formGroup]="form">
+    <div class="v1-settings-panel__heading">
+      <div>
+        <p>Backup</p>
+        <h2>Backup and import</h2>
+      </div>
+      <span class="v1-settings-panel__status" [class.v1-settings-panel__status--error]="saveState === 'error'">
+        @if (saveState === 'saving' || isBackingUp || automaticBackupSaving()) {
+          <span class="fa fa-circle-notch fa-spin" aria-hidden="true"></span>
+          Working
+        } @else if (saveState === 'saved') {
+          <span class="fa fa-check" aria-hidden="true"></span>
+          Saved
+        } @else if (saveState === 'error') {
+          <span class="fa fa-triangle-exclamation" aria-hidden="true"></span>
+          Not saved
+        }
+      </span>
+    </div>
+
+    <div class="v1-settings-grid v1-settings-grid--2">
+      <article class="v1-settings-card">
+        <span class="fa fa-file-arrow-down" aria-hidden="true"></span>
+        <h3>Manual account backup</h3>
+        <p>Download a JSON backup for this account.</p>
+        <div class="v1-settings-actions">
+          <button type="button" class="v1-btn v1-btn--primary" [disabled]="isBackingUp" (click)="openBackupConfirm()">
+            Backup account
+            <span class="fa fa-download" aria-hidden="true"></span>
+          </button>
+        </div>
+      </article>
+
+      <article class="v1-settings-card">
+        <span class="fa fa-file-import" aria-hidden="true"></span>
+        <h3>Import backup file</h3>
+        <p>Open the v1 account backup import panel.</p>
+        <div class="v1-settings-actions">
+          <button type="button" class="v1-btn v1-btn--secondary" (click)="openImportPanel()">
+            Import backup
+            <span class="fa fa-arrow-right" aria-hidden="true"></span>
+          </button>
+        </div>
+      </article>
+    </div>
+
+    <article class="v1-settings-card">
+      <span class="fa fa-rotate" aria-hidden="true"></span>
+      <h3>Automatic account backup</h3>
+      <p>{{ automaticBackupLabel }}</p>
+      @if (currentAccount.dataBackupFilePath) {
+        <small>{{ currentAccount.dataBackupFilePath }}</small>
+      }
+      <div class="v1-settings-actions">
+        <button type="button" class="v1-btn v1-btn--quiet"
+          [disabled]="!canWrite() || saveState === 'saving' || !backupGateway.isAvailable || automaticBackupSaving()"
+          (click)="chooseAutomaticBackupLocation()">
+          {{ currentAccount.dataBackupFilePath ? 'Change backup file' : 'Select backup file' }}
+        </button>
+      </div>
+    </article>
+
+    @if (currentAccount.dataBackupFilePath) {
+      <fieldset>
+        <legend>Shared backup file</legend>
+        <label class="v1-settings-choice">
+          <input type="radio" formControlName="isSharedBackupFile" [value]="false" (change)="saveBackupSettings()">
+          <span>No, this computer is the only one that will modify this file.</span>
+        </label>
+        <label class="v1-settings-choice">
+          <input type="radio" formControlName="isSharedBackupFile" [value]="true" (change)="saveBackupSettings()">
+          <span>Yes, this is a shared file that may be edited on another computer.</span>
+        </label>
+        @if (form.controls['isSharedBackupFile'].value) {
+          <label>
+            <span>Shared file author</span>
+            <input type="text" formControlName="sharedFileAuthor"
+              (input)="scheduleBackupSettingsSave()" (blur)="flushBackupSettingsSave()">
+          </label>
+        }
+      </fieldset>
+
+      <fieldset>
+        <legend>Archive version history</legend>
+        <label class="v1-settings-choice">
+          <input type="radio" formControlName="archiveOption" value="skip" (change)="saveBackupSettings()">
+          <span>Ask me to archive when account is opened</span>
+        </label>
+        <label class="v1-settings-choice">
+          <input type="radio" formControlName="archiveOption" value="always" (change)="saveBackupSettings()">
+          <span>Always archive</span>
+        </label>
+        <label class="v1-settings-choice">
+          <input type="radio" formControlName="archiveOption" value="never" (change)="saveBackupSettings()">
+          <span>Never archive</span>
+        </label>
+      </fieldset>
+    }
+  </section>
+}
+
+@if (showBackupConfirm && currentAccount) {
+  <button type="button" class="v1-modal-backdrop" aria-label="Cancel account backup" [disabled]="isBackingUp"
+    (click)="cancelBackupConfirm()"></button>
+  <section class="v1-modal" role="dialog" aria-modal="true" aria-labelledby="v1-backup-confirm-title">
+    <header class="v1-modal__header">
+      <h2 id="v1-backup-confirm-title">Backup {{ currentAccount.name }}</h2>
+      <button type="button" class="v1-icon-btn" aria-label="Cancel account backup" [disabled]="isBackingUp"
+        (click)="cancelBackupConfirm()">
+        <span class="fa fa-xmark" aria-hidden="true"></span>
+      </button>
+    </header>
+    <div class="v1-modal__body">
+      <p>Download a JSON backup for this account, including facilities, meters, predictors, analyses, reports, and account settings.</p>
+    </div>
+    <footer class="v1-modal__footer">
+      <button type="button" class="v1-btn v1-btn--quiet" [disabled]="isBackingUp" (click)="cancelBackupConfirm()">Cancel</button>
+      <button type="button" class="v1-btn v1-btn--primary" [disabled]="isBackingUp" (click)="confirmBackupDownload()">
+        @if (isBackingUp) {
+          <span class="fa fa-circle-notch fa-spin" aria-hidden="true"></span>
+          Preparing
+        } @else {
+          Download JSON backup
+          <span class="fa fa-download" aria-hidden="true"></span>
+        }
+      </button>
+    </footer>
+  </section>
+}
+
+@if (showImportPanel) {
+  <app-import-account-backup-panel
+    (closed)="closeImportPanel()"
+    (completed)="openImportedAccount($any($event))">
+  </app-import-account-backup-panel>
+}

--- a/src/app/v1/account/settings/backup/account-settings-backup.component.ts
+++ b/src/app/v1/account/settings/backup/account-settings-backup.component.ts
@@ -1,11 +1,13 @@
-import { Component, effect, inject, untracked } from '@angular/core';
+import { Component, TemplateRef, ViewChild, ViewContainerRef, effect, inject, untracked } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { TemplatePortal } from '@angular/cdk/portal';
 import { BackupExportCoordinator } from '@data/backup/backup-export-coordinator.service';
 import { IdbAccount } from '@data/models/idbModels/account';
 import { AutomaticBackupStatus, AutomaticBackupsService } from '@platform/electron/automatic-backups.service';
 import { ElectronBackupFileGateway } from '@platform/electron/electron-backup-file.gateway';
 import { WorkspaceNavigationService } from '../../../shell/workspace-navigation.service';
+import { ModalPortalService } from '../../../shell/modal-portal.service';
 import { AccountSettingsDetailBase } from '../account-settings-detail.base';
 
 @Component({
@@ -19,10 +21,14 @@ export class AccountSettingsBackupComponent extends AccountSettingsDetailBase {
   private readonly backupExportCoordinator = inject(BackupExportCoordinator);
   private readonly automaticBackups = inject(AutomaticBackupsService);
   private readonly navigation = inject(WorkspaceNavigationService);
+  private readonly modalPortal = inject(ModalPortalService);
+  private readonly viewContainerRef = inject(ViewContainerRef);
   readonly backupGateway = inject(ElectronBackupFileGateway);
 
   readonly automaticBackupStatus = toSignal(this.automaticBackups.status, { initialValue: 'disabled' as AutomaticBackupStatus });
   readonly automaticBackupSaving = toSignal(this.automaticBackups.saving, { initialValue: false });
+
+  @ViewChild('backupConfirmModal') private readonly backupConfirmModal!: TemplateRef<unknown>;
 
   form: FormGroup;
   showBackupConfirm = false;
@@ -96,11 +102,13 @@ export class AccountSettingsBackupComponent extends AccountSettingsDetailBase {
     }
     this.showBackupConfirm = true;
     this.saveError = '';
+    this.modalPortal.show(new TemplatePortal(this.backupConfirmModal, this.viewContainerRef));
   }
 
   cancelBackupConfirm(): void {
     if (!this.isBackingUp) {
       this.showBackupConfirm = false;
+      this.modalPortal.hide();
     }
   }
 
@@ -109,6 +117,7 @@ export class AccountSettingsBackupComponent extends AccountSettingsDetailBase {
       return;
     }
     this.showBackupConfirm = false;
+    this.modalPortal.hide();
     this.isBackingUp = true;
     await this.runSave('Preparing account backup', async () => {
       await this.backupExportCoordinator.exportActiveAccount({ downloadAsZip: false });

--- a/src/app/v1/account/settings/backup/account-settings-backup.component.ts
+++ b/src/app/v1/account/settings/backup/account-settings-backup.component.ts
@@ -1,0 +1,185 @@
+import { Component, effect, inject, untracked } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { BackupExportCoordinator } from '@data/backup/backup-export-coordinator.service';
+import { IdbAccount } from '@data/models/idbModels/account';
+import { AutomaticBackupStatus, AutomaticBackupsService } from '@platform/electron/automatic-backups.service';
+import { ElectronBackupFileGateway } from '@platform/electron/electron-backup-file.gateway';
+import { WorkspaceNavigationService } from '../../../shell/workspace-navigation.service';
+import { AccountSettingsDetailBase } from '../account-settings-detail.base';
+
+@Component({
+  selector: 'app-account-settings-backup',
+  templateUrl: './account-settings-backup.component.html',
+  styleUrls: ['../account-settings.component.css'],
+  host: { style: 'display: block;' },
+  standalone: false
+})
+export class AccountSettingsBackupComponent extends AccountSettingsDetailBase {
+  private readonly backupExportCoordinator = inject(BackupExportCoordinator);
+  private readonly automaticBackups = inject(AutomaticBackupsService);
+  private readonly navigation = inject(WorkspaceNavigationService);
+  readonly backupGateway = inject(ElectronBackupFileGateway);
+
+  readonly automaticBackupStatus = toSignal(this.automaticBackups.status, { initialValue: 'disabled' as AutomaticBackupStatus });
+  readonly automaticBackupSaving = toSignal(this.automaticBackups.saving, { initialValue: false });
+
+  form: FormGroup;
+  showBackupConfirm = false;
+  showImportPanel = false;
+  isBackingUp = false;
+
+  get automaticBackupLabel(): string {
+    if (!this.backupGateway.isAvailable) {
+      return 'Available in the desktop application';
+    }
+    switch (this.automaticBackupStatus()) {
+      case 'checking':
+        return 'Checking selected backup file';
+      case 'ready':
+        return 'Automatic backup is ready';
+      case 'pending':
+        return 'Backup queued';
+      case 'saving':
+        return 'Saving backup file';
+      case 'conflict':
+        return 'Backup file needs review';
+      case 'error':
+        return 'Backup file needs attention';
+      default:
+        return this.account()?.dataBackupFilePath ? 'Backup file selected' : 'No automatic backup file selected';
+    }
+  }
+
+  constructor() {
+    super();
+    effect(() => {
+      const account = this.account();
+      if (!account) {
+        return;
+      }
+      if (this.skipNextWorkspaceRefresh) {
+        this.skipNextWorkspaceRefresh = false;
+        return;
+      }
+      this.buildForm(account);
+    });
+    effect(() => {
+      this.applyFormAvailability(this.canWrite());
+    });
+  }
+
+  scheduleBackupSettingsSave(): void {
+    this.scheduleSave(() => this.saveBackupSettings());
+  }
+
+  flushBackupSettingsSave(): void {
+    this.flushSave(() => this.saveBackupSettings());
+  }
+
+  async saveBackupSettings(): Promise<void> {
+    if (!this.form) {
+      return;
+    }
+    this.applyFormAvailability(this.canWrite());
+    await this.saveAccount('Saving backup settings', account => ({
+      ...account,
+      isSharedBackupFile: !!this.form.controls['isSharedBackupFile'].value,
+      sharedFileAuthor: this.form.controls['sharedFileAuthor'].value,
+      archiveOption: this.form.controls['archiveOption'].value
+    }));
+  }
+
+  openBackupConfirm(): void {
+    if (!this.account() || this.isBackingUp) {
+      return;
+    }
+    this.showBackupConfirm = true;
+    this.saveError = '';
+  }
+
+  cancelBackupConfirm(): void {
+    if (!this.isBackingUp) {
+      this.showBackupConfirm = false;
+    }
+  }
+
+  async confirmBackupDownload(): Promise<void> {
+    if (!this.account() || this.isBackingUp) {
+      return;
+    }
+    this.showBackupConfirm = false;
+    this.isBackingUp = true;
+    await this.runSave('Preparing account backup', async () => {
+      await this.backupExportCoordinator.exportActiveAccount({ downloadAsZip: false });
+    });
+    this.isBackingUp = false;
+  }
+
+  async chooseAutomaticBackupLocation(): Promise<void> {
+    const account = this.account();
+    if (!account || !this.canWrite() || !this.backupGateway.isAvailable) {
+      return;
+    }
+    const backupFile = this.backupExportCoordinator.buildActiveAccountBackup();
+    const defaultPath = account.dataBackupFilePath ?? `${account.name}.json`;
+    const savedFilePath = await this.backupGateway.chooseSavePath(defaultPath);
+    if (!savedFilePath) {
+      return;
+    }
+
+    await this.runSave('Saving automatic backup settings', async () => {
+      await this.backupGateway.write(savedFilePath, backupFile);
+      await this.automaticBackups.addOrUpdateFile(backupFile.dataBackupId, account.guid);
+      const updatedAccount: IdbAccount = {
+        ...structuredClone(account),
+        dataBackupFilePath: savedFilePath,
+        dataBackupId: backupFile.dataBackupId
+      };
+      await this.commandBoundary.execute(
+        {
+          entityKind: 'account',
+          changeKind: 'update',
+          entityGuid: updatedAccount.guid,
+          label: 'Saving automatic backup settings',
+          publication: { mode: 'patch', buildPatch: value => ({ account: value }) }
+        },
+        () => this.accountHandler.update(updatedAccount, updatedAccount.guid)
+      );
+      await this.automaticBackups.inspectCurrentAccountFile();
+      await this.lifecycle.refreshAccountCatalog();
+    });
+  }
+
+  openImportPanel(): void {
+    this.showImportPanel = true;
+    this.saveError = '';
+  }
+
+  closeImportPanel(): void {
+    this.showImportPanel = false;
+  }
+
+  async openImportedAccount(account: IdbAccount): Promise<void> {
+    this.closeImportPanel();
+    await this.navigation.openAccount(account.guid);
+  }
+
+  private buildForm(account: IdbAccount): void {
+    this.form = new FormGroup({
+      isSharedBackupFile: new FormControl(!!account.isSharedBackupFile),
+      sharedFileAuthor: new FormControl(account.sharedFileAuthor || ''),
+      archiveOption: new FormControl(account.archiveOption || 'skip')
+    });
+    this.applyFormAvailability(untracked(() => this.canWrite()));
+  }
+
+  private applyFormAvailability(canWrite: boolean): void {
+    const hasAutomaticBackupFile = !!this.account()?.dataBackupFilePath;
+    this.setFormEnabled(this.form, canWrite && hasAutomaticBackupFile);
+    this.setControlEnabled(
+      this.form?.controls['sharedFileAuthor'],
+      canWrite && hasAutomaticBackupFile && !!this.form?.controls['isSharedBackupFile'].value
+    );
+  }
+}

--- a/src/app/v1/account/settings/backup/account-settings-backup.component.ts
+++ b/src/app/v1/account/settings/backup/account-settings-backup.component.ts
@@ -35,6 +35,12 @@ export class AccountSettingsBackupComponent extends AccountSettingsDetailBase {
   showImportPanel = false;
   isBackingUp = false;
 
+  override ngOnDestroy(): void {
+    super.ngOnDestroy();
+    this.showBackupConfirm = false;
+    this.modalPortal.hide();
+  }
+
   get automaticBackupLabel(): string {
     if (!this.backupGateway.isAvailable) {
       return 'Available in the desktop application';

--- a/src/app/v1/account/settings/delete/account-settings-delete.component.html
+++ b/src/app/v1/account/settings/delete/account-settings-delete.component.html
@@ -1,0 +1,79 @@
+@let currentAccount = account();
+
+@if (currentAccount) {
+<section class="v1-settings-panel v1-settings-panel--danger" aria-label="Delete account">
+  <div class="v1-settings-panel__heading">
+    <div>
+      <p>Safety</p>
+      <h2>Delete account</h2>
+    </div>
+    <span class="v1-settings-panel__status" [class.v1-settings-panel__status--error]="saveState === 'error'">
+      @if (isDeleting || saveState === 'saving') {
+      <span class="fa fa-circle-notch fa-spin" aria-hidden="true"></span>
+      Deleting
+      } @else if (saveState === 'error') {
+      <span class="fa fa-triangle-exclamation" aria-hidden="true"></span>
+      Not deleted
+      }
+    </span>
+  </div>
+
+  @if (saveError) {
+  <div class="v1-alert v1-alert--danger" role="alert">
+    <span class="fa fa-triangle-exclamation" aria-hidden="true"></span>
+    <span>{{ saveError }}</span>
+  </div>
+  }
+
+  <article class="v1-settings-card v1-settings-card--danger">
+    <span class="fa fa-triangle-exclamation" aria-hidden="true"></span>
+    <h3>Permanent account removal</h3>
+    <p>Deleting this account removes the account and all related facilities, meters, predictors, analyses, reports, and
+      settings.</p>
+    <p>Create a backup before continuing if this account data may be needed later.</p>
+    <div class="v1-settings-actions">
+      <button type="button" class="v1-btn v1-btn--danger" [disabled]="!canWrite() || isDeleting"
+        (click)="openDeleteConfirm()">
+        Delete account
+        <span class="fa fa-trash" aria-hidden="true"></span>
+      </button>
+    </div>
+  </article>
+</section>
+}
+
+
+<ng-template #deleteConfirmModal>
+  <div class="v1-modal-layer">
+    <button type="button" class="v1-modal-backdrop" aria-label="Cancel account deletion" [disabled]="isDeleting"
+      (click)="cancelDeleteConfirm()"></button>
+    <section class="v1-modal" role="dialog" aria-modal="true" aria-labelledby="v1-delete-account-title">
+      <header class="v1-modal__header">
+        <h2 id="v1-delete-account-title">Delete {{ account()?.name }}</h2>
+        <button type="button" class="v1-icon-btn" aria-label="Cancel account deletion" [disabled]="isDeleting"
+          (click)="cancelDeleteConfirm()">
+          <span class="fa fa-xmark" aria-hidden="true"></span>
+        </button>
+      </header>
+      <div class="v1-modal__body">
+        <p>Deleting this account will permanently remove all facilities, meters, predictors, analyses, reports, and settings
+          associated with it.</p>
+        <p>This action cannot be undone. Create a backup before continuing if this account data may be needed later.</p>
+      </div>
+      <footer class="v1-modal__footer">
+        <button type="button" class="v1-btn v1-btn--quiet" [disabled]="isDeleting"
+          (click)="cancelDeleteConfirm()">Cancel</button>
+        <button type="button" class="v1-btn v1-btn--danger" [disabled]="!canWrite() || isDeleting"
+          (click)="confirmDeleteAccount()">
+          @if (isDeleting) {
+          <span class="fa fa-circle-notch fa-spin" aria-hidden="true"></span>
+          Deleting
+          } @else {
+          Delete account
+          <span class="fa fa-trash" aria-hidden="true"></span>
+          }
+        </button>
+      </footer>
+    </section>
+  </div>
+</ng-template>

--- a/src/app/v1/account/settings/delete/account-settings-delete.component.ts
+++ b/src/app/v1/account/settings/delete/account-settings-delete.component.ts
@@ -1,0 +1,74 @@
+import { Component, TemplateRef, ViewChild, ViewContainerRef, inject } from '@angular/core';
+import { TemplatePortal } from '@angular/cdk/portal';
+import { WorkspaceNavigationService } from '../../../shell/workspace-navigation.service';
+import { ModalPortalService } from '../../../shell/modal-portal.service';
+import { AccountSettingsDetailBase } from '../account-settings-detail.base';
+
+@Component({
+  selector: 'app-account-settings-delete',
+  templateUrl: './account-settings-delete.component.html',
+  styleUrls: ['../account-settings.component.css'],
+  host: { style: 'display: block;' },
+  standalone: false
+})
+export class AccountSettingsDeleteComponent extends AccountSettingsDetailBase {
+  private readonly navigation = inject(WorkspaceNavigationService);
+  private readonly modalPortal = inject(ModalPortalService);
+  private readonly viewContainerRef = inject(ViewContainerRef);
+
+  @ViewChild('deleteConfirmModal') private readonly deleteConfirmModal!: TemplateRef<unknown>;
+
+  showDeleteConfirm = false;
+  isDeleting = false;
+
+  openDeleteConfirm(): void {
+    if (!this.account() || !this.canWrite() || this.isDeleting) {
+      return;
+    }
+    this.saveError = '';
+    this.showDeleteConfirm = true;
+    this.modalPortal.show(new TemplatePortal(this.deleteConfirmModal, this.viewContainerRef));
+  }
+
+  cancelDeleteConfirm(): void {
+    if (!this.isDeleting) {
+      this.showDeleteConfirm = false;
+      this.modalPortal.hide();
+    }
+  }
+
+  async confirmDeleteAccount(): Promise<void> {
+    const account = this.account();
+    if (!account || !this.canWrite() || this.isDeleting) {
+      return;
+    }
+
+    this.showDeleteConfirm = false;
+    this.modalPortal.hide();
+    this.isDeleting = true;
+    await this.runSave('Deleting account', async () => {
+      await this.commandBoundary.execute(
+        {
+          entityKind: 'account',
+          changeKind: 'delete',
+          entityGuid: account.guid,
+          label: 'Deleting account',
+          publication: { mode: 'patch', buildPatch: value => ({ account: value }) }
+        },
+        () => this.accountHandler.update({ ...account, deleteAccount: true }, account.guid)
+      );
+      await this.lifecycle.handleMarkedAccountDeletion(account.guid);
+    });
+    this.isDeleting = false;
+
+    const nextAccount = this.account();
+    if (this.saveState === 'error') {
+      return;
+    }
+    if (nextAccount?.guid) {
+      await this.navigation.openAccount(nextAccount.guid);
+      return;
+    }
+    this.navigation.showWelcome();
+  }
+}

--- a/src/app/v1/account/settings/delete/account-settings-delete.component.ts
+++ b/src/app/v1/account/settings/delete/account-settings-delete.component.ts
@@ -21,6 +21,12 @@ export class AccountSettingsDeleteComponent extends AccountSettingsDetailBase {
   showDeleteConfirm = false;
   isDeleting = false;
 
+  override ngOnDestroy(): void {
+    super.ngOnDestroy();
+    this.showDeleteConfirm = false;
+    this.modalPortal.hide();
+  }
+
   openDeleteConfirm(): void {
     if (!this.account() || !this.canWrite() || this.isDeleting) {
       return;

--- a/src/app/v1/account/settings/financial/account-settings-financial.component.html
+++ b/src/app/v1/account/settings/financial/account-settings-financial.component.html
@@ -1,0 +1,51 @@
+@if (form) {
+  <form class="v1-settings-panel" [formGroup]="form" aria-label="Financial reporting">
+    <div class="v1-settings-panel__heading">
+      <div>
+        <p>Reporting</p>
+        <h2>Financial reporting</h2>
+      </div>
+      <span class="v1-settings-panel__status" [class.v1-settings-panel__status--error]="saveState === 'error'">
+        @if (saveState === 'saving') {
+          <span class="fa fa-circle-notch fa-spin" aria-hidden="true"></span>
+          Saving
+        } @else if (saveState === 'saved') {
+          <span class="fa fa-check" aria-hidden="true"></span>
+          Saved
+        } @else if (saveState === 'error') {
+          <span class="fa fa-triangle-exclamation" aria-hidden="true"></span>
+          Not saved
+        }
+      </span>
+    </div>
+
+    <fieldset>
+      <legend>Fiscal year</legend>
+      <label class="v1-settings-choice">
+        <input type="radio" formControlName="fiscalYear" value="calendarYear" (change)="saveFinancial()">
+        <span>Calendar year</span>
+      </label>
+      <label class="v1-settings-choice">
+        <input type="radio" formControlName="fiscalYear" value="nonCalendarYear" (change)="saveFinancial()">
+        <span>Non-calendar year</span>
+      </label>
+    </fieldset>
+
+    @if (form.controls['fiscalYear'].value === 'nonCalendarYear') {
+      <div class="v1-settings-grid v1-settings-grid--2">
+        <label>
+          <span>Start month</span>
+          <select formControlName="fiscalYearMonth" (change)="saveFinancial()">
+            @for (month of months; track month.monthNumValue) {
+              <option [ngValue]="month.monthNumValue">{{ month.name }}</option>
+            }
+          </select>
+        </label>
+        <label class="v1-settings-choice v1-settings-choice--block">
+          <input type="checkbox" formControlName="fiscalYearCalendarEnd" (change)="saveFinancial()">
+          <span>Fiscal year is denoted by the calendar year in which it ends</span>
+        </label>
+      </div>
+    }
+  </form>
+}

--- a/src/app/v1/account/settings/financial/account-settings-financial.component.ts
+++ b/src/app/v1/account/settings/financial/account-settings-financial.component.ts
@@ -1,0 +1,94 @@
+import { Component, effect, inject, untracked } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { FacilityCommandHandler } from '@data/account-workspace/handlers/facility-command-handler.service';
+import { IdbAccount } from '@data/models/idbModels/account';
+import { Months } from '@shared/form-data/months';
+import { AccountSettingsFormService } from '@shared/settings-forms/account-settings-form.service';
+import { AccountSettingsDetailBase } from '../account-settings-detail.base';
+
+@Component({
+  selector: 'app-account-settings-financial',
+  templateUrl: './account-settings-financial.component.html',
+  styleUrls: ['../account-settings.component.css'],
+  host: { style: 'display: block;' },
+  standalone: false
+})
+export class AccountSettingsFinancialComponent extends AccountSettingsDetailBase {
+  private readonly settingsForms = inject(AccountSettingsFormService);
+  private readonly facilityHandler = inject(FacilityCommandHandler);
+
+  readonly facilities = this.workspace.facilities;
+  readonly months = Months;
+  form: FormGroup;
+
+  constructor() {
+    super();
+    effect(() => {
+      const account = this.account();
+      if (!account) {
+        return;
+      }
+      if (this.skipNextWorkspaceRefresh) {
+        this.skipNextWorkspaceRefresh = false;
+        return;
+      }
+      this.buildForm(account);
+    });
+    effect(() => {
+      this.applyFormAvailability(this.canWrite());
+    });
+  }
+
+  async saveFinancial(): Promise<void> {
+    const account = this.account();
+    if (!account || !this.canWrite() || !this.form) {
+      return;
+    }
+    this.applyFormAvailability(this.canWrite());
+    const updatedAccount = this.settingsForms.updateAccountFromFiscalForm(this.form, structuredClone(account));
+    const activeAccountGuid = updatedAccount.guid;
+    const updatedFacilities = this.facilities().map(facility =>
+      this.settingsForms.updateFacilityFromFiscalForm(this.form, structuredClone(facility))
+    );
+
+    await this.runSave('Saving financial reporting settings', async () => {
+      await this.commandBoundary.execute(
+        {
+          entityKind: 'account',
+          changeKind: 'update',
+          entityGuid: activeAccountGuid,
+          label: 'Saving financial reporting settings',
+          publication: {
+            mode: 'patch',
+            buildPatch: value => ({
+              account: value.account,
+              collections: [{ collection: 'facilities', upsert: value.facilities }]
+            })
+          }
+        },
+        async () => {
+          const savedAccount = await this.accountHandler.update(updatedAccount, activeAccountGuid);
+          for (const facility of updatedFacilities) {
+            await this.facilityHandler.update(facility, activeAccountGuid);
+          }
+          return { account: savedAccount, facilities: updatedFacilities };
+        }
+      );
+      await this.lifecycle.refreshAccountCatalog();
+    });
+  }
+
+  private buildForm(account: IdbAccount): void {
+    this.form = this.settingsForms.getFiscalYearForm(account);
+    this.applyFormAvailability(untracked(() => this.canWrite()));
+  }
+
+  private applyFormAvailability(canWrite: boolean): void {
+    this.setFormEnabled(this.form, canWrite);
+    this.setControlsEnabled(
+      this.form,
+      ['fiscalYearMonth', 'fiscalYearCalendarEnd'],
+      canWrite && this.form?.controls['fiscalYear'].value === 'nonCalendarYear'
+    );
+  }
+}

--- a/src/app/v1/account/settings/goals/account-settings-goals.component.html
+++ b/src/app/v1/account/settings/goals/account-settings-goals.component.html
@@ -1,0 +1,176 @@
+@if (form) {
+  <form class="v1-settings-panel" [formGroup]="form" aria-label="Reduction goals">
+    <div class="v1-settings-panel__heading">
+      <div>
+        <p>Goals</p>
+        <h2>Organizational goals</h2>
+      </div>
+      <span class="v1-settings-panel__status" [class.v1-settings-panel__status--error]="saveState === 'error'">
+        @if (saveState === 'saving') {
+          <span class="fa fa-circle-notch fa-spin" aria-hidden="true"></span>
+          Saving
+        } @else if (saveState === 'saved') {
+          <span class="fa fa-check" aria-hidden="true"></span>
+          Saved
+        } @else if (saveState === 'error') {
+          <span class="fa fa-triangle-exclamation" aria-hidden="true"></span>
+          Not saved
+        }
+      </span>
+    </div>
+
+    <label class="v1-settings-choice v1-settings-choice--block">
+      <input type="checkbox" formControlName="isBetterPlantsPartner" (change)="saveGoals()">
+      <span>Better Plants Program Partner</span>
+    </label>
+
+    <div class="v1-settings-goal v1-settings-choice--block">
+      <label class="v1-settings-choice">
+        <input type="checkbox" formControlName="energyReductionGoal" (change)="saveGoals()">
+        <span>Energy reduction goal</span>
+      </label>
+      @if (form.controls['energyReductionGoal'].value) {
+        <div class="v1-settings-grid v1-settings-grid--4">
+          <label>
+            <span>Reduction goal</span>
+            <div class="input-group">
+              <input type="number" class="form-control" formControlName="energyReductionPercent" min="0" max="100"
+                (input)="scheduleGoalsSave()" (blur)="flushGoalsSave()">
+              <span class="input-group-text">%</span>
+            </div>
+          </label>
+          <label>
+            <span>Baseline year</span>
+            <select formControlName="energyReductionBaselineYear"
+              (change)="changeBaselineYear('energyReductionBaselineYear', 'energyReductionTargetYear')">
+              @for (year of years; track year) { <option [ngValue]="year">{{ year }}</option> }
+            </select>
+          </label>
+          <label>
+            <span>Target year</span>
+            <select formControlName="energyReductionTargetYear" (change)="saveGoals()">
+              @for (year of years; track year) { <option [ngValue]="year">{{ year }}</option> }
+            </select>
+          </label>
+          <fieldset>
+            <legend>Goal type</legend>
+            <label class="v1-settings-choice">
+              <input type="radio" formControlName="energyIsAbsolute" [value]="true" (change)="saveGoals()">
+              <span>Absolute</span>
+            </label>
+            <label class="v1-settings-choice">
+              <input type="radio" formControlName="energyIsAbsolute" [value]="false" (change)="saveGoals()">
+              <span>Intensity</span>
+            </label>
+          </fieldset>
+        </div>
+      }
+    </div>
+
+    <div class="v1-settings-goal v1-settings-choice--block">
+      <label class="v1-settings-choice">
+        <input type="checkbox" formControlName="waterReductionGoal" (change)="saveGoals()">
+        <span>Water reduction goal</span>
+      </label>
+      @if (form.controls['waterReductionGoal'].value) {
+        <div class="v1-settings-grid v1-settings-grid--4">
+          <label>
+            <span>Reduction goal</span>
+            <div class="input-group">
+              <input type="number" class="form-control" formControlName="waterReductionPercent" min="0" max="100"
+                (input)="scheduleGoalsSave()" (blur)="flushGoalsSave()">
+              <span class="input-group-text">%</span>
+            </div>
+          </label>
+          <label>
+            <span>Baseline year</span>
+            <select formControlName="waterReductionBaselineYear"
+              (change)="changeBaselineYear('waterReductionBaselineYear', 'waterReductionTargetYear')">
+              @for (year of years; track year) { <option [ngValue]="year">{{ year }}</option> }
+            </select>
+          </label>
+          <label>
+            <span>Target year</span>
+            <select formControlName="waterReductionTargetYear" (change)="saveGoals()">
+              @for (year of years; track year) { <option [ngValue]="year">{{ year }}</option> }
+            </select>
+          </label>
+          <fieldset>
+            <legend>Goal type</legend>
+            <label class="v1-settings-choice">
+              <input type="radio" formControlName="waterIsAbsolute" [value]="true" (change)="saveGoals()">
+              <span>Absolute</span>
+            </label>
+            <label class="v1-settings-choice">
+              <input type="radio" formControlName="waterIsAbsolute" [value]="false" (change)="saveGoals()">
+              <span>Intensity</span>
+            </label>
+          </fieldset>
+        </div>
+      }
+    </div>
+
+    <div class="v1-settings-goal v1-settings-choice--block">
+      <label class="v1-settings-choice">
+        <input type="checkbox" formControlName="displayEmissions" (change)="saveGoals()">
+        <span>Assess other impacts of operations</span>
+      </label>
+      @if (form.controls['displayEmissions'].value) {
+        <fieldset>
+          <legend>IPCC assessment report version</legend>
+          @for (version of assessmentReportVersions; track version) {
+            <label class="v1-settings-choice">
+              <input type="radio" formControlName="assessmentReportVersion" [value]="version" (change)="saveGoals()">
+              <span>{{ version }}</span>
+            </label>
+          }
+        </fieldset>
+      }
+    </div>
+
+    @if (form.controls['displayEmissions'].value) {
+      <div class="v1-settings-goal v1-settings-choice--block">
+        <label class="v1-settings-choice">
+          <input type="checkbox" formControlName="greenhouseReductionGoal" (change)="saveGoals()">
+          <span>Greenhouse emission/carbon reduction goal</span>
+        </label>
+        @if (form.controls['greenhouseReductionGoal'].value) {
+          <div class="v1-settings-grid v1-settings-grid--4">
+            <label>
+              <span>Reduction goal</span>
+              <div class="input-group">
+                <input type="number" class="form-control" formControlName="greenhouseReductionPercent" min="0" max="100"
+                  (input)="scheduleGoalsSave()" (blur)="flushGoalsSave()">
+                <span class="input-group-text">%</span>
+              </div>
+            </label>
+            <label>
+              <span>Baseline year</span>
+              <select formControlName="greenhouseReductionBaselineYear"
+                (change)="changeBaselineYear('greenhouseReductionBaselineYear', 'greenhouseReductionTargetYear')">
+                @for (year of years; track year) { <option [ngValue]="year">{{ year }}</option> }
+              </select>
+            </label>
+            <label>
+              <span>Target year</span>
+              <select formControlName="greenhouseReductionTargetYear" (change)="saveGoals()">
+                @for (year of years; track year) { <option [ngValue]="year">{{ year }}</option> }
+              </select>
+            </label>
+            <fieldset>
+              <legend>Goal type</legend>
+              <label class="v1-settings-choice">
+                <input type="radio" formControlName="greenhouseIsAbsolute" [value]="true" (change)="saveGoals()">
+                <span>Absolute</span>
+              </label>
+              <label class="v1-settings-choice">
+                <input type="radio" formControlName="greenhouseIsAbsolute" [value]="false" (change)="saveGoals()">
+                <span>Intensity</span>
+              </label>
+            </fieldset>
+          </div>
+        }
+      </div>
+    }
+  </form>
+}

--- a/src/app/v1/account/settings/goals/account-settings-goals.component.ts
+++ b/src/app/v1/account/settings/goals/account-settings-goals.component.ts
@@ -1,0 +1,90 @@
+import { Component, effect, inject, untracked } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { IdbAccount } from '@data/models/idbModels/account';
+import { AccountSettingsFormService } from '@shared/settings-forms/account-settings-form.service';
+import { AccountSettingsDetailBase } from '../account-settings-detail.base';
+
+@Component({
+  selector: 'app-account-settings-goals',
+  templateUrl: './account-settings-goals.component.html',
+  styleUrls: ['../account-settings.component.css'],
+  host: { style: 'display: block;' },
+  standalone: false
+})
+export class AccountSettingsGoalsComponent extends AccountSettingsDetailBase {
+  private readonly settingsForms = inject(AccountSettingsFormService);
+
+  readonly years = Array.from({ length: 50 }, (_, index) => 2050 - index);
+  readonly assessmentReportVersions = ['AR4', 'AR5', 'AR6'];
+  form: FormGroup;
+
+  constructor() {
+    super();
+    effect(() => {
+      const account = this.account();
+      if (!account) {
+        return;
+      }
+      if (this.skipNextWorkspaceRefresh) {
+        this.skipNextWorkspaceRefresh = false;
+        return;
+      }
+      this.buildForm(account);
+    });
+    effect(() => {
+      this.applyFormAvailability(this.canWrite());
+    });
+  }
+
+  scheduleGoalsSave(): void {
+    this.scheduleSave(() => this.saveGoals());
+  }
+
+  flushGoalsSave(): void {
+    this.flushSave(() => this.saveGoals());
+  }
+
+  async saveGoals(): Promise<void> {
+    if (!this.form) {
+      return;
+    }
+    this.applyFormAvailability(this.canWrite());
+    await this.saveAccount('Saving goal settings', account =>
+      this.settingsForms.updateAccountFromSustainabilityQuestionsForm(this.form, account)
+    );
+  }
+
+  async changeBaselineYear(baselineControl: string, targetControl: string): Promise<void> {
+    const baseline = Number(this.form.controls[baselineControl].value);
+    this.form.controls[targetControl].patchValue(Math.min(baseline + 10, 2050));
+    await this.saveGoals();
+  }
+
+  private buildForm(account: IdbAccount): void {
+    this.form = this.settingsForms.getSustainabilityQuestionsForm(account);
+    this.applyFormAvailability(untracked(() => this.canWrite()));
+  }
+
+  private applyFormAvailability(canWrite: boolean): void {
+    this.setFormEnabled(this.form, canWrite);
+    this.setGoalControlsEnabled('energy', canWrite && !!this.form?.controls['energyReductionGoal'].value);
+    this.setGoalControlsEnabled('water', canWrite && !!this.form?.controls['waterReductionGoal'].value);
+    this.setControlEnabled(
+      this.form?.controls['assessmentReportVersion'],
+      canWrite && !!this.form?.controls['displayEmissions'].value
+    );
+    this.setGoalControlsEnabled(
+      'greenhouse',
+      canWrite && !!this.form?.controls['displayEmissions'].value && !!this.form?.controls['greenhouseReductionGoal'].value
+    );
+  }
+
+  private setGoalControlsEnabled(goal: 'energy' | 'water' | 'greenhouse', enabled: boolean): void {
+    this.setControlsEnabled(this.form, [
+      `${goal}ReductionPercent`,
+      `${goal}ReductionBaselineYear`,
+      `${goal}ReductionTargetYear`,
+      `${goal}IsAbsolute`
+    ], enabled);
+  }
+}

--- a/src/app/v1/account/settings/profile/account-settings-profile.component.html
+++ b/src/app/v1/account/settings/profile/account-settings-profile.component.html
@@ -1,0 +1,116 @@
+@if (form) {
+  <form class="v1-settings-panel" [formGroup]="form" aria-label="Corporate information">
+    <div class="v1-settings-panel__heading">
+      <div>
+        <p>Profile</p>
+        <h2>Corporate information</h2>
+      </div>
+      <span class="v1-settings-panel__status" [class.v1-settings-panel__status--error]="saveState === 'error'">
+        @if (saveState === 'saving') {
+          <span class="fa fa-circle-notch fa-spin" aria-hidden="true"></span>
+          Saving
+        } @else if (saveState === 'saved') {
+          <span class="fa fa-check" aria-hidden="true"></span>
+          Saved
+        } @else if (saveState === 'error') {
+          <span class="fa fa-triangle-exclamation" aria-hidden="true"></span>
+          Not saved
+        }
+      </span>
+    </div>
+
+    <div class="v1-settings-grid v1-settings-grid--2">
+      <label>
+        <span>Account name</span>
+        <input type="text" formControlName="name" maxlength="42"
+          (input)="scheduleProfileSave()" (blur)="flushProfileSave()">
+        @if (form.controls['name'].invalid && (form.controls['name'].dirty || form.controls['name'].touched)) {
+          <em>Name is required.</em>
+        }
+      </label>
+      <label>
+        <span>Country</span>
+        <select formControlName="country" (change)="saveProfile()">
+          @for (country of countries; track country.code) {
+            <option [ngValue]="country.code">{{ country.name }}</option>
+          }
+        </select>
+      </label>
+    </div>
+
+    <label>
+      <span>Address</span>
+      <input type="text" formControlName="address" (input)="scheduleProfileSave()" (blur)="flushProfileSave()">
+    </label>
+
+    <div class="v1-settings-grid v1-settings-grid--3">
+      <label>
+        <span>City</span>
+        <input type="text" formControlName="city" (input)="scheduleProfileSave()" (blur)="flushProfileSave()">
+      </label>
+      @if (form.controls['country'].value === 'US') {
+        <label>
+          <span>State</span>
+          <input type="text" formControlName="state" (input)="scheduleProfileSave()" (blur)="flushProfileSave()">
+        </label>
+        <label>
+          <span>Zip</span>
+          <input type="text" formControlName="zip" (input)="scheduleProfileSave()" (blur)="flushProfileSave()">
+        </label>
+      }
+    </div>
+
+    <div class="v1-settings-grid v1-settings-grid--3">
+      <label>
+        <span>NAICS level 1</span>
+        <select formControlName="naics1" (change)="checkNAICS()">
+          <option [ngValue]="null"></option>
+          @for (naics of firstNaicsList; track naics.code) {
+            <option [ngValue]="naics.code">{{ naics.code }} - {{ naics.industryType }}</option>
+          }
+        </select>
+      </label>
+      <label>
+        <span>NAICS level 2</span>
+        <select formControlName="naics2" (change)="checkNAICS()">
+          <option [ngValue]="null"></option>
+          @for (naics of secondNaicsOptions(form.controls['naics1'].value); track naics.code) {
+            <option [ngValue]="naics.code">{{ naics.code }} - {{ naics.industryType }}</option>
+          }
+        </select>
+      </label>
+      <label>
+        <span>NAICS level 3</span>
+        <select formControlName="naics3" (change)="checkNAICS()">
+          <option [ngValue]="null"></option>
+          @for (naics of thirdNaicsOptions(form.controls['naics2'].value); track naics.code) {
+            <option [ngValue]="naics.code">{{ naics.code }} - {{ naics.industryType }}</option>
+          }
+        </select>
+      </label>
+    </div>
+
+    <label>
+      <span>Notes</span>
+      <textarea formControlName="notes" (input)="scheduleProfileSave()" (blur)="flushProfileSave()"></textarea>
+    </label>
+
+    <div class="v1-settings-grid v1-settings-grid--3">
+      <label>
+        <span>Contact name</span>
+        <input type="text" formControlName="contactName" maxlength="60"
+          (input)="scheduleProfileSave()" (blur)="flushProfileSave()">
+      </label>
+      <label>
+        <span>Contact phone</span>
+        <input type="text" formControlName="contactPhone" maxlength="12"
+          (input)="formatPhone($event)" (blur)="flushProfileSave()">
+      </label>
+      <label>
+        <span>Contact email</span>
+        <input type="email" formControlName="contactEmail" maxlength="85"
+          (input)="scheduleProfileSave()" (blur)="flushProfileSave()">
+      </label>
+    </div>
+  </form>
+}

--- a/src/app/v1/account/settings/profile/account-settings-profile.component.ts
+++ b/src/app/v1/account/settings/profile/account-settings-profile.component.ts
@@ -1,0 +1,117 @@
+import { Component, effect, inject, untracked } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { Countries } from '@shared/form-data/countries';
+import { FirstNaicsList, NAICS, SecondNaicsList, ThirdNaicsList } from '@shared/form-data/naics-data';
+import { AccountSettingsFormService } from '@shared/settings-forms/account-settings-form.service';
+import { IdbAccount } from '@data/models/idbModels/account';
+import { AccountSettingsDetailBase } from '../account-settings-detail.base';
+
+@Component({
+  selector: 'app-account-settings-profile',
+  templateUrl: './account-settings-profile.component.html',
+  styleUrls: ['../account-settings.component.css'],
+  host: { style: 'display: block;' },
+  standalone: false
+})
+export class AccountSettingsProfileComponent extends AccountSettingsDetailBase {
+  private readonly settingsForms = inject(AccountSettingsFormService);
+
+  readonly countries = Countries;
+  readonly firstNaicsList = FirstNaicsList;
+  form: FormGroup;
+
+  constructor() {
+    super();
+    effect(() => {
+      const account = this.account();
+      if (!account) {
+        return;
+      }
+      if (this.skipNextWorkspaceRefresh) {
+        this.skipNextWorkspaceRefresh = false;
+        return;
+      }
+      this.buildForm(account);
+    });
+    effect(() => {
+      this.applyFormAvailability(this.canWrite());
+    });
+  }
+
+  secondNaicsOptions(parentCode: string | undefined): NAICS[] {
+    return parentCode ? SecondNaicsList.filter(item => item.matchNum === parentCode) : [];
+  }
+
+  thirdNaicsOptions(parentCode: string | undefined): NAICS[] {
+    return parentCode ? ThirdNaicsList.filter(item => item.matchNum === parentCode) : [];
+  }
+
+  scheduleProfileSave(): void {
+    this.scheduleSave(() => this.saveProfile());
+  }
+
+  flushProfileSave(): void {
+    this.flushSave(() => this.saveProfile());
+  }
+
+  async saveProfile(): Promise<void> {
+    this.normalizeRequiredProfileText();
+    if (!this.form || this.form.invalid) {
+      this.form?.markAllAsTouched();
+      return;
+    }
+    await this.saveAccount('Saving profile settings', account =>
+      this.settingsForms.updateAccountFromGeneralInformationForm(this.form, account)
+    );
+  }
+
+  checkNAICS(): void {
+    const naics1 = this.form.controls['naics1'].value;
+    const naics2 = this.form.controls['naics2'].value;
+    const naics3 = this.form.controls['naics3'].value;
+    if (naics2 && !this.secondNaicsOptions(naics1).some(item => item.code === naics2)) {
+      this.form.controls['naics2'].patchValue(null);
+      this.form.controls['naics3'].patchValue(null);
+    }
+    if (naics3 && !this.thirdNaicsOptions(this.form.controls['naics2'].value).some(item => item.code === naics3)) {
+      this.form.controls['naics3'].patchValue(null);
+    }
+    this.applyFormAvailability(this.canWrite());
+    void this.saveProfile();
+  }
+
+  formatPhone(event: Event): void {
+    if (this.form.controls['country'].value === 'US') {
+      let input = (event.target as HTMLInputElement).value.replace(/\D/g, '');
+      if (input.length > 3 && input.length <= 6) {
+        input = input.replace(/(\d{3})(\d+)/, '$1-$2');
+      } else if (input.length > 6) {
+        input = input.replace(/(\d{3})(\d{3})(\d+)/, '$1-$2-$3');
+      }
+      this.form.controls['contactPhone'].setValue(input.substring(0, 12), { emitEvent: false });
+    }
+    this.scheduleProfileSave();
+  }
+
+  private buildForm(account: IdbAccount): void {
+    this.form = this.settingsForms.getGeneralInformationForm(account);
+    this.applyFormAvailability(untracked(() => this.canWrite()));
+  }
+
+  private normalizeRequiredProfileText(): void {
+    if (!this.form) {
+      return;
+    }
+    const nameControl = this.form.controls['name'];
+    const trimmedName = String(nameControl.value || '').trim();
+    if (nameControl.value !== trimmedName) {
+      nameControl.setValue(trimmedName, { emitEvent: false });
+    }
+  }
+
+  private applyFormAvailability(canWrite: boolean): void {
+    this.setFormEnabled(this.form, canWrite);
+    this.setControlEnabled(this.form?.controls['naics2'], canWrite && !!this.form?.controls['naics1'].value);
+    this.setControlEnabled(this.form?.controls['naics3'], canWrite && !!this.form?.controls['naics2'].value);
+  }
+}

--- a/src/app/v1/account/settings/staleness/account-settings-staleness.component.html
+++ b/src/app/v1/account/settings/staleness/account-settings-staleness.component.html
@@ -1,0 +1,37 @@
+@if (form) {
+  <form class="v1-settings-panel" [formGroup]="form" aria-label="Data staleness">
+    <div class="v1-settings-panel__heading">
+      <div>
+        <p>Data quality</p>
+        <h2>Data staleness alerts</h2>
+      </div>
+      <span class="v1-settings-panel__status" [class.v1-settings-panel__status--error]="saveState === 'error'">
+        @if (saveState === 'saving') {
+          <span class="fa fa-circle-notch fa-spin" aria-hidden="true"></span>
+          Saving
+        } @else if (saveState === 'saved') {
+          <span class="fa fa-check" aria-hidden="true"></span>
+          Saved
+        } @else if (saveState === 'error') {
+          <span class="fa fa-triangle-exclamation" aria-hidden="true"></span>
+          Not saved
+        }
+      </span>
+    </div>
+
+    <label class="v1-settings-choice v1-settings-choice--block">
+      <input type="checkbox" formControlName="enabled" (change)="saveStaleness()">
+      <span>Enable time-based staleness alerts</span>
+    </label>
+    @if (form.controls['enabled'].value) {
+      <label>
+        <span>Alert when data is older than</span>
+        <select formControlName="thresholdMonths" (change)="saveStaleness()">
+          @for (option of stalenessOptions; track option.value) {
+            <option [ngValue]="option.value">{{ option.label }}</option>
+          }
+        </select>
+      </label>
+    }
+  </form>
+}

--- a/src/app/v1/account/settings/staleness/account-settings-staleness.component.ts
+++ b/src/app/v1/account/settings/staleness/account-settings-staleness.component.ts
@@ -1,0 +1,61 @@
+import { Component, effect, inject, untracked } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { IdbAccount } from '@data/models/idbModels/account';
+import { DATA_STALENESS_OPTIONS } from '@domain/calculations/status-check-calculations/statusCheckModels';
+import { AccountSettingsFormService } from '@shared/settings-forms/account-settings-form.service';
+import { AccountSettingsDetailBase } from '../account-settings-detail.base';
+
+@Component({
+  selector: 'app-account-settings-staleness',
+  templateUrl: './account-settings-staleness.component.html',
+  styleUrls: ['../account-settings.component.css'],
+  host: { style: 'display: block;' },
+  standalone: false
+})
+export class AccountSettingsStalenessComponent extends AccountSettingsDetailBase {
+  private readonly settingsForms = inject(AccountSettingsFormService);
+
+  readonly stalenessOptions = DATA_STALENESS_OPTIONS;
+  form: FormGroup;
+
+  constructor() {
+    super();
+    effect(() => {
+      const account = this.account();
+      if (!account) {
+        return;
+      }
+      if (this.skipNextWorkspaceRefresh) {
+        this.skipNextWorkspaceRefresh = false;
+        return;
+      }
+      this.buildForm(account);
+    });
+    effect(() => {
+      this.applyFormAvailability(this.canWrite());
+    });
+  }
+
+  async saveStaleness(): Promise<void> {
+    if (!this.form) {
+      return;
+    }
+    this.applyFormAvailability(this.canWrite());
+    await this.saveAccount('Saving data staleness settings', account =>
+      this.settingsForms.updateAccountFromStalenessForm(this.form, account)
+    );
+  }
+
+  private buildForm(account: IdbAccount): void {
+    this.form = this.settingsForms.getStalenessForm(account.dataStalenessSettings);
+    this.applyFormAvailability(untracked(() => this.canWrite()));
+  }
+
+  private applyFormAvailability(canWrite: boolean): void {
+    this.setFormEnabled(this.form, canWrite);
+    this.setControlEnabled(
+      this.form?.controls['thresholdMonths'],
+      canWrite && !!this.form?.controls['enabled'].value
+    );
+  }
+}

--- a/src/app/v1/account/settings/units/account-settings-units.component.html
+++ b/src/app/v1/account/settings/units/account-settings-units.component.html
@@ -1,0 +1,96 @@
+@if (form) {
+  <form class="v1-settings-panel" [formGroup]="form" aria-label="Account units">
+    <div class="v1-settings-panel__heading">
+      <div>
+        <p>Units</p>
+        <h2>Units of measure</h2>
+      </div>
+      <span class="v1-settings-panel__status" [class.v1-settings-panel__status--error]="saveState === 'error'">
+        @if (saveState === 'saving') {
+          <span class="fa fa-circle-notch fa-spin" aria-hidden="true"></span>
+          Saving
+        } @else if (saveState === 'saved') {
+          <span class="fa fa-check" aria-hidden="true"></span>
+          Saved
+        } @else if (saveState === 'error') {
+          <span class="fa fa-triangle-exclamation" aria-hidden="true"></span>
+          Not saved
+        }
+      </span>
+    </div>
+
+    <div class="v1-settings-grid v1-settings-grid--2">
+      <label>
+        <span>Units of measure</span>
+        <select formControlName="unitsOfMeasure" (change)="setUnitsOfMeasure()">
+          <option [ngValue]="'Imperial'">Imperial</option>
+          <option [ngValue]="'Metric'">Metric</option>
+          <option [ngValue]="'Custom'">Custom</option>
+        </select>
+      </label>
+      <fieldset>
+        <legend>Energy boundary</legend>
+        <label class="v1-settings-choice">
+          <input type="radio" formControlName="energyIsSource" [value]="true" (change)="saveUnits()">
+          <span>Source energy</span>
+        </label>
+        <label class="v1-settings-choice">
+          <input type="radio" formControlName="energyIsSource" [value]="false" (change)="saveUnits()">
+          <span>Site energy</span>
+        </label>
+      </fieldset>
+    </div>
+
+    <div class="v1-settings-grid v1-settings-grid--2">
+      <label>
+        <span>Result energy unit</span>
+        <select formControlName="energyUnit" (change)="saveUnits()">
+          @for (option of energyUnitOptions; track option.value) {
+            <option [ngValue]="option.value" [innerHTML]="option.display"></option>
+          }
+        </select>
+      </label>
+      <label>
+        <span>Electricity unit</span>
+        <select formControlName="electricityUnit" (change)="saveUnits()">
+          @for (option of energyUnitOptions; track option.value) {
+            <option [ngValue]="option.value" [innerHTML]="option.display"></option>
+          }
+        </select>
+      </label>
+      <label>
+        <span>Liquid volume unit</span>
+        <select formControlName="volumeLiquidUnit" (change)="saveUnits()">
+          @for (option of volumeLiquidOptions; track option.value) {
+            <option [ngValue]="option.value" [innerHTML]="option.display"></option>
+          }
+        </select>
+      </label>
+      <label>
+        <span>Gas volume unit</span>
+        <select formControlName="volumeGasUnit" (change)="saveUnits()">
+          @for (option of volumeGasOptions; track option.value) {
+            <option [ngValue]="option.value" [innerHTML]="option.display"></option>
+          }
+        </select>
+      </label>
+      <label>
+        <span>Mass unit</span>
+        <select formControlName="massUnit" (change)="saveUnits()">
+          @for (option of massUnitOptions; track option.value) {
+            <option [ngValue]="option.value" [innerHTML]="option.display"></option>
+          }
+        </select>
+      </label>
+      <label>
+        <span>eGRID subregion</span>
+        <select formControlName="eGridSubregion" (change)="saveUnits()">
+          @for (subregion of subregionOptions(); track subregion) {
+            <option [ngValue]="subregion">{{ subregion }}</option>
+          }
+        </select>
+      </label>
+    </div>
+
+  </form>
+}

--- a/src/app/v1/account/settings/units/account-settings-units.component.ts
+++ b/src/app/v1/account/settings/units/account-settings-units.component.ts
@@ -1,0 +1,93 @@
+import { Component, computed, effect, inject, untracked } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { IdbAccount } from '@data/models/idbModels/account';
+import { EGridService } from '@shared/helper-services/e-grid.service';
+import { AccountSettingsFormService } from '@shared/settings-forms/account-settings-form.service';
+import { EnergyUnitOptions, MassUnitOptions, VolumeGasOptions, VolumeLiquidOptions } from '@shared/unitOptions';
+import { AccountSettingsDetailBase } from '../account-settings-detail.base';
+
+@Component({
+  selector: 'app-account-settings-units',
+  templateUrl: './account-settings-units.component.html',
+  styleUrls: ['../account-settings.component.css'],
+  host: { style: 'display: block;' },
+  standalone: false
+})
+export class AccountSettingsUnitsComponent extends AccountSettingsDetailBase {
+  private readonly settingsForms = inject(AccountSettingsFormService);
+  private readonly eGridService = inject(EGridService);
+
+  readonly energyUnitOptions = EnergyUnitOptions;
+  readonly volumeLiquidOptions = VolumeLiquidOptions;
+  readonly volumeGasOptions = VolumeGasOptions;
+  readonly massUnitOptions = MassUnitOptions;
+  readonly subregionOptions = computed(() => this.getSubregionOptions(this.account()?.zip));
+  form: FormGroup;
+
+  constructor() {
+    super();
+    effect(() => {
+      const account = this.account();
+      if (!account) {
+        return;
+      }
+      if (this.skipNextWorkspaceRefresh) {
+        this.skipNextWorkspaceRefresh = false;
+        return;
+      }
+      this.buildForm(account);
+    });
+    effect(() => {
+      this.applyFormAvailability(this.canWrite());
+    });
+  }
+
+  async setUnitsOfMeasure(): Promise<void> {
+    this.form = this.settingsForms.setUnitsOfMeasure(this.form);
+    this.ensureSelectedSubregion();
+    this.applyFormAvailability(this.canWrite());
+    await this.saveUnits();
+  }
+
+  async saveUnits(): Promise<void> {
+    if (!this.form) {
+      return;
+    }
+    this.form = this.settingsForms.checkCustom(this.form);
+    this.ensureSelectedSubregion();
+    this.applyFormAvailability(this.canWrite());
+    await this.saveAccount('Saving unit settings', account =>
+      this.settingsForms.updateAccountFromUnitsForm(this.form, account)
+    );
+  }
+
+  private buildForm(account: IdbAccount): void {
+    this.form = this.settingsForms.getUnitsForm(account);
+    this.ensureSelectedSubregion();
+    this.applyFormAvailability(untracked(() => this.canWrite()));
+  }
+
+  private getSubregionOptions(zip: string | undefined): string[] {
+    const options = ['US Average'];
+    if (zip && zip.length === 5) {
+      const match = this.eGridService.subRegionsByZipcode.find(item => String(item.zip) === zip);
+      match?.subregions.filter(Boolean).forEach(subregion => options.unshift(subregion));
+    }
+    this.workspace.customEmissions().forEach(item => options.push(item.subregion));
+    return [...new Set(options)];
+  }
+
+  private ensureSelectedSubregion(): void {
+    if (!this.form) {
+      return;
+    }
+    const current = this.form.controls['eGridSubregion'].value;
+    if (!current || !this.subregionOptions().includes(current)) {
+      this.form.controls['eGridSubregion'].patchValue(this.subregionOptions()[0], { emitEvent: false });
+    }
+  }
+
+  private applyFormAvailability(canWrite: boolean): void {
+    this.setFormEnabled(this.form, canWrite);
+  }
+}

--- a/src/app/v1/facility/home/facility-home.component.css
+++ b/src/app/v1/facility/home/facility-home.component.css
@@ -5,22 +5,6 @@
   padding: clamp(1rem, 3vw, 1.5rem);
 }
 
-.v1-home h1,
-.v1-home p {
-  margin: 0;
-}
-
-.v1-home h1 {
-  color: var(--v1-text);
-  font-size: 1.8rem;
-  line-height: 1.15;
-}
-
-.v1-home__summary {
-  max-width: 44rem;
-  color: var(--v1-muted);
-}
-
 .v1-home__metrics {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));

--- a/src/app/v1/facility/home/facility-home.component.html
+++ b/src/app/v1/facility/home/facility-home.component.html
@@ -2,12 +2,14 @@
   @if (navigation.facility(); as facility) {
     @let content = navigation.panelContent();
 
-    <p class="v1-eyebrow">Facility Home</p>
-    <h1 id="v1-facility-home-title">{{ facility.name }}</h1>
-    <p class="v1-home__summary">
-      Facility workspace shell is ready for {{ facility.name }}. Facility-specific data, analysis, and reporting pages
-      will plug into this frame as v1 workflows migrate.
-    </p>
+    <header class="v1-section-header">
+      <p class="v1-eyebrow">Facility Home</p>
+      <h1 id="v1-facility-home-title">{{ facility.name }}</h1>
+      <p class="v1-section-header__summary">
+        Facility workspace shell is ready for {{ facility.name }}. Facility-specific data, analysis, and reporting pages
+        will plug into this frame as v1 workflows migrate.
+      </p>
+    </header>
 
     <div class="v1-home__metrics" aria-label="Facility summary">
       <article>

--- a/src/app/v1/shell/modal-portal.service.ts
+++ b/src/app/v1/shell/modal-portal.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, signal } from '@angular/core';
+import { Portal } from '@angular/cdk/portal';
+
+/**
+ * Allows components inside the isolated workspace stacking context to render
+ * modal layers at the shell root level, where they paint above the header and
+ * side panels.
+ */
+@Injectable({ providedIn: 'root' })
+export class ModalPortalService {
+  readonly activePortal = signal<Portal<unknown> | null>(null);
+
+  show(portal: Portal<unknown>): void {
+    this.activePortal.set(portal);
+  }
+
+  hide(): void {
+    this.activePortal.set(null);
+  }
+}

--- a/src/app/v1/shell/primary-rail/primary-rail.component.html
+++ b/src/app/v1/shell/primary-rail/primary-rail.component.html
@@ -5,8 +5,9 @@
     @if (section.enabled) {
       <button
         type="button"
-        class="active"
-        [attr.aria-current]="activeSection === section.id ? 'page' : null">
+        [class.active]="activeSection === section.id"
+        [attr.aria-current]="activeSection === section.id ? 'page' : null"
+        (click)="navigation.openSection(section.id)">
         <span [class]="'fa ' + section.icon" aria-hidden="true"></span>
         <span>{{ section.shortLabel }}</span>
       </button>

--- a/src/app/v1/shell/section-nav/section-nav.component.css
+++ b/src/app/v1/shell/section-nav/section-nav.component.css
@@ -108,6 +108,16 @@
   box-shadow: inset 3px 0 0 var(--v1-facility);
 }
 
+.v1-nav__group a.v1-nav__item--danger {
+  color: var(--v1-danger);
+}
+
+.v1-nav__group a.v1-nav__item--danger.active {
+  border-color: color-mix(in srgb, var(--v1-danger) 38%, var(--v1-border));
+  background: color-mix(in srgb, var(--v1-danger) 8%, var(--v1-surface));
+  box-shadow: inset 3px 0 0 var(--v1-danger);
+}
+
 .v1-nav__group button:disabled {
   cursor: not-allowed;
   opacity: .58;

--- a/src/app/v1/shell/section-nav/section-nav.component.html
+++ b/src/app/v1/shell/section-nav/section-nav.component.html
@@ -44,6 +44,7 @@
           @for (item of settingsItems; track item.id) {
             <a
               [class.active]="navigation.activeDetail() === item.id"
+              [class.v1-nav__item--danger]="item.tone === 'danger'"
               [routerLink]="navigation.accountSettingsRoute(account.guid, item.id)"
               [attr.aria-current]="navigation.activeDetail() === item.id ? 'page' : null">
               <span [class]="'fa ' + item.icon" aria-hidden="true"></span>

--- a/src/app/v1/shell/section-nav/section-nav.component.html
+++ b/src/app/v1/shell/section-nav/section-nav.component.html
@@ -22,22 +22,42 @@
     </button>
   </div>
 
-  <section class="v1-nav__group" aria-labelledby="v1-home-nav-title">
-    <span id="v1-home-nav-title" class="v1-nav__label">Home</span>
-    <a
-      class="active"
-      [routerLink]="contextMode === 'facility' && selectedFacility
-        ? navigation.facilityRoute(selectedFacility.guid)
-        : navigation.accountRoute(account!.guid)"
-      aria-current="page">
-      <span class="fa fa-chart-pie" aria-hidden="true"></span>
-      Overview
-    </a>
-  </section>
-
-  <section class="v1-nav__group" aria-labelledby="v1-future-nav-title">
-    <span id="v1-future-nav-title" class="v1-nav__label">Coming next</span>
-    <button type="button" disabled>Goal progress</button>
-    <button type="button" disabled>Todo list</button>
-  </section>
+  @switch (navigation.activeSection()) {
+    @case ('home') {
+      <section class="v1-nav__group" aria-labelledby="v1-home-nav-title">
+        <span id="v1-home-nav-title" class="v1-nav__label">{{ contextMode === 'account' ? 'Account Home' : 'Facility Home' }}</span>
+        <a
+          class="active"
+          [routerLink]="contextMode === 'facility' && selectedFacility
+            ? navigation.facilityRoute(selectedFacility.guid)
+            : navigation.accountRoute(account!.guid)"
+          aria-current="page">
+          <span class="fa fa-chart-pie" aria-hidden="true"></span>
+          Overview
+        </a>
+      </section>
+    }
+    @case ('settings') {
+      @if (contextMode === 'account' && account) {
+        <section class="v1-nav__group" aria-labelledby="v1-settings-nav-title">
+          <span id="v1-settings-nav-title" class="v1-nav__label">Account Settings</span>
+          @for (item of settingsItems; track item.id) {
+            <a
+              [class.active]="navigation.activeDetail() === item.id"
+              [routerLink]="navigation.accountSettingsRoute(account.guid, item.id)"
+              [attr.aria-current]="navigation.activeDetail() === item.id ? 'page' : null">
+              <span [class]="'fa ' + item.icon" aria-hidden="true"></span>
+              {{ item.label }}
+            </a>
+          }
+        </section>
+      }
+    }
+    @default {
+      <section class="v1-nav__group" aria-labelledby="v1-future-nav-title">
+        <span id="v1-future-nav-title" class="v1-nav__label">{{ navigation.activeSection() }}</span>
+        <button type="button" disabled>Available in current VERIFI</button>
+      </section>
+    }
+  }
 </aside>

--- a/src/app/v1/shell/section-nav/section-nav.component.spec.ts
+++ b/src/app/v1/shell/section-nav/section-nav.component.spec.ts
@@ -48,6 +48,7 @@ describe('SectionNavComponent', () => {
 
     expect(fixture.nativeElement.textContent).toContain('Account Settings');
     expect(fixture.nativeElement.textContent).toContain('Profile');
+    expect(fixture.nativeElement.textContent).toContain('Delete account');
     expect(fixture.nativeElement.textContent).not.toContain('Account Home');
     expect(fixture.nativeElement.textContent).not.toContain('Overview');
   });

--- a/src/app/v1/shell/section-nav/section-nav.component.spec.ts
+++ b/src/app/v1/shell/section-nav/section-nav.component.spec.ts
@@ -1,0 +1,54 @@
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { RouterModule } from '@angular/router';
+import { WorkspaceNavigationService } from '../workspace-navigation.service';
+import { SectionNavComponent } from './section-nav.component';
+
+describe('SectionNavComponent', () => {
+  let activeSection: ReturnType<typeof signal<string>>;
+
+  beforeEach(() => {
+    activeSection = signal('home');
+    TestBed.configureTestingModule({
+      declarations: [SectionNavComponent],
+      imports: [RouterModule.forRoot([])],
+      providers: [
+        {
+          provide: WorkspaceNavigationService,
+          useValue: {
+            contextMode: signal('account'),
+            facilities: signal([]),
+            facility: signal(undefined),
+            account: signal({ guid: 'account-a', name: 'Account A' }),
+            activeSection,
+            activeDetail: signal('profile'),
+            accountRoute: () => ['/v1', 'workspace', 'account', 'account-a', 'home', 'overview'],
+            facilityRoute: () => ['/v1', 'workspace', 'facility', 'facility-a', 'home', 'overview'],
+            accountSettingsRoute: (_accountGuid: string, detail = 'profile') => ['/v1', 'workspace', 'account', 'account-a', 'settings', detail],
+            setContext: () => undefined
+          }
+        }
+      ]
+    });
+  });
+
+  it('shows home navigation only when the Home rail section is active', () => {
+    const fixture = TestBed.createComponent(SectionNavComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Account Home');
+    expect(fixture.nativeElement.textContent).toContain('Overview');
+    expect(fixture.nativeElement.textContent).not.toContain('Account Settings');
+  });
+
+  it('shows account settings navigation only when the Settings rail section is active', () => {
+    activeSection.set('settings');
+    const fixture = TestBed.createComponent(SectionNavComponent);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain('Account Settings');
+    expect(fixture.nativeElement.textContent).toContain('Profile');
+    expect(fixture.nativeElement.textContent).not.toContain('Account Home');
+    expect(fixture.nativeElement.textContent).not.toContain('Overview');
+  });
+});

--- a/src/app/v1/shell/section-nav/section-nav.component.ts
+++ b/src/app/v1/shell/section-nav/section-nav.component.ts
@@ -1,14 +1,22 @@
 import { Component, inject } from '@angular/core';
 import { WorkspaceNavigationService } from '../workspace-navigation.service';
 
-const ACCOUNT_SETTINGS_ITEMS = [
+type AccountSettingsNavItem = {
+  readonly id: string;
+  readonly label: string;
+  readonly icon: string;
+  readonly tone?: 'danger';
+};
+
+const ACCOUNT_SETTINGS_ITEMS: ReadonlyArray<AccountSettingsNavItem> = [
   { id: 'profile', label: 'Profile', icon: 'fa-building' },
   { id: 'units', label: 'Units', icon: 'fa-ruler-combined' },
   { id: 'goals', label: 'Goals', icon: 'fa-bullseye' },
   { id: 'financial', label: 'Financial', icon: 'fa-calendar-days' },
   { id: 'staleness', label: 'Staleness', icon: 'fa-clock' },
-  { id: 'backup', label: 'Backup', icon: 'fa-file-arrow-down' }
-] as const;
+  { id: 'backup', label: 'Backup', icon: 'fa-file-arrow-down' },
+  { id: 'delete', label: 'Delete account', icon: 'fa-trash', tone: 'danger' }
+];
 
 @Component({
   selector: 'app-section-nav',

--- a/src/app/v1/shell/section-nav/section-nav.component.ts
+++ b/src/app/v1/shell/section-nav/section-nav.component.ts
@@ -1,6 +1,15 @@
 import { Component, inject } from '@angular/core';
 import { WorkspaceNavigationService } from '../workspace-navigation.service';
 
+const ACCOUNT_SETTINGS_ITEMS = [
+  { id: 'profile', label: 'Profile', icon: 'fa-building' },
+  { id: 'units', label: 'Units', icon: 'fa-ruler-combined' },
+  { id: 'goals', label: 'Goals', icon: 'fa-bullseye' },
+  { id: 'financial', label: 'Financial', icon: 'fa-calendar-days' },
+  { id: 'staleness', label: 'Staleness', icon: 'fa-clock' },
+  { id: 'backup', label: 'Backup', icon: 'fa-file-arrow-down' }
+] as const;
+
 @Component({
   selector: 'app-section-nav',
   templateUrl: './section-nav.component.html',
@@ -9,4 +18,5 @@ import { WorkspaceNavigationService } from '../workspace-navigation.service';
 })
 export class SectionNavComponent {
   readonly navigation = inject(WorkspaceNavigationService);
+  readonly settingsItems = ACCOUNT_SETTINGS_ITEMS;
 }

--- a/src/app/v1/shell/shell.component.html
+++ b/src/app/v1/shell/shell.component.html
@@ -23,4 +23,5 @@
     [@.disabled]="prefersReducedMotion()">
     <router-outlet></router-outlet>
   </div>
+  <ng-container [cdkPortalOutlet]="modalPortal.activePortal()"></ng-container>
 </section>

--- a/src/app/v1/shell/shell.component.spec.ts
+++ b/src/app/v1/shell/shell.component.spec.ts
@@ -1,4 +1,5 @@
 import { CommonModule } from '@angular/common';
+import { PortalModule } from '@angular/cdk/portal';
 import { NgModule } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -10,7 +11,7 @@ import { ShellComponent } from './shell.component';
 import { WorkspaceNavigationService } from './workspace-navigation.service';
 
 @NgModule({
-  imports: [CommonModule, NoopAnimationsModule, RouterModule.forRoot([])],
+  imports: [CommonModule, NoopAnimationsModule, PortalModule, RouterModule.forRoot([])],
   declarations: [ShellComponent, ShellHeaderComponent]
 })
 class ShellTestModule { }

--- a/src/app/v1/shell/shell.component.ts
+++ b/src/app/v1/shell/shell.component.ts
@@ -4,6 +4,7 @@ import { NavigationEnd, Router } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { filter } from 'rxjs';
 import { AppearanceService } from '../appearance/appearance.service';
+import { ModalPortalService } from './modal-portal.service';
 
 @Component({
   selector: 'app-shell',
@@ -67,6 +68,7 @@ export class ShellComponent {
   private readonly destroyRef = inject(DestroyRef);
   private readonly router = inject(Router);
   readonly appearance = inject(AppearanceService);
+  readonly modalPortal = inject(ModalPortalService);
   readonly prefersReducedMotion = signal(this.resolveReducedMotionPreference());
   readonly routeMotion = signal(this.resolveRouteMotion());
 

--- a/src/app/v1/shell/workspace-navigation.service.spec.ts
+++ b/src/app/v1/shell/workspace-navigation.service.spec.ts
@@ -11,6 +11,19 @@ describe('WorkspaceNavigationService', () => {
   let service: WorkspaceNavigationService;
   let router: { url: string; events: Subject<unknown>; navigate: ReturnType<typeof vi.fn> };
   let workspaceService: { selectAccount: ReturnType<typeof vi.fn>; selectFacility: ReturnType<typeof vi.fn> };
+  let workspaceStore: {
+    account: ReturnType<typeof vi.fn>;
+    facilities: ReturnType<typeof vi.fn>;
+    selectedFacility: ReturnType<typeof vi.fn>;
+    meters: ReturnType<typeof vi.fn>;
+    facilityMeters: ReturnType<typeof vi.fn>;
+    predictors: ReturnType<typeof vi.fn>;
+    facilityPredictors: ReturnType<typeof vi.fn>;
+    accountAnalyses: ReturnType<typeof vi.fn>;
+    selectedFacilityAnalyses: ReturnType<typeof vi.fn>;
+    accountReports: ReturnType<typeof vi.fn>;
+    selectedFacilityReports: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     router = {
@@ -22,28 +35,26 @@ describe('WorkspaceNavigationService', () => {
       selectAccount: vi.fn().mockResolvedValue('published'),
       selectFacility: vi.fn()
     };
+    workspaceStore = {
+      account: vi.fn(() => ({ guid: 'account-a', name: 'Account A' })),
+      facilities: vi.fn(() => [{ guid: 'facility-a', name: 'Facility A' }]),
+      selectedFacility: vi.fn(() => ({ guid: 'facility-a', name: 'Facility A' })),
+      meters: vi.fn(() => []),
+      facilityMeters: vi.fn(() => []),
+      predictors: vi.fn(() => []),
+      facilityPredictors: vi.fn(() => []),
+      accountAnalyses: vi.fn(() => []),
+      selectedFacilityAnalyses: vi.fn(() => []),
+      accountReports: vi.fn(() => []),
+      selectedFacilityReports: vi.fn(() => [])
+    };
 
     TestBed.configureTestingModule({
       providers: [
         WorkspaceNavigationService,
         { provide: Router, useValue: router },
         { provide: ApplicationLifecycleService, useValue: { usableAccounts: vi.fn(() => []) } },
-        {
-          provide: AccountWorkspaceStore,
-          useValue: {
-            account: vi.fn(() => undefined),
-            facilities: vi.fn(() => []),
-            selectedFacility: vi.fn(() => undefined),
-            meters: vi.fn(() => []),
-            facilityMeters: vi.fn(() => []),
-            predictors: vi.fn(() => []),
-            facilityPredictors: vi.fn(() => []),
-            accountAnalyses: vi.fn(() => []),
-            selectedFacilityAnalyses: vi.fn(() => []),
-            accountReports: vi.fn(() => []),
-            selectedFacilityReports: vi.fn(() => [])
-          }
-        },
+        { provide: AccountWorkspaceStore, useValue: workspaceStore },
         { provide: AccountWorkspaceService, useValue: workspaceService }
       ]
     });
@@ -58,6 +69,14 @@ describe('WorkspaceNavigationService', () => {
       'account-a',
       'home',
       'overview'
+    ]);
+    expect(service.accountSettingsRoute('account-a', 'units')).toEqual([
+      '/v1',
+      'workspace',
+      'account',
+      'account-a',
+      'settings',
+      'units'
     ]);
     expect(service.facilityRoute('facility-a')).toEqual([
       '/v1',
@@ -91,6 +110,51 @@ describe('WorkspaceNavigationService', () => {
       'home',
       'overview'
     ]);
+  });
+
+  it('parses account settings routes and enables settings only for account context', () => {
+    router.events.next(new NavigationEnd(
+      1,
+      '/v1/workspace/account/account-a/settings/financial',
+      '/v1/workspace/account/account-a/settings/financial'
+    ));
+
+    expect(service.activeSection()).toBe('settings');
+    expect(service.activeDetail()).toBe('financial');
+    expect(service.sections().find(section => section.id === 'settings')?.enabled).toBe(true);
+
+    router.events.next(new NavigationEnd(
+      2,
+      '/v1/workspace/facility/facility-a/home/overview',
+      '/v1/workspace/facility/facility-a/home/overview'
+    ));
+
+    expect(service.activeSection()).toBe('home');
+    expect(service.sections().find(section => section.id === 'settings')?.enabled).toBe(false);
+  });
+
+  it('opens account settings from the account section rail only', () => {
+    service.openSection('settings');
+
+    expect(router.navigate).toHaveBeenCalledWith([
+      '/v1',
+      'workspace',
+      'account',
+      'account-a',
+      'settings',
+      'profile'
+    ]);
+
+    router.navigate.mockClear();
+    router.events.next(new NavigationEnd(
+      1,
+      '/v1/workspace/facility/facility-a/home/overview',
+      '/v1/workspace/facility/facility-a/home/overview'
+    ));
+
+    service.openSection('settings');
+
+    expect(router.navigate).not.toHaveBeenCalled();
   });
 
   it('marks route motion when entering the workspace from welcome', () => {

--- a/src/app/v1/shell/workspace-navigation.service.ts
+++ b/src/app/v1/shell/workspace-navigation.service.ts
@@ -50,7 +50,7 @@ export const WORKSPACE_SECTIONS: ReadonlyArray<SectionDefinition> = [
   { id: 'visualization', label: 'Visualization', shortLabel: 'Visuals', icon: 'fa-chart-line', enabled: false },
   { id: 'analysis', label: 'Analysis', shortLabel: 'Analysis', icon: 'fa-chart-simple', enabled: false },
   { id: 'reports', label: 'Reports', shortLabel: 'Reports', icon: 'fa-file-lines', enabled: false },
-  { id: 'settings', label: 'Settings', shortLabel: 'Settings', icon: 'fa-sliders', enabled: false },
+  { id: 'settings', label: 'Settings', shortLabel: 'Settings', icon: 'fa-sliders', enabled: true },
   { id: 'imports', label: 'Imports & Backup', shortLabel: 'Imports', icon: 'fa-file-import', enabled: false }
 ];
 
@@ -62,6 +62,16 @@ export const SUPPORT_PANEL_TABS: ReadonlyArray<PanelTab> = [
 ];
 
 const DEFAULT_PANEL_TAB: PanelTabId = 'help';
+const VALID_SECTION_IDS: ReadonlyArray<SectionId> = ['home', 'data', 'visualization', 'analysis', 'reports', 'settings', 'imports'];
+const DEFAULT_DETAILS: Record<SectionId, string> = {
+  home: 'overview',
+  data: 'facilities',
+  visualization: 'time-series',
+  analysis: 'rollup',
+  reports: 'setup',
+  settings: 'profile',
+  imports: 'template'
+};
 
 @Injectable({ providedIn: 'root' })
 export class WorkspaceNavigationService {
@@ -74,7 +84,10 @@ export class WorkspaceNavigationService {
   private readonly previousUrl = signal(this.router.url);
   private readonly activePanelTabState = signal<PanelTabId>(DEFAULT_PANEL_TAB);
 
-  readonly sections = signal(WORKSPACE_SECTIONS).asReadonly();
+  readonly sections = computed(() => WORKSPACE_SECTIONS.map(section => ({
+    ...section,
+    enabled: section.id === 'settings' ? this.contextMode() === 'account' : section.enabled
+  })));
   readonly panelTabs = signal(SUPPORT_PANEL_TABS).asReadonly();
   readonly isSupportPanelOpen = signal(true);
   readonly activePanelTab = this.activePanelTabState.asReadonly();
@@ -146,8 +159,26 @@ export class WorkspaceNavigationService {
     this.isSupportPanelOpen.set(false);
   }
 
+  openSection(sectionId: SectionId): void {
+    const contextMode = this.contextMode();
+    if (sectionId === 'home') {
+      this.setContext(contextMode);
+      return;
+    }
+    if (sectionId === 'settings' && contextMode === 'account') {
+      const accountGuid = this.account()?.guid || this.routeState().accountGuid;
+      if (accountGuid) {
+        void this.router.navigate(this.accountSettingsRoute(accountGuid));
+      }
+    }
+  }
+
   accountRoute(accountGuid: string): Array<string> {
     return ['/v1', 'workspace', 'account', accountGuid, 'home', 'overview'];
+  }
+
+  accountSettingsRoute(accountGuid: string, detail = 'profile'): Array<string> {
+    return ['/v1', 'workspace', 'account', accountGuid, 'settings', detail];
   }
 
   facilityRoute(facilityGuid: string): Array<string> {
@@ -187,8 +218,8 @@ export class WorkspaceNavigationService {
         'Use the rail and context controls to confirm account and facility navigation before workflow pages are migrated.'
       ],
       todos: [
-        isFacility ? 'Review facility setup and migrated workflow readiness.' : 'Review account setup and portfolio readiness.',
-        'Data, analysis, reports, settings, and import workflows remain in current VERIFI until their v1 slices are built.'
+        isFacility ? 'Review facility setup and migrated workflow readiness.' : this.activeSection() === 'settings' ? 'Confirm account settings before detailed workflows use them.' : 'Review account setup and portfolio readiness.',
+        'Data, analysis, reports, and import workflows remain in current VERIFI until their v1 slices are built.'
       ],
       results: [
         { label: 'Facilities', value: String(this.facilities().length), tone: 'info' },
@@ -199,7 +230,7 @@ export class WorkspaceNavigationService {
       ],
       details: [
         { label: 'Context', value: isFacility ? 'Facility workspace' : 'Account workspace' },
-        { label: 'Active section', value: 'Home / Overview' },
+        { label: 'Active section', value: `${this.activeSection()} / ${this.activeDetail()}` },
         { label: 'Support tab', value: this.activePanelTab() }
       ]
     };
@@ -232,19 +263,25 @@ export function parseWorkspaceRoute(url: string): RouteState {
     };
   }
   if (routeParts[1] === 'facility') {
+    const section = normalizeSection(routeParts[3]);
     return {
       view: 'workspace',
       contextMode: 'facility',
       facilityGuid: routeParts[2],
-      section: 'home',
-      detail: routeParts[4] || 'overview'
+      section,
+      detail: routeParts[4] || DEFAULT_DETAILS[section]
     };
   }
+  const section = normalizeSection(routeParts[3]);
   return {
     view: 'workspace',
     contextMode: 'account',
     accountGuid: routeParts[2],
-    section: 'home',
-    detail: routeParts[4] || 'overview'
+    section,
+    detail: routeParts[4] || DEFAULT_DETAILS[section]
   };
+}
+
+function normalizeSection(section: string | undefined): SectionId {
+  return VALID_SECTION_IDS.includes(section as SectionId) ? section as SectionId : 'home';
 }

--- a/src/app/v1/styles/foundation.css
+++ b/src/app/v1/styles/foundation.css
@@ -781,7 +781,7 @@
 .v1-modal__header,
 .v1-modal__body,
 .v1-modal__footer {
-  padding: clamp(.5rem, 3vw, .5rem);
+  padding: clamp(.3rem, 3vw, .75rem);
 }
 
 .v1-drawer__body {

--- a/src/app/v1/styles/foundation.css
+++ b/src/app/v1/styles/foundation.css
@@ -10,6 +10,10 @@
   --v1-surface: #ffffff;
   --v1-surface-muted: #eef4f1;
   --v1-panel: #f8faf9;
+  --v1-content-block: color-mix(in srgb, var(--v1-surface-muted) 55%, var(--v1-surface));
+  --v1-control-surface: color-mix(in srgb, var(--v1-surface) 84%, var(--v1-bg));
+  --v1-control-addon-surface: color-mix(in srgb, var(--v1-surface-muted) 72%, var(--v1-surface));
+  --v1-control-border: color-mix(in srgb, var(--v1-border) 78%, var(--v1-text));
   --v1-text: #17231f;
   --v1-muted: #5f6f68;
   --v1-inverse-text: #ffffff;
@@ -468,6 +472,32 @@
   font-weight: 900;
   letter-spacing: 0;
   text-transform: uppercase;
+}
+
+.v1-section-header {
+  display: grid;
+  gap: .35rem;
+  min-width: 0;
+  padding: 1rem;
+  border: 1px solid var(--v1-border);
+  border-radius: var(--v1-radius);
+  background: var(--v1-surface);
+}
+
+.v1-section-header h1,
+.v1-section-header p {
+  margin: 0;
+}
+
+.v1-section-header h1 {
+  color: var(--v1-text);
+  font-size: 1.8rem;
+  line-height: 1.15;
+}
+
+.v1-section-header__summary {
+  max-width: 44rem;
+  color: var(--v1-muted);
 }
 
 .v1-label {

--- a/src/app/v1/styles/foundation.css
+++ b/src/app/v1/styles/foundation.css
@@ -763,10 +763,25 @@
 .v1-drawer__header,
 .v1-drawer__body,
 .v1-drawer__footer,
+.v1-modal__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: .75rem;
+}
+
+.v1-modal__header h2 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  line-height: 1.25;
+  margin-top: auto;
+}
+
 .v1-modal__header,
 .v1-modal__body,
 .v1-modal__footer {
-  padding: clamp(1rem, 3vw, 1.5rem);
+  padding: clamp(.5rem, 3vw, .5rem);
 }
 
 .v1-drawer__body {

--- a/src/app/v1/v1.module.ts
+++ b/src/app/v1/v1.module.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { PortalModule } from '@angular/cdk/portal';
 
 import { AccountHomeComponent } from './account/home/account-home.component';
 import { AccountSettingsModule } from './account/settings/account-settings.module';
@@ -27,6 +28,7 @@ import { WelcomeComponent } from './welcome/welcome.component';
   ],
   imports: [
     CommonModule,
+    PortalModule,
     AccountSettingsModule,
     WelcomeComponent,
     RouterModule.forChild(V1Routes)

--- a/src/app/v1/v1.module.ts
+++ b/src/app/v1/v1.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
 import { AccountHomeComponent } from './account/home/account-home.component';
+import { AccountSettingsModule } from './account/settings/account-settings.module';
 import { FacilityHomeComponent } from './facility/home/facility-home.component';
 import { ShellHeaderComponent } from './shell/header/shell-header.component';
 import { PrimaryRailComponent } from './shell/primary-rail/primary-rail.component';
@@ -26,6 +27,7 @@ import { WelcomeComponent } from './welcome/welcome.component';
   ],
   imports: [
     CommonModule,
+    AccountSettingsModule,
     WelcomeComponent,
     RouterModule.forChild(V1Routes)
   ]

--- a/src/app/v1/v1.routes.ts
+++ b/src/app/v1/v1.routes.ts
@@ -3,6 +3,7 @@ import { accountGuidReadyGuard, facilityReadyGuard, persistenceReadyGuard } from
 import { AccountHomeComponent } from './account/home/account-home.component';
 import { AccountSettingsComponent } from './account/settings/account-settings.component';
 import { AccountSettingsBackupComponent } from './account/settings/backup/account-settings-backup.component';
+import { AccountSettingsDeleteComponent } from './account/settings/delete/account-settings-delete.component';
 import { AccountSettingsFinancialComponent } from './account/settings/financial/account-settings-financial.component';
 import { AccountSettingsGoalsComponent } from './account/settings/goals/account-settings-goals.component';
 import { AccountSettingsProfileComponent } from './account/settings/profile/account-settings-profile.component';
@@ -44,6 +45,7 @@ export const V1Routes: Routes = [
               { path: 'financial', component: AccountSettingsFinancialComponent },
               { path: 'staleness', component: AccountSettingsStalenessComponent },
               { path: 'backup', component: AccountSettingsBackupComponent },
+              { path: 'delete', component: AccountSettingsDeleteComponent },
               { path: '**', redirectTo: 'profile' }
             ]
           },

--- a/src/app/v1/v1.routes.ts
+++ b/src/app/v1/v1.routes.ts
@@ -1,6 +1,13 @@
 import { Routes } from '@angular/router';
 import { accountGuidReadyGuard, facilityReadyGuard, persistenceReadyGuard } from '@app/routing/workspace-readiness.guards';
 import { AccountHomeComponent } from './account/home/account-home.component';
+import { AccountSettingsComponent } from './account/settings/account-settings.component';
+import { AccountSettingsBackupComponent } from './account/settings/backup/account-settings-backup.component';
+import { AccountSettingsFinancialComponent } from './account/settings/financial/account-settings-financial.component';
+import { AccountSettingsGoalsComponent } from './account/settings/goals/account-settings-goals.component';
+import { AccountSettingsProfileComponent } from './account/settings/profile/account-settings-profile.component';
+import { AccountSettingsStalenessComponent } from './account/settings/staleness/account-settings-staleness.component';
+import { AccountSettingsUnitsComponent } from './account/settings/units/account-settings-units.component';
 import { FacilityHomeComponent } from './facility/home/facility-home.component';
 import { accountHomeCanonicalGuard, facilityHomeCanonicalGuard } from './routing/canonical-route.guards';
 import { ShellComponent } from './shell/shell.component';
@@ -25,6 +32,20 @@ export const V1Routes: Routes = [
             path: 'home/:detail',
             component: AccountHomeComponent,
             canActivate: [accountHomeCanonicalGuard]
+          },
+          {
+            path: 'settings',
+            component: AccountSettingsComponent,
+            children: [
+              { path: '', pathMatch: 'full', redirectTo: 'profile' },
+              { path: 'profile', component: AccountSettingsProfileComponent },
+              { path: 'units', component: AccountSettingsUnitsComponent },
+              { path: 'goals', component: AccountSettingsGoalsComponent },
+              { path: 'financial', component: AccountSettingsFinancialComponent },
+              { path: 'staleness', component: AccountSettingsStalenessComponent },
+              { path: 'backup', component: AccountSettingsBackupComponent },
+              { path: '**', redirectTo: 'profile' }
+            ]
           },
           { path: '**', redirectTo: 'home/overview' }
         ]


### PR DESCRIPTION
connects #2639 

This pull request introduces a comprehensive refactor and enhancement of the account settings forms in the application. The main focus is on modularizing and improving the maintainability and testability of account settings logic by introducing a new service, providing robust unit tests, and establishing a reusable base class for account settings detail components. Additionally, there are minor improvements to the account home page layout and styling.

**Account Settings Forms Refactor and Enhancement:**

* Introduced the new `AccountSettingsFormService` (`account-settings-form.service.ts`) to encapsulate all logic related to creating, normalizing, and updating account settings forms, including profile, units, sustainability, fiscal, and data staleness settings. This service ensures consistent handling of default values, normalization for legacy records, and unit selection logic.
* Added comprehensive unit tests for `AccountSettingsFormService` to verify correct mapping, normalization, and update behaviors for all supported account settings forms, improving reliability and maintainability.
* Added `AccountSettingsDetailBase` abstract class to provide a reusable foundation for account settings detail components, including debounced save logic, save state management, and form control enable/disable utilities. This centralizes common logic and reduces duplication across settings-related components.

**UI and Layout Improvements:**

* Updated the account home page header structure and summary text for improved accessibility and clarity, using semantic HTML and new CSS classes.
* Removed redundant or unused CSS rules from the account home component stylesheet, streamlining the styles and relying on new or existing shared classes.