### PR TITLE
feat: add converting single site to portfolio functionality

### DIFF
--- a/docs/unified-ux-migration.md
+++ b/docs/unified-ux-migration.md
@@ -53,6 +53,15 @@ If the workflow needs current-state detail, add a short current-state note using
 - **Shared contracts:** No IndexedDB schema, migration, backup, import/export, calculation, Worker, or Electron contract changes.
 - **Tests:** Focused v1 navigation, header, side-nav, route guard, welcome, and facility settings specs; production web build before handoff.
 
+### Single-Site to Portfolio Conversion Workflow
+
+- **Workflow:** v1 single-site account conversion to portfolio presentation, issue #2641.
+- **Existing v0 entry point:** Facility management is available under the current Data Management facilities route.
+- **Decision:** Rebuild the scoped conversion path in v1 facility settings by adding a Portfolio detail between Backup and Delete account. Adding a second facility clears the existing `isSingleFacilityCompany` flag through account command handling.
+- **Parity:** Facility creation uses existing facility defaults and facility command handling; invalid single-site accounts with multiple facilities can clear the flag without creating another facility.
+- **Shared contracts:** No IndexedDB schema, migration, backup, import/export, calculation, Worker, or Electron contract changes.
+- **Tests:** Focused facility settings route/component specs and section navigation specs; validation planner decides parent checks.
+
 ## Implementation Rules
 
 - Do not add v0/v1 conditionals to legacy components.

--- a/src/app/v1/facility/settings/facility-settings-detail.base.ts
+++ b/src/app/v1/facility/settings/facility-settings-detail.base.ts
@@ -8,7 +8,7 @@ import { IdbAccount } from '@data/models/idbModels/account';
 import { IdbFacility } from '@data/models/idbModels/facility';
 import { SettingsDetailBase, SettingsSaveState } from '../../shared/settings/settings-detail.base';
 
-export type FacilitySettingsDetail = 'profile' | 'units' | 'goals' | 'financial' | 'staleness' | 'backup' | 'delete';
+export type FacilitySettingsDetail = 'profile' | 'units' | 'goals' | 'financial' | 'staleness' | 'backup' | 'portfolio' | 'delete';
 export type FacilitySettingsSaveState = SettingsSaveState;
 
 export const FACILITY_SETTINGS_DETAILS: ReadonlyArray<FacilitySettingsDetail> = [
@@ -18,6 +18,7 @@ export const FACILITY_SETTINGS_DETAILS: ReadonlyArray<FacilitySettingsDetail> = 
   'financial',
   'staleness',
   'backup',
+  'portfolio',
   'delete'
 ];
 

--- a/src/app/v1/facility/settings/facility-settings.component.spec.ts
+++ b/src/app/v1/facility/settings/facility-settings.component.spec.ts
@@ -26,6 +26,7 @@ import { FacilitySettingsComponent } from './facility-settings.component';
 import { FacilitySettingsModule } from './facility-settings.module';
 import { FacilitySettingsFinancialComponent } from './financial/facility-settings-financial.component';
 import { FacilitySettingsGoalsComponent } from './goals/facility-settings-goals.component';
+import { PortfolioTransitionSettingsComponent } from './portfolio-transition/portfolio-transition-settings.component';
 import { FacilitySettingsProfileComponent } from './profile/facility-settings-profile.component';
 import { FacilitySettingsStalenessComponent } from './staleness/facility-settings-staleness.component';
 import { FacilitySettingsUnitsComponent } from './units/facility-settings-units.component';
