### PR TITLE
Issue 2435 - changed unit for consumption additional charge in meters

### DIFF
--- a/src/app/v0/shared/shared-meter-content/meter-data/meter-data-table/electricity-data-table/electricity-data-table.component.html
+++ b/src/app/v0/shared/shared-meter-content/meter-data/meter-data-table/electricity-data-table/electricity-data-table.component.html
@@ -84,7 +84,13 @@
       @if ((charge.chargeType == 'consumption' || charge.chargeType == 'demand') && charge.displayUsageInTable) {
       <th (click)="setOrderDataField(undefined, charge.guid, 'usage')"
         [ngClass]="{'active': _orderByChargeId == charge.guid && _orderByCharge == 'usage'}">
-        {{charge.name}} <br>({{_meter.demandUnit}})
+        {{charge.name}} <br>
+        @if (charge.chargeType === 'consumption') {
+        ({{_meter.startingUnit}})
+        }
+        @else {
+        ({{_meter.demandUnit}})
+        }
       </th>
       }
       @if (charge.displayChargeInTable) {


### PR DESCRIPTION
This pull request updates the display logic for units in the `electricity-data-table.component.html` file to show the correct unit based on the charge type. The main change is that the table now displays `startingUnit` for consumption charges and `demandUnit` for other charge types, improving clarity for users.

Display improvements:

* Updated the table header to display `startingUnit` when `charge.chargeType` is `'consumption'`, and `demandUnit` otherwise, ensuring the correct unit is shown for each charge type.