@@ -38,6 +39,7 @@ describe('Facility settings routed components', () => {
   let commandBoundary: { execute: ReturnType<typeof vi.fn> };
   let accountHandler: { update: ReturnType<typeof vi.fn> };
   let facilityHandler: {
+    add: ReturnType<typeof vi.fn>;
     update: ReturnType<typeof vi.fn>;
     delete: ReturnType<typeof vi.fn>;
   };
@@ -72,6 +74,7 @@ describe('Facility settings routed components', () => {
       update: vi.fn(async updated => updated)
     };
     facilityHandler = {
+      add: vi.fn(async (facility: IdbFacility) => ({ facility: { ...facility, id: 3, guid: 'facility-new' } })),
       update: vi.fn(async updated => updated),
       delete: vi.fn(async () => undefined)
     };
@@ -110,6 +113,8 @@ describe('Facility settings routed components', () => {
             account,
             selectedFacility,
             facilities,
+            accountAnalyses: signal([]),
+            accountReports: signal([]),
             canWrite,
             hasPending: signal(false),
             customEmissions: signal([])
@@ -175,7 +180,7 @@ describe('Facility settings routed components', () => {
     const childPaths = settingsRoute?.children?.map(route => route.path);
 
     expect(settingsRoute?.component).toBe(FacilitySettingsComponent);
-    expect(childPaths).toEqual(['', 'profile', 'units', 'goals', 'financial', 'staleness', 'backup', 'delete', '**']);
+    expect(childPaths).toEqual(['', 'profile', 'units', 'goals', 'financial', 'staleness', 'backup', 'portfolio', 'delete', '**']);
   });
 
   it('autosaves facility profile text after a debounce without stealing focus', async () => {
@@ -499,6 +504,88 @@ describe('Facility settings routed components', () => {
     fixture.detectChanges(false);
 
     expect(fixture.nativeElement.textContent).toContain('Upload Facility Backup');
+  });
+
+  it('requires a facility name before converting a single-facility account', async () => {
+    account.set({ ...accountFixture(), isSingleFacilityCompany: true });
+    facilities.set([selectedFacility()!]);
+    const fixture = createDetail(PortfolioTransitionSettingsComponent);
+
+    buttonByText(fixture, 'Add facility and convert').click();
+    fixture.detectChanges(false);
+
+    expect(fixture.nativeElement.textContent).toContain('Name is required');
+    expect(commandBoundary.execute).not.toHaveBeenCalled();
+    expect(facilityHandler.add).not.toHaveBeenCalled();
+    expect(accountHandler.update).not.toHaveBeenCalled();
+  });
+
+  it('adds a facility and clears single-facility mode through one reload command', async () => {
+    account.set({ ...accountFixture(), isSingleFacilityCompany: true });
+    facilities.set([selectedFacility()!]);
+    const fixture = createDetail(PortfolioTransitionSettingsComponent);
+    const input: HTMLInputElement = fixture.nativeElement.querySelector('input[formControlName="facilityName"]');
+    input.value = '  Second Site  ';
+    input.dispatchEvent(new Event('input'));
+
+    buttonByText(fixture, 'Add facility and convert').click();
+    fixture.detectChanges(false);
+
+    expect(fixture.componentInstance.showConfirm).toBe(true);
+    await fixture.componentInstance.confirmConversion();
+    fixture.detectChanges(false);
+
+    expect(commandBoundary.execute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        entityKind: 'account',
+        changeKind: 'update',
+        entityGuid: 'account-a',
+        publication: { mode: 'reload' }
+      }),
+      expect.any(Function)
+    );
+    expect(facilityHandler.add).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Second Site', accountId: 'account-a' }),
+      'account-a',
+      [],
+      []
+    );
+    expect(accountHandler.update).toHaveBeenCalledWith(
+      expect.objectContaining({ guid: 'account-a', isSingleFacilityCompany: false }),
+      'account-a'
+    );
+    expect(lifecycle.refreshAccountCatalog).toHaveBeenCalled();
+    expect(fixture.componentInstance.completedFacility).toEqual(expect.objectContaining({ guid: 'facility-new' }));
+  });
+
+  it('keeps the new facility name visible when conversion fails', async () => {
+    account.set({ ...accountFixture(), isSingleFacilityCompany: true });
+    facilities.set([selectedFacility()!]);
+    commandBoundary.execute.mockRejectedValueOnce(new Error('persist failed'));
+    const fixture = createDetail(PortfolioTransitionSettingsComponent);
+    fixture.componentInstance.form.controls.facilityName.setValue('Unsaved Site');
+
+    await fixture.componentInstance.confirmConversion();
+    fixture.detectChanges(false);
+
+    expect(fixture.componentInstance.form.controls.facilityName.value).toBe('Unsaved Site');
+    expect(fixture.componentInstance.saveState).toBe('error');
+    expect(fixture.nativeElement.textContent).toContain('Changes could not be saved');
+  });
+
+  it('repairs single-facility accounts that already have multiple facilities without adding another facility', async () => {
+    account.set({ ...accountFixture(), isSingleFacilityCompany: true });
+    facilities.set([selectedFacility()!, facilityFixture('facility-b')]);
+    const fixture = createDetail(PortfolioTransitionSettingsComponent);
+
+    expect(fixture.nativeElement.textContent).toContain('Finish portfolio conversion');
+    await fixture.componentInstance.confirmConversion();
+
+    expect(facilityHandler.add).not.toHaveBeenCalled();
+    expect(accountHandler.update).toHaveBeenCalledWith(
+      expect.objectContaining({ guid: 'account-a', isSingleFacilityCompany: false }),
+      'account-a'
+    );
   });
 
   it('imports facility backups as replace or new from the v1 import panel', async () => {

--- a/src/app/v1/facility/settings/facility-settings.module.ts
+++ b/src/app/v1/facility/settings/facility-settings.module.ts
@@ -8,6 +8,7 @@ import { FacilitySettingsComponent } from './facility-settings.component';
 import { FacilitySettingsDeleteComponent } from './delete/facility-settings-delete.component';
 import { FacilitySettingsFinancialComponent } from './financial/facility-settings-financial.component';
 import { FacilitySettingsGoalsComponent } from './goals/facility-settings-goals.component';
+import { PortfolioTransitionSettingsComponent } from './portfolio-transition/portfolio-transition-settings.component';
 import { FacilitySettingsProfileComponent } from './profile/facility-settings-profile.component';
 import { FacilitySettingsStalenessComponent } from './staleness/facility-settings-staleness.component';
 import { FacilitySettingsUnitsComponent } from './units/facility-settings-units.component';
@@ -21,6 +22,7 @@ import { FacilitySettingsUnitsComponent } from './units/facility-settings-units.
     FacilitySettingsFinancialComponent,
     FacilitySettingsStalenessComponent,
     FacilitySettingsBackupComponent,
+    PortfolioTransitionSettingsComponent,
     FacilitySettingsDeleteComponent
   ],
   imports: [

--- a/src/app/v1/facility/settings/portfolio-transition/portfolio-transition-settings.component.html
+++ b/src/app/v1/facility/settings/portfolio-transition/portfolio-transition-settings.component.html
@@ -1,0 +1,136 @@
+@let currentAccount = account();
+@let currentFacility = facility();
+@let facilitiesCount = facilityCount();
+
+@if (currentAccount && currentFacility) {
+  <section class="v1-settings-panel v1-settings-panel--facility" aria-label="Portfolio transition">
+    <div class="v1-settings-panel__heading">
+      <div>
+        <p>Portfolio</p>
+        <h2>Convert to portfolio</h2>
+      </div>
+      <span class="v1-settings-panel__status" [class.v1-settings-panel__status--error]="saveState === 'error'">
+        @if (isConverting || saveState === 'saving') {
+          <span class="fa fa-circle-notch fa-spin" aria-hidden="true"></span>
+          Converting
+        } @else if (saveState === 'saved' || portfolioModeReady()) {
+          <span class="fa fa-check" aria-hidden="true"></span>
+          Portfolio mode
+        } @else if (saveState === 'error') {
+          <span class="fa fa-triangle-exclamation" aria-hidden="true"></span>
+          Not converted
+        }
+      </span>
+    </div>
+
+    @if (saveError) {
+      <div class="v1-alert v1-alert--danger" role="alert">
+        <span class="fa fa-triangle-exclamation" aria-hidden="true"></span>
+        <span>{{ saveError }}</span>
+      </div>
+    }
+
+    @if (portfolioModeReady()) {
+      <article class="v1-settings-card">
+        <span class="fa fa-layer-group" aria-hidden="true"></span>
+        <h3>Portfolio mode is on</h3>
+        <p>{{ currentAccount.name }} now supports account and facility workspace navigation.</p>
+        <div class="v1-settings-actions">
+          <button type="button" class="v1-btn v1-btn--primary" (click)="openAccountWorkspace()">
+            Open account workspace
+            <span class="fa fa-arrow-right" aria-hidden="true"></span>
+          </button>
+          @if (completedFacility) {
+            <button type="button" class="v1-btn v1-btn--secondary" (click)="openCompletedFacility()">
+              Open {{ completedFacility.name }}
+              <span class="fa fa-industry" aria-hidden="true"></span>
+            </button>
+          }
+        </div>
+      </article>
+    } @else if (hasMultipleFacilityRecovery()) {
+      <article class="v1-settings-card">
+        <span class="fa fa-layer-group" aria-hidden="true"></span>
+        <h3>Finish portfolio conversion</h3>
+        <p>This account already has {{ facilitiesCount }} facilities. Finish the transition to show account and facility workspace navigation.</p>
+        <div class="v1-settings-actions">
+          <button type="button" class="v1-btn v1-btn--primary" [disabled]="!canWrite() || isConverting"
+            (click)="openConversionConfirm()">
+            Finish conversion
+            <span class="fa fa-check" aria-hidden="true"></span>
+          </button>
+        </div>
+      </article>
+    } @else {
+      <form class="v1-settings-grid v1-settings-grid--1" [formGroup]="form" aria-label="Convert to portfolio">
+        <article class="v1-settings-card">
+          <span class="fa fa-plus" aria-hidden="true"></span>
+          <h3>Add another facility</h3>
+          <p>Adding a second facility converts {{ currentAccount.name }} from single-facility presentation to portfolio presentation.</p>
+          <label>
+            <span>New facility name</span>
+            <input type="text" formControlName="facilityName" [disabled]="!canWrite() || isConverting"
+              [attr.aria-invalid]="facilityNameInvalid ? 'true' : null"
+              aria-describedby="v1-new-facility-name-error">
+            @if (facilityNameInvalid) {
+              <small id="v1-new-facility-name-error" class="v1-field-hint">Name is required.</small>
+            }
+          </label>
+          <div class="v1-settings-actions">
+            <button type="button" class="v1-btn v1-btn--primary" [disabled]="!canWrite() || isConverting"
+              (click)="openConversionConfirm()">
+              Add facility and convert
+              <span class="fa fa-layer-group" aria-hidden="true"></span>
+            </button>
+          </div>
+        </article>
+      </form>
+    }
+  </section>
+}
+
+<ng-template #portfolioConfirmModal>
+  <div class="v1-modal-layer">
+    <button type="button" class="v1-modal-backdrop" aria-label="Cancel portfolio conversion" [disabled]="isConverting"
+      (click)="cancelConversionConfirm()"></button>
+    <section class="v1-modal" role="dialog" aria-modal="true" aria-labelledby="v1-portfolio-confirm-title">
+      <header class="v1-modal__header">
+        <h2 id="v1-portfolio-confirm-title">
+          @if (shouldAddFacility()) {
+            Add facility and convert?
+          } @else {
+            Finish portfolio conversion?
+          }
+        </h2>
+        <button type="button" class="v1-icon-btn" aria-label="Cancel portfolio conversion" [disabled]="isConverting"
+          (click)="cancelConversionConfirm()">
+          <span class="fa fa-xmark" aria-hidden="true"></span>
+        </button>
+      </header>
+      <div class="v1-modal__body">
+        @if (shouldAddFacility()) {
+          <p>This will add {{ form.controls.facilityName.value }} to {{ account()?.name }} and turn on portfolio navigation.</p>
+        } @else {
+          <p>This will turn on portfolio navigation for the {{ facilityCount() }} facilities already in this account.</p>
+        }
+      </div>
+      <footer class="v1-modal__footer">
+        <button type="button" class="v1-btn v1-btn--quiet" [disabled]="isConverting"
+          (click)="cancelConversionConfirm()">Cancel</button>
+        <button type="button" class="v1-btn v1-btn--primary" [disabled]="!canWrite() || isConverting"
+          (click)="confirmConversion()">
+          @if (isConverting) {
+            <span class="fa fa-circle-notch fa-spin" aria-hidden="true"></span>
+            Converting
+          } @else if (shouldAddFacility()) {
+            Add facility and convert
+            <span class="fa fa-layer-group" aria-hidden="true"></span>
+          } @else {
+            Finish conversion
+            <span class="fa fa-check" aria-hidden="true"></span>
+          }
+        </button>
+      </footer>
+    </section>
+  </div>
+</ng-template>

--- a/src/app/v1/facility/settings/portfolio-transition/portfolio-transition-settings.component.ts
+++ b/src/app/v1/facility/settings/portfolio-transition/portfolio-transition-settings.component.ts
@@ -1,0 +1,156 @@
+import { TemplatePortal } from '@angular/cdk/portal';
+import { Component, TemplateRef, ViewChild, ViewContainerRef, computed, inject } from '@angular/core';
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { Router } from '@angular/router';
+import { getNewIdbFacility, IdbFacility } from '@data/models/idbModels/facility';
+import { WorkspaceNavigationService } from '../../../shell/workspace-navigation.service';
+import { ModalPortalService } from '../../../shell/modal-portal.service';
+import { FacilitySettingsDetailBase } from '../facility-settings-detail.base';
+
+interface PortfolioTransitionResult {
+  readonly facility?: IdbFacility;
+}
+
+@Component({
+  selector: 'app-portfolio-transition-settings',
+  templateUrl: './portfolio-transition-settings.component.html',
+  host: { style: 'display: block;' },
+  standalone: false
+})
+export class PortfolioTransitionSettingsComponent extends FacilitySettingsDetailBase {
+  private readonly navigation = inject(WorkspaceNavigationService);
+  private readonly router = inject(Router);
+  private readonly modalPortal = inject(ModalPortalService);
+  private readonly viewContainerRef = inject(ViewContainerRef);
+
+  @ViewChild('portfolioConfirmModal') private readonly portfolioConfirmModal!: TemplateRef<unknown>;
+
+  readonly form = new FormGroup({
+    facilityName: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required]
+    })
+  });
+  readonly isSingleFacilityAccount = computed(() => this.account()?.isSingleFacilityCompany === true);
+  readonly facilityCount = computed(() => this.facilities().length);
+  readonly shouldAddFacility = computed(() => this.isSingleFacilityAccount() && this.facilityCount() <= 1);
+  readonly hasMultipleFacilityRecovery = computed(() => this.isSingleFacilityAccount() && this.facilityCount() > 1);
+  readonly portfolioModeReady = computed(() => !!this.account() && !this.isSingleFacilityAccount());
+
+  showConfirm = false;
+  isConverting = false;
+  completedFacility?: IdbFacility;
+
+  get facilityNameInvalid(): boolean {
+    const control = this.form.controls.facilityName;
+    return control.invalid && (control.touched || control.dirty);
+  }
+
+  override ngOnDestroy(): void {
+    super.ngOnDestroy();
+    this.showConfirm = false;
+    this.modalPortal.hide();
+  }
+
+  openConversionConfirm(): void {
+    if (!this.account() || !this.isSingleFacilityAccount() || !this.canWrite() || this.isConverting) {
+      return;
+    }
+    this.saveError = '';
+    if (this.shouldAddFacility()) {
+      this.normalizeFacilityName();
+      if (this.form.invalid) {
+        this.form.markAllAsTouched();
+        return;
+      }
+    }
+    this.showConfirm = true;
+    this.modalPortal.show(new TemplatePortal(this.portfolioConfirmModal, this.viewContainerRef));
+  }
+
+  cancelConversionConfirm(): void {
+    if (!this.isConverting) {
+      this.showConfirm = false;
+      this.modalPortal.hide();
+    }
+  }
+
+  async confirmConversion(): Promise<void> {
+    const account = this.account();
+    if (!account || !this.isSingleFacilityAccount() || !this.canWrite() || this.isConverting) {
+      return;
+    }
+
+    const addFacility = this.shouldAddFacility();
+    if (addFacility) {
+      this.normalizeFacilityName();
+      if (this.form.invalid) {
+        this.form.markAllAsTouched();
+        return;
+      }
+    }
+
+    const newFacilityName = this.form.controls.facilityName.value;
+    this.showConfirm = false;
+    this.modalPortal.hide();
+    this.isConverting = true;
+    this.completedFacility = undefined;
+
+    await this.runSave('Converting to portfolio', async () => {
+      const result = await this.commandBoundary.execute(
+        {
+          entityKind: 'account',
+          changeKind: 'update',
+          entityGuid: account.guid,
+          label: 'Converting to portfolio',
+          publication: { mode: 'reload' }
+        },
+        async (): Promise<PortfolioTransitionResult> => {
+          let addedFacility: IdbFacility | undefined;
+          if (addFacility) {
+            const facility: IdbFacility = {
+              ...getNewIdbFacility(account),
+              name: newFacilityName
+            };
+            const addResult = await this.facilityHandler.add(
+              facility,
+              account.guid,
+              this.workspace.accountAnalyses(),
+              this.workspace.accountReports()
+            );
+            addedFacility = addResult.facility;
+          }
+          await this.accountHandler.update({ ...structuredClone(account), isSingleFacilityCompany: false }, account.guid);
+          return { facility: addedFacility };
+        }
+      );
+      this.completedFacility = result.value.facility;
+      await this.lifecycle.refreshAccountCatalog();
+      if (addFacility && this.completedFacility?.guid) {
+        void this.router.navigate(this.navigation.facilitySettingsRoute(this.completedFacility.guid));
+      }
+    });
+    this.isConverting = false;
+  }
+
+  openAccountWorkspace(): void {
+    const account = this.account();
+    if (account?.guid) {
+      void this.navigation.openAccount(account.guid);
+    }
+  }
+
+  openCompletedFacility(): void {
+    if (this.completedFacility?.guid) {
+      this.navigation.setFacility(this.completedFacility.guid);
+    }
+  }
+
+  private normalizeFacilityName(): void {
+    const control = this.form.controls.facilityName;
+    const trimmedName = control.value.trim();
+    if (control.value !== trimmedName) {
+      control.setValue(trimmedName, { emitEvent: false });
+    }
+  }
+}

--- a/src/app/v1/shell/section-nav/section-nav.component.spec.ts
+++ b/src/app/v1/shell/section-nav/section-nav.component.spec.ts
@@ -80,6 +80,7 @@ describe('SectionNavComponent', () => {
     expect(fixture.nativeElement.textContent).toContain('Facility Settings');
     expect(fixture.nativeElement.textContent).toContain('Profile');
     expect(fixture.nativeElement.textContent).toContain('Delete facility');
+    expect(fixture.nativeElement.textContent).not.toContain('Portfolio');
     expect(fixture.nativeElement.textContent).not.toContain('Delete account');
   });
 
@@ -92,7 +93,13 @@ describe('SectionNavComponent', () => {
     fixture.detectChanges();
 
     expect(fixture.nativeElement.textContent).toContain('Facility Settings');
+    expect(fixture.nativeElement.textContent).toContain('Portfolio');
     expect(fixture.nativeElement.textContent).toContain('Delete account');
+
+    account.set({ guid: 'account-a', name: 'Account A', isSingleFacilityCompany: false });
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).not.toContain('Portfolio');
   });
 
   it('hides context switching for a valid single-facility workspace', () => {

--- a/src/app/v1/shell/section-nav/section-nav.component.ts
+++ b/src/app/v1/shell/section-nav/section-nav.component.ts
@@ -27,6 +27,8 @@ const FACILITY_SETTINGS_ITEMS: ReadonlyArray<SettingsNavItem> = [
   { id: 'backup', label: 'Backup', icon: 'fa-file-arrow-down' }
 ];
 
+const PORTFOLIO_TRANSITION_ITEM: SettingsNavItem = { id: 'portfolio', label: 'Portfolio', icon: 'fa-layer-group' };
+
 @Component({
   selector: 'app-section-nav',
   templateUrl: './section-nav.component.html',
@@ -41,9 +43,14 @@ export class SectionNavComponent {
     if (this.navigation.contextMode() !== 'facility') {
       return ACCOUNT_SETTINGS_ITEMS;
     }
-    const deleteLabel = this.navigation.account()?.isSingleFacilityCompany ? 'Delete account' : 'Delete facility';
+    const account = this.navigation.account();
+    const isSingleFacilityAccount = !!account?.isSingleFacilityCompany;
+    const deleteLabel = isSingleFacilityAccount ? 'Delete account' : 'Delete facility';
+    const facilityItems = isSingleFacilityAccount
+      ? [...FACILITY_SETTINGS_ITEMS, PORTFOLIO_TRANSITION_ITEM]
+      : FACILITY_SETTINGS_ITEMS;
     return [
-      ...FACILITY_SETTINGS_ITEMS,
+      ...facilityItems,
       { id: 'delete', label: deleteLabel, icon: 'fa-trash', tone: 'danger' as const }
     ];
   });

--- a/src/app/v1/v1.routes.ts
+++ b/src/app/v1/v1.routes.ts
@@ -15,6 +15,7 @@ import { FacilitySettingsBackupComponent } from './facility/settings/backup/faci
 import { FacilitySettingsDeleteComponent } from './facility/settings/delete/facility-settings-delete.component';
 import { FacilitySettingsFinancialComponent } from './facility/settings/financial/facility-settings-financial.component';
 import { FacilitySettingsGoalsComponent } from './facility/settings/goals/facility-settings-goals.component';
+import { PortfolioTransitionSettingsComponent } from './facility/settings/portfolio-transition/portfolio-transition-settings.component';
 import { FacilitySettingsProfileComponent } from './facility/settings/profile/facility-settings-profile.component';
 import { FacilitySettingsStalenessComponent } from './facility/settings/staleness/facility-settings-staleness.component';
 import { FacilitySettingsUnitsComponent } from './facility/settings/units/facility-settings-units.component';
@@ -83,6 +84,7 @@ export const V1Routes: Routes = [
               { path: 'financial', component: FacilitySettingsFinancialComponent },
               { path: 'staleness', component: FacilitySettingsStalenessComponent },
               { path: 'backup', component: FacilitySettingsBackupComponent },
+              { path: 'portfolio', component: PortfolioTransitionSettingsComponent },
               { path: 'delete', component: FacilitySettingsDeleteComponent },
               { path: '**', redirectTo: 'profile' }
             ]


### PR DESCRIPTION
connects #2641 

This pull request introduces a new workflow and UI for converting a single-site account to a portfolio (multi-facility) account in the v1 facility settings. It adds a dedicated "Portfolio" settings section, a new routed component for the conversion process, and comprehensive tests for the new behavior. The implementation ensures users can add a second facility to enable portfolio mode, handles edge cases, and provides clear user feedback throughout the process.

**Single-Site to Portfolio Conversion Feature:**

* Added a new `PortfolioTransitionSettingsComponent` with UI and logic for converting a single-facility account to portfolio mode, including form validation, confirmation modal, and navigation after conversion (`src/app/v1/facility/settings/portfolio-transition/portfolio-transition-settings.component.ts`, `portfolio-transition-settings.component.html`). [[1]](diffhunk://#diff-21d4e980c2d36372bdb6648df3d89869be51ea6af5000566b7510bcd5564dee2R1-R156) [[2]](diffhunk://#diff-1202aaf03f28c3732d085662e1c8e1c2f17c8e6c08e27e902b44483271ebdca4R1-R136)
* Updated facility settings routing and navigation to include the new `portfolio` detail, and registered the new component in the module (`facility-settings-detail.base.ts`, `facility-settings.module.ts`). [[1]](diffhunk://#diff-f857f35681f4cb500b2df567c9802112cf9863fc6277e9e465990a3f818fa465L11-R11) [[2]](diffhunk://#diff-f857f35681f4cb500b2df567c9802112cf9863fc6277e9e465990a3f818fa465R21) [[3]](diffhunk://#diff-377a168ae2520a451df6998a50d6e965494c999364e65782d1887a39b4d1e50eR11) [[4]](diffhunk://#diff-377a168ae2520a451df6998a50d6e965494c999364e65782d1887a39b4d1e50eR25)

**Testing and Validation:**

* Added comprehensive tests for the conversion workflow, including validation, error handling, and recovery scenarios in `facility-settings.component.spec.ts`.
* Updated test setup and expectations to include the new `portfolio` route and handler mocks. [[1]](diffhunk://#diff-5b510bc1405cc5d4a0ec2e97bee5022c0b6beb12cf548d84e965158aa1164e67R29) [[2]](diffhunk://#diff-5b510bc1405cc5d4a0ec2e97bee5022c0b6beb12cf548d84e965158aa1164e67R42) [[3]](diffhunk://#diff-5b510bc1405cc5d4a0ec2e97bee5022c0b6beb12cf548d84e965158aa1164e67R77) [[4]](diffhunk://#diff-5b510bc1405cc5d4a0ec2e97bee5022c0b6beb12cf548d84e965158aa1164e67R116-R117) [[5]](diffhunk://#diff-5b510bc1405cc5d4a0ec2e97bee5022c0b6beb12cf548d84e965158aa1164e67L178-R183)

**Documentation:**

* Added a new section to the migration documentation describing the single-site to portfolio conversion workflow, design decisions, and test coverage (`docs/unified-ux-migration.md`).