### PR TITLE
feat: Add toast notification system

### DIFF
--- a/docs/agents/v1-visual-foundation.md
+++ b/docs/agents/v1-visual-foundation.md
@@ -66,6 +66,18 @@ Button color should communicate the action's consequence, not decorative emphasi
 
 Keep one filled orange button per section, card group, or dialog footer. Icon-only buttons should stay neutral unless they are destructive or actively selected. Disabled buttons should not rely on color to explain state; pair the disabled state with labels, helper text, validation, or status copy where the reason is not obvious.
 
+## Toast notifications
+
+Use v1 toast notifications for brief, non-blocking feedback that confirms a completed action or reports a recoverable status after the user can safely keep working. Toasts support success, danger, warning, and info tones, and their styles must come from v1 semantic theme tokens.
+
+- Use success toasts for completed create, update, delete, and bulk operations after persistence and workspace publication succeed.
+- Suppress success toasts for high-frequency autosave typing, background backup observation, hydration, selection-only changes, or any workflow that already has persistent inline confirmation.
+- Use danger toasts only for recoverable, non-blocking failures when the relevant UI is no longer visible. Keep validation, destructive failures, and blocked states inline with `v1-alert`.
+- Use warning toasts for completed actions with caveats or follow-up needed.
+- Use info toasts for short-lived process or context feedback, not help text or persistent instructions.
+- Keep toast copy short, object-specific when possible, and plain text only.
+- Do not show duplicate inline success and toast success for the same event unless the inline state is deliberately persistent.
+
 ## Drawers and modals
 
 Use contextual slideout drawers for meaningful form and data-entry work:

--- a/src/app/data/account-workspace/workspace-command-boundary.service.spec.ts
+++ b/src/app/data/account-workspace/workspace-command-boundary.service.spec.ts
@@ -95,6 +95,32 @@ describe('WorkspaceCommandBoundary', () => {
     });
   });
 
+  it('passes notification hints through committed-change events', async () => {
+    const { boundary, store, workspaceService } = createBoundary();
+    publishReady(store);
+    workspaceService.reloadActiveWorkspace.mockResolvedValue('published');
+
+    const changes: unknown[] = [];
+    boundary.committedChange$.subscribe(c => changes.push(c));
+
+    await boundary.execute({
+      ...makeOptions('facility', 'delete', 'facility-a'),
+      notification: {
+        entityName: 'North Plant',
+        successMessage: 'Meters and related data were removed.'
+      }
+    }, () => Promise.resolve(null));
+
+    expect(changes[0]).toMatchObject({
+      entityKind: 'facility',
+      changeKind: 'delete',
+      notification: {
+        entityName: 'North Plant',
+        successMessage: 'Meters and related data were removed.'
+      }
+    });
+  });
+
   it('publishes a committed patch without reloading the workspace', async () => {
     const { boundary, store, workspaceService } = createBoundary();
     publishReady(store);

--- a/src/app/data/account-workspace/workspace-command-boundary.service.ts
+++ b/src/app/data/account-workspace/workspace-command-boundary.service.ts
@@ -18,6 +18,7 @@ import { WorkspacePatch } from './account-workspace.models';
 import {
   WorkspaceChangeKind,
   WorkspaceCommittedChange,
+  WorkspaceCommandNotificationOptions,
   WorkspaceCommandResult,
   WorkspaceEntityKind,
   WorkspaceWriteError
@@ -31,6 +32,7 @@ export interface WorkspaceCommandOptions {
   readonly entityGuid?: string;
   /** Human-readable label shown while the operation is in-flight. */
   readonly label: string;
+  readonly notification?: WorkspaceCommandNotificationOptions;
 }
 
 export type WorkspacePublication<T> =
@@ -166,7 +168,8 @@ export class WorkspaceCommandBoundary {
       entityKind: options.entityKind,
       changeKind: options.changeKind,
       entityGuid: options.entityGuid,
-      accountGuid: submittedAccountGuid
+      accountGuid: submittedAccountGuid,
+      notification: options.notification
     };
     this.committedChangeSubject.next(change);
 

--- a/src/app/data/account-workspace/workspace-commands.models.ts
+++ b/src/app/data/account-workspace/workspace-commands.models.ts
@@ -31,6 +31,17 @@ export type WorkspaceEntityKind =
 export type WorkspaceChangeKind = 'add' | 'update' | 'delete' | 'bulk';
 
 // ---------------------------------------------------------------------------
+// Optional UI notification hints
+// ---------------------------------------------------------------------------
+
+export interface WorkspaceCommandNotificationOptions {
+  readonly suppressSuccessToast?: boolean;
+  readonly successTitle?: string;
+  readonly successMessage?: string;
+  readonly entityName?: string;
+}
+
+// ---------------------------------------------------------------------------
 // Committed-change event
 // ---------------------------------------------------------------------------
 
@@ -40,6 +51,7 @@ export interface WorkspaceCommittedChange {
   /** GUID of the affected entity, or the account GUID for bulk/account-level changes. */
   readonly entityGuid?: string;
   readonly accountGuid: string;
+  readonly notification?: WorkspaceCommandNotificationOptions;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/app/v1/account/settings/account-settings-detail.base.ts
+++ b/src/app/v1/account/settings/account-settings-detail.base.ts
@@ -42,6 +42,7 @@ export abstract class AccountSettingsDetailBase extends SettingsDetailBase {
           changeKind: 'update',
           entityGuid: updatedAccount.guid,
           label,
+          notification: { suppressSuccessToast: true },
           publication: { mode: 'patch', buildPatch: value => ({ account: value }) }
         },
         () => this.accountHandler.update({ ...updatedAccount }, updatedAccount.guid)

--- a/src/app/v1/account/settings/backup/account-settings-backup.component.ts
+++ b/src/app/v1/account/settings/backup/account-settings-backup.component.ts
@@ -157,6 +157,7 @@ export class AccountSettingsBackupComponent extends AccountSettingsDetailBase {
           changeKind: 'update',
           entityGuid: updatedAccount.guid,
           label: 'Saving automatic backup settings',
+          notification: { suppressSuccessToast: true },
           publication: { mode: 'patch', buildPatch: value => ({ account: value }) }
         },
         () => this.accountHandler.update(updatedAccount, updatedAccount.guid)

--- a/src/app/v1/account/settings/delete/account-settings-delete.component.ts
+++ b/src/app/v1/account/settings/delete/account-settings-delete.component.ts
@@ -1,5 +1,6 @@
 import { Component, TemplateRef, ViewChild, ViewContainerRef, inject } from '@angular/core';
 import { TemplatePortal } from '@angular/cdk/portal';
+import { NotificationService } from '../../../shared/notifications/notification.service';
 import { WorkspaceNavigationService } from '../../../shell/workspace-navigation.service';
 import { ModalPortalService } from '../../../shell/modal-portal.service';
 import { AccountSettingsDetailBase } from '../account-settings-detail.base';
@@ -12,6 +13,7 @@ import { AccountSettingsDetailBase } from '../account-settings-detail.base';
   standalone: false
 })
 export class AccountSettingsDeleteComponent extends AccountSettingsDetailBase {
+  private readonly notifications = inject(NotificationService);
   private readonly navigation = inject(WorkspaceNavigationService);
   private readonly modalPortal = inject(ModalPortalService);
   private readonly viewContainerRef = inject(ViewContainerRef);
@@ -59,6 +61,7 @@ export class AccountSettingsDeleteComponent extends AccountSettingsDetailBase {
           changeKind: 'delete',
           entityGuid: account.guid,
           label: 'Deleting account',
+          notification: { suppressSuccessToast: true },
           publication: { mode: 'patch', buildPatch: value => ({ account: value }) }
         },
         () => this.accountHandler.update({ ...account, deleteAccount: true }, account.guid)
@@ -71,6 +74,7 @@ export class AccountSettingsDeleteComponent extends AccountSettingsDetailBase {
     if (this.saveState === 'error') {
       return;
     }
+    this.notifications.success('Account deleted', { message: account.name });
     if (nextAccount?.guid) {
       await this.navigation.openAccount(nextAccount.guid);
       return;

--- a/src/app/v1/account/settings/financial/account-settings-financial.component.ts
+++ b/src/app/v1/account/settings/financial/account-settings-financial.component.ts
@@ -58,6 +58,7 @@ export class AccountSettingsFinancialComponent extends AccountSettingsDetailBase
           changeKind: 'update',
           entityGuid: activeAccountGuid,
           label: 'Saving financial reporting settings',
+          notification: { suppressSuccessToast: true },
           publication: {
             mode: 'patch',
             buildPatch: value => ({

--- a/src/app/v1/facility/settings/delete/facility-settings-delete.component.ts
+++ b/src/app/v1/facility/settings/delete/facility-settings-delete.component.ts
@@ -3,6 +3,7 @@ import { Component, TemplateRef, ViewChild, ViewContainerRef, computed, inject }
 import { Router } from '@angular/router';
 import { LoadingService } from '@app/core-components/loading/loading.service';
 import { FACILITY_DELETION_MESSAGES } from '@data/indexedDB/facility-deletion.config';
+import { NotificationService } from '../../../shared/notifications/notification.service';
 import { WorkspaceNavigationService } from '../../../shell/workspace-navigation.service';
 import { ModalPortalService } from '../../../shell/modal-portal.service';
 import { FacilitySettingsDetailBase } from '../facility-settings-detail.base';
@@ -15,6 +16,7 @@ import { FacilitySettingsDetailBase } from '../facility-settings-detail.base';
 })
 export class FacilitySettingsDeleteComponent extends FacilitySettingsDetailBase {
   private readonly loadingService = inject(LoadingService);
+  private readonly notifications = inject(NotificationService);
   private readonly modalPortal = inject(ModalPortalService);
   private readonly viewContainerRef = inject(ViewContainerRef);
   private readonly navigation = inject(WorkspaceNavigationService);
@@ -73,6 +75,7 @@ export class FacilitySettingsDeleteComponent extends FacilitySettingsDetailBase 
           changeKind: 'delete',
           entityGuid: account.guid,
           label: 'Deleting account',
+          notification: { suppressSuccessToast: true },
           publication: { mode: 'patch', buildPatch: value => ({ account: value }) }
         },
         () => this.accountHandler.update({ ...account, deleteAccount: true }, account.guid)
@@ -84,6 +87,7 @@ export class FacilitySettingsDeleteComponent extends FacilitySettingsDetailBase 
     if (this.saveState === 'error') {
       return;
     }
+    this.notifications.success('Account deleted', { message: account.name });
     const nextAccount = this.account();
     if (nextAccount?.guid) {
       await this.navigation.openAccount(nextAccount.guid);
@@ -111,7 +115,13 @@ export class FacilitySettingsDeleteComponent extends FacilitySettingsDetailBase 
 
     await this.runSave('Deleting facility', async () => {
       await this.commandBoundary.execute(
-        { entityKind: 'facility', changeKind: 'delete', entityGuid: facility.guid, label: 'Deleting facility' },
+        {
+          entityKind: 'facility',
+          changeKind: 'delete',
+          entityGuid: facility.guid,
+          label: 'Deleting facility',
+          notification: { entityName: facility.name }
+        },
         () => this.facilityHandler.delete(facility, account.guid, phase => {
           this.loadingService.setCurrentLoadingIndex(phase.index);
         })

--- a/src/app/v1/facility/settings/facility-settings-detail.base.ts
+++ b/src/app/v1/facility/settings/facility-settings-detail.base.ts
@@ -63,6 +63,7 @@ export abstract class FacilitySettingsDetailBase extends SettingsDetailBase {
           changeKind: 'update',
           entityGuid: updatedAccount?.guid ?? updatedFacility.guid,
           label,
+          notification: { suppressSuccessToast: true },
           publication: {
             mode: 'patch',
             buildPatch: value => ({

--- a/src/app/v1/facility/settings/portfolio-transition/portfolio-transition-settings.component.ts
+++ b/src/app/v1/facility/settings/portfolio-transition/portfolio-transition-settings.component.ts
@@ -103,6 +103,10 @@ export class PortfolioTransitionSettingsComponent extends FacilitySettingsDetail
           changeKind: 'update',
           entityGuid: account.guid,
           label: 'Converting to portfolio',
+          notification: {
+            successTitle: 'Portfolio mode enabled',
+            successMessage: addFacility ? `${newFacilityName} was added to the account.` : undefined
+          },
           publication: { mode: 'reload' }
         },
         async (): Promise<PortfolioTransitionResult> => {

--- a/src/app/v1/shared/notifications/command-notification-bridge.service.spec.ts
+++ b/src/app/v1/shared/notifications/command-notification-bridge.service.spec.ts
@@ -1,0 +1,92 @@
+import { TestBed } from '@angular/core/testing';
+import { WorkspaceCommittedChange } from '@data/account-workspace/workspace-commands.models';
+import { Subject } from 'rxjs';
+import { vi } from 'vitest';
+import { WorkspaceCommandBoundary } from '@data/account-workspace/workspace-command-boundary.service';
+import { CommandNotificationBridgeService } from './command-notification-bridge.service';
+import { NotificationService } from './notification.service';
+
+describe('CommandNotificationBridgeService', () => {
+  let committedChanges: Subject<WorkspaceCommittedChange>;
+  let success: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    committedChanges = new Subject<WorkspaceCommittedChange>();
+    success = vi.fn();
+    TestBed.configureTestingModule({
+      providers: [
+        CommandNotificationBridgeService,
+        { provide: WorkspaceCommandBoundary, useValue: { committedChange$: committedChanges.asObservable() } },
+        { provide: NotificationService, useValue: { success } }
+      ]
+    });
+    TestBed.inject(CommandNotificationBridgeService);
+  });
+
+  afterEach(() => {
+    committedChanges.complete();
+  });
+
+  it('creates success toasts for add, update, delete, and bulk committed changes', () => {
+    emitChange({ entityKind: 'facility', changeKind: 'add' });
+    emitChange({ entityKind: 'meter', changeKind: 'update' });
+    emitChange({ entityKind: 'predictor', changeKind: 'delete' });
+    emitChange({ entityKind: 'meterData', changeKind: 'bulk' });
+
+    expect(success.mock.calls.map(call => call[0])).toEqual([
+      'Facility created',
+      'Meter updated',
+      'Predictor deleted',
+      'Meter data updated'
+    ]);
+  });
+
+  it('honors custom success copy', () => {
+    emitChange({
+      entityKind: 'account',
+      changeKind: 'update',
+      notification: {
+        successTitle: 'Portfolio mode enabled',
+        successMessage: 'North Plant was added to the account.'
+      }
+    });
+
+    expect(success).toHaveBeenCalledWith(
+      'Portfolio mode enabled',
+      { message: 'North Plant was added to the account.' }
+    );
+  });
+
+  it('uses an entity name override in default copy', () => {
+    emitChange({
+      entityKind: 'facility',
+      changeKind: 'delete',
+      notification: { entityName: 'North Plant' }
+    });
+
+    expect(success).toHaveBeenCalledWith('North Plant deleted', { message: undefined });
+  });
+
+  it('suppresses success toasts when requested', () => {
+    emitChange({
+      entityKind: 'account',
+      changeKind: 'update',
+      notification: { suppressSuccessToast: true }
+    });
+
+    expect(success).not.toHaveBeenCalled();
+  });
+
+  it('does not toast when no committed change is emitted', () => {
+    expect(success).not.toHaveBeenCalled();
+  });
+
+  function emitChange(change: Partial<WorkspaceCommittedChange>): void {
+    committedChanges.next({
+      entityKind: 'account',
+      changeKind: 'update',
+      accountGuid: 'account-a',
+      ...change
+    });
+  }
+});

--- a/src/app/v1/shared/notifications/command-notification-bridge.service.ts
+++ b/src/app/v1/shared/notifications/command-notification-bridge.service.ts
@@ -1,0 +1,60 @@
+import { DestroyRef, Injectable, inject } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { WorkspaceChangeKind, WorkspaceCommittedChange, WorkspaceEntityKind } from '@data/account-workspace/workspace-commands.models';
+import { WorkspaceCommandBoundary } from '@data/account-workspace/workspace-command-boundary.service';
+import { NotificationService } from './notification.service';
+
+const ENTITY_LABELS: Record<WorkspaceEntityKind, string> = {
+  account: 'Account',
+  facility: 'Facility',
+  meter: 'Meter',
+  meterData: 'Meter data',
+  meterGroup: 'Meter group',
+  predictor: 'Predictor',
+  predictorData: 'Predictor data',
+  facilityAnalysis: 'Facility analysis',
+  accountAnalysis: 'Account analysis',
+  facilityReport: 'Facility report',
+  accountReport: 'Account report',
+  customEmissions: 'Custom emissions item',
+  customFuel: 'Custom fuel',
+  customGWP: 'Custom GWP',
+  energyUseGroup: 'Energy-use group',
+  energyUseEquipment: 'Energy-use equipment'
+};
+
+const CHANGE_LABELS: Record<WorkspaceChangeKind, string> = {
+  add: 'created',
+  update: 'updated',
+  delete: 'deleted',
+  bulk: 'updated'
+};
+
+@Injectable({ providedIn: 'root' })
+export class CommandNotificationBridgeService {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly commandBoundary = inject(WorkspaceCommandBoundary);
+  private readonly notifications = inject(NotificationService);
+
+  constructor() {
+    this.commandBoundary.committedChange$
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(change => this.notifyCommittedChange(change));
+  }
+
+  private notifyCommittedChange(change: WorkspaceCommittedChange): void {
+    if (change.notification?.suppressSuccessToast) {
+      return;
+    }
+
+    this.notifications.success(
+      change.notification?.successTitle ?? this.defaultSuccessTitle(change),
+      { message: change.notification?.successMessage }
+    );
+  }
+
+  private defaultSuccessTitle(change: WorkspaceCommittedChange): string {
+    const entityLabel = change.notification?.entityName || ENTITY_LABELS[change.entityKind];
+    return `${entityLabel} ${CHANGE_LABELS[change.changeKind]}`;
+  }
+}

--- a/src/app/v1/shared/notifications/notification.service.spec.ts
+++ b/src/app/v1/shared/notifications/notification.service.spec.ts
@@ -1,0 +1,68 @@
+import { vi } from 'vitest';
+import { NotificationService } from './notification.service';
+
+describe('NotificationService', () => {
+  let service: NotificationService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    service = new NotificationService();
+  });
+
+  afterEach(() => {
+    service.ngOnDestroy();
+    vi.useRealTimers();
+  });
+
+  it('queues at most three visible notifications', () => {
+    service.success('One', { durationMs: 0 });
+    service.info('Two', { durationMs: 0 });
+    service.warning('Three', { durationMs: 0 });
+    service.danger('Four', { durationMs: 0 });
+
+    expect(service.notifications().map(notification => notification.title)).toEqual(['Two', 'Three', 'Four']);
+  });
+
+  it('applies default durations by tone', () => {
+    expect(service.success('Saved').durationMs).toBe(5000);
+    expect(service.info('Heads up').durationMs).toBe(5000);
+    expect(service.warning('Check this').durationMs).toBe(8000);
+    expect(service.danger('Could not save').durationMs).toBe(8000);
+  });
+
+  it('dismisses notifications automatically after their duration', async () => {
+    const notification = service.success('Saved', { durationMs: 1500 });
+
+    await vi.advanceTimersByTimeAsync(1499);
+    expect(service.notifications()).toContain(notification);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(service.notifications()).not.toContain(notification);
+  });
+
+  it('dismisses one notification or all notifications', () => {
+    const first = service.success('Saved', { durationMs: 0 });
+    service.danger('Could not save', { durationMs: 0 });
+
+    service.dismiss(first.id);
+    expect(service.notifications().map(notification => notification.title)).toEqual(['Could not save']);
+
+    service.dismissAll();
+    expect(service.notifications()).toEqual([]);
+  });
+
+  it('preserves supplied title and message copy', () => {
+    service.warning('Backup completed with warnings', {
+      message: 'Review skipped archive files.',
+      dismissible: false,
+      durationMs: 0
+    });
+
+    expect(service.notifications()[0]).toMatchObject({
+      tone: 'warning',
+      title: 'Backup completed with warnings',
+      message: 'Review skipped archive files.',
+      dismissible: false
+    });
+  });
+});

--- a/src/app/v1/shared/notifications/notification.service.ts
+++ b/src/app/v1/shared/notifications/notification.service.ts
@@ -1,0 +1,122 @@
+import { Injectable, OnDestroy, signal } from '@angular/core';
+
+const MAX_VISIBLE_NOTIFICATIONS = 3;
+const DEFAULT_SUCCESS_DURATION_MS = 5000;
+const DEFAULT_INFO_DURATION_MS = 5000;
+const DEFAULT_WARNING_DURATION_MS = 8000;
+const DEFAULT_DANGER_DURATION_MS = 8000;
+
+let nextNotificationId = 0;
+
+export type NotificationTone = 'success' | 'danger' | 'warning' | 'info';
+
+export interface NotificationAction {
+  readonly label: string;
+  readonly ariaLabel?: string;
+}
+
+export interface NotificationRequest {
+  readonly tone: NotificationTone;
+  readonly title: string;
+  readonly message?: string;
+  readonly durationMs?: number;
+  readonly dismissible?: boolean;
+  readonly action?: NotificationAction;
+}
+
+export type NotificationShortcutOptions = Omit<NotificationRequest, 'tone' | 'title'>;
+
+export interface NotificationToast extends NotificationRequest {
+  readonly id: string;
+  readonly durationMs: number;
+  readonly dismissible: boolean;
+  readonly createdAt: number;
+}
+
+@Injectable({ providedIn: 'root' })
+export class NotificationService implements OnDestroy {
+  private readonly writableNotifications = signal<NotificationToast[]>([]);
+  private readonly timeoutIds = new Map<string, ReturnType<typeof setTimeout>>();
+
+  readonly notifications = this.writableNotifications.asReadonly();
+
+  ngOnDestroy(): void {
+    this.dismissAll();
+  }
+
+  show(request: NotificationRequest): NotificationToast {
+    const notification: NotificationToast = {
+      ...request,
+      id: `v1-toast-${++nextNotificationId}`,
+      createdAt: Date.now(),
+      durationMs: request.durationMs ?? getDefaultDuration(request.tone),
+      dismissible: request.dismissible ?? true
+    };
+
+    this.writableNotifications.update(current => {
+      const next = [...current, notification];
+      const removed = next.slice(0, Math.max(0, next.length - MAX_VISIBLE_NOTIFICATIONS));
+      removed.forEach(item => this.clearDismissTimer(item.id));
+      return next.slice(-MAX_VISIBLE_NOTIFICATIONS);
+    });
+    this.scheduleDismiss(notification);
+    return notification;
+  }
+
+  success(title: string, options: NotificationShortcutOptions = {}): NotificationToast {
+    return this.show({ ...options, title, tone: 'success' });
+  }
+
+  danger(title: string, options: NotificationShortcutOptions = {}): NotificationToast {
+    return this.show({ ...options, title, tone: 'danger' });
+  }
+
+  warning(title: string, options: NotificationShortcutOptions = {}): NotificationToast {
+    return this.show({ ...options, title, tone: 'warning' });
+  }
+
+  info(title: string, options: NotificationShortcutOptions = {}): NotificationToast {
+    return this.show({ ...options, title, tone: 'info' });
+  }
+
+  dismiss(id: string): void {
+    this.clearDismissTimer(id);
+    this.writableNotifications.update(current => current.filter(notification => notification.id !== id));
+  }
+
+  dismissAll(): void {
+    this.timeoutIds.forEach(timeoutId => clearTimeout(timeoutId));
+    this.timeoutIds.clear();
+    this.writableNotifications.set([]);
+  }
+
+  private scheduleDismiss(notification: NotificationToast): void {
+    if (notification.durationMs <= 0) {
+      return;
+    }
+    const timeoutId = setTimeout(() => this.dismiss(notification.id), notification.durationMs);
+    this.timeoutIds.set(notification.id, timeoutId);
+  }
+
+  private clearDismissTimer(id: string): void {
+    const timeoutId = this.timeoutIds.get(id);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+      this.timeoutIds.delete(id);
+    }
+  }
+}
+
+function getDefaultDuration(tone: NotificationTone): number {
+  switch (tone) {
+    case 'danger':
+      return DEFAULT_DANGER_DURATION_MS;
+    case 'warning':
+      return DEFAULT_WARNING_DURATION_MS;
+    case 'info':
+      return DEFAULT_INFO_DURATION_MS;
+    case 'success':
+    default:
+      return DEFAULT_SUCCESS_DURATION_MS;
+  }
+}

--- a/src/app/v1/shared/notifications/notifications.module.ts
+++ b/src/app/v1/shared/notifications/notifications.module.ts
@@ -1,0 +1,10 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { ToastHostComponent } from './toast-host.component';
+
+@NgModule({
+  declarations: [ToastHostComponent],
+  imports: [CommonModule],
+  exports: [ToastHostComponent]
+})
+export class NotificationsModule { }

--- a/src/app/v1/shared/notifications/toast-host.component.css
+++ b/src/app/v1/shared/notifications/toast-host.component.css
@@ -1,0 +1,108 @@
+:host {
+  display: block;
+  width: 100%;
+  pointer-events: none;
+}
+
+.v1-toast-stack {
+  display: grid;
+  gap: .65rem;
+}
+
+.v1-toast {
+  --v1-toast-accent: var(--v1-info);
+
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: .7rem;
+  align-items: start;
+  min-height: 4rem;
+  padding: .85rem;
+  border: 1px solid color-mix(in srgb, var(--v1-toast-accent) 42%, var(--v1-border));
+  border-left-width: 4px;
+  border-radius: var(--v1-radius);
+  background: color-mix(in srgb, var(--v1-toast-accent) 7%, var(--v1-surface));
+  color: var(--v1-text);
+  box-shadow: 0 .7rem 2rem var(--v1-shadow);
+  pointer-events: auto;
+}
+
+.v1-toast--success {
+  --v1-toast-accent: var(--v1-success);
+}
+
+.v1-toast--danger {
+  --v1-toast-accent: var(--v1-danger);
+}
+
+.v1-toast--warning {
+  --v1-toast-accent: var(--v1-warning);
+}
+
+.v1-toast--info {
+  --v1-toast-accent: var(--v1-info);
+}
+
+.v1-toast__icon {
+  display: grid;
+  width: 1.5rem;
+  height: 1.5rem;
+  place-items: center;
+  color: var(--v1-toast-accent);
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.v1-toast__content {
+  display: grid;
+  gap: .2rem;
+  min-width: 0;
+}
+
+.v1-toast__content strong,
+.v1-toast__content p {
+  margin: 0;
+}
+
+.v1-toast__content strong {
+  color: var(--v1-text);
+  font-size: .92rem;
+  line-height: 1.2;
+}
+
+.v1-toast__content p {
+  color: var(--v1-muted);
+  font-size: .82rem;
+  line-height: 1.35;
+}
+
+.v1-toast__close {
+  display: grid;
+  width: 1.75rem;
+  height: 1.75rem;
+  place-items: center;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--v1-radius-sm);
+  background: transparent;
+  color: var(--v1-muted);
+  cursor: pointer;
+}
+
+.v1-toast__close:hover,
+.v1-toast__close:focus-visible {
+  border-color: color-mix(in srgb, var(--v1-toast-accent) 45%, var(--v1-border));
+  background: color-mix(in srgb, var(--v1-toast-accent) 10%, var(--v1-surface));
+  color: var(--v1-toast-accent);
+}
+
+:host-context(.v1-contrast-strong) .v1-toast {
+  border-width: 2px;
+  border-left-width: 5px;
+}
+
+@media (max-width: 640px) {
+  :host {
+    width: 100%;
+  }
+}

--- a/src/app/v1/shared/notifications/toast-host.component.html
+++ b/src/app/v1/shared/notifications/toast-host.component.html
@@ -1,0 +1,36 @@
+@let visibleNotifications = notifications();
+
+@if (visibleNotifications.length > 0) {
+  <aside class="v1-toast-stack" aria-label="Notifications">
+    @for (notification of visibleNotifications; track notification.id) {
+      @let metadata = toneMetadata[notification.tone];
+
+      <article
+        class="v1-toast"
+        [class.v1-toast--success]="notification.tone === 'success'"
+        [class.v1-toast--danger]="notification.tone === 'danger'"
+        [class.v1-toast--warning]="notification.tone === 'warning'"
+        [class.v1-toast--info]="notification.tone === 'info'"
+        [attr.role]="metadata.role"
+        [attr.aria-live]="metadata.live">
+        <span class="v1-toast__icon fa {{ metadata.iconClass }}" aria-hidden="true"></span>
+        <div class="v1-toast__content">
+          <strong>{{ notification.title }}</strong>
+          @if (notification.message) {
+            <p>{{ notification.message }}</p>
+          }
+        </div>
+        @if (notification.dismissible) {
+          <button
+            type="button"
+            class="v1-toast__close"
+            title="Dismiss notification"
+            [attr.aria-label]="'Dismiss notification: ' + notification.title"
+            (click)="dismiss(notification.id)">
+            <span class="fa fa-xmark" aria-hidden="true"></span>
+          </button>
+        }
+      </article>
+    }
+  </aside>
+}

--- a/src/app/v1/shared/notifications/toast-host.component.spec.ts
+++ b/src/app/v1/shared/notifications/toast-host.component.spec.ts
@@ -1,0 +1,70 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NotificationService } from './notification.service';
+import { NotificationsModule } from './notifications.module';
+import { ToastHostComponent } from './toast-host.component';
+
+describe('ToastHostComponent', () => {
+  let fixture: ComponentFixture<ToastHostComponent>;
+  let notifications: NotificationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [NotificationsModule]
+    });
+    notifications = TestBed.inject(NotificationService);
+    notifications.dismissAll();
+    fixture = TestBed.createComponent(ToastHostComponent);
+  });
+
+  afterEach(() => {
+    notifications.dismissAll();
+  });
+
+  it('renders no host chrome when no notifications are visible', () => {
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.v1-toast-stack')).toBeNull();
+  });
+
+  it('renders tone classes and icons for each notification tone', () => {
+    notifications.success('Saved', { durationMs: 0 });
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.v1-toast--success .fa-circle-check')).toBeTruthy();
+
+    notifications.dismissAll();
+    notifications.danger('Save failed', { durationMs: 0 });
+    notifications.warning('Check results', { durationMs: 0 });
+    notifications.info('Import running', { durationMs: 0 });
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.v1-toast--danger .fa-circle-xmark')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('.v1-toast--warning .fa-triangle-exclamation')).toBeTruthy();
+    expect(fixture.nativeElement.querySelector('.v1-toast--info .fa-circle-info')).toBeTruthy();
+    expect(fixture.nativeElement.querySelectorAll('.v1-toast')).toHaveLength(3);
+  });
+
+  it('uses assertive semantics for danger and polite semantics for other tones', () => {
+    notifications.danger('Save failed', { durationMs: 0 });
+    notifications.info('Import running', { durationMs: 0 });
+    fixture.detectChanges();
+
+    const danger = fixture.nativeElement.querySelector('.v1-toast--danger');
+    const info = fixture.nativeElement.querySelector('.v1-toast--info');
+    expect(danger.getAttribute('role')).toBe('alert');
+    expect(danger.getAttribute('aria-live')).toBe('assertive');
+    expect(info.getAttribute('role')).toBe('status');
+    expect(info.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('dismisses a notification from its close button', () => {
+    notifications.success('Saved', { durationMs: 0 });
+    fixture.detectChanges();
+
+    const closeButton: HTMLButtonElement = fixture.nativeElement.querySelector('.v1-toast__close');
+    closeButton.click();
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('.v1-toast')).toBeNull();
+  });
+});

--- a/src/app/v1/shared/notifications/toast-host.component.ts
+++ b/src/app/v1/shared/notifications/toast-host.component.ts
@@ -1,0 +1,30 @@
+import { Component, inject } from '@angular/core';
+import { NotificationService, NotificationTone } from './notification.service';
+
+interface NotificationToneMetadata {
+  readonly iconClass: string;
+  readonly role: 'alert' | 'status';
+  readonly live: 'assertive' | 'polite';
+}
+
+@Component({
+  selector: 'app-notification-toast-host',
+  templateUrl: './toast-host.component.html',
+  styleUrls: ['./toast-host.component.css'],
+  standalone: false
+})
+export class ToastHostComponent {
+  private readonly notificationService = inject(NotificationService);
+
+  readonly notifications = this.notificationService.notifications;
+  readonly toneMetadata: Record<NotificationTone, NotificationToneMetadata> = {
+    success: { iconClass: 'fa-circle-check', role: 'status', live: 'polite' },
+    danger: { iconClass: 'fa-circle-xmark', role: 'alert', live: 'assertive' },
+    warning: { iconClass: 'fa-triangle-exclamation', role: 'status', live: 'polite' },
+    info: { iconClass: 'fa-circle-info', role: 'status', live: 'polite' }
+  };
+
+  dismiss(id: string): void {
+    this.notificationService.dismiss(id);
+  }
+}

--- a/src/app/v1/shell/workspace-shell/workspace-shell.component.css
+++ b/src/app/v1/shell/workspace-shell/workspace-shell.component.css
@@ -78,6 +78,16 @@
   background: transparent;
 }
 
+.v1-workspace__notifications {
+  grid-area: main;
+  align-self: end;
+  justify-self: end;
+  z-index: 4;
+  width: min(24rem, calc(100% - 1.5rem));
+  margin: clamp(.75rem, 2vw, 1.25rem);
+  pointer-events: none;
+}
+
 .v1-workspace__main > router-outlet + * {
   display: block;
 }
@@ -160,6 +170,15 @@
     display: flex;
     flex-direction: column;
     min-height: 100%;
+  }
+
+  .v1-workspace__notifications {
+    position: absolute;
+    right: .75rem;
+    bottom: .75rem;
+    left: .75rem;
+    width: auto;
+    margin: 0;
   }
 }
 

--- a/src/app/v1/shell/workspace-shell/workspace-shell.component.html
+++ b/src/app/v1/shell/workspace-shell/workspace-shell.component.html
@@ -18,6 +18,10 @@
     <router-outlet></router-outlet>
   </section>
 
+  <div class="v1-workspace__notifications">
+    <app-notification-toast-host></app-notification-toast-host>
+  </div>
+
   @if (isSupportPanelOpen) {
     <app-support-panel></app-support-panel>
   }

--- a/src/app/v1/shell/workspace-shell/workspace-shell.component.spec.ts
+++ b/src/app/v1/shell/workspace-shell/workspace-shell.component.spec.ts
@@ -3,6 +3,8 @@ import { NgModule } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterModule } from '@angular/router';
 import { vi } from 'vitest';
+import { CommandNotificationBridgeService } from '../../shared/notifications/command-notification-bridge.service';
+import { NotificationsModule } from '../../shared/notifications/notifications.module';
 import { PrimaryRailComponent } from '../primary-rail/primary-rail.component';
 import { SectionNavComponent } from '../section-nav/section-nav.component';
 import { SupportPanelComponent } from '../support-panel/support-panel.component';
@@ -10,7 +12,7 @@ import { WorkspaceNavigationService, SUPPORT_PANEL_TABS, WORKSPACE_SECTIONS } fr
 import { WorkspaceShellComponent } from './workspace-shell.component';
 
 @NgModule({
-  imports: [CommonModule, RouterModule.forRoot([])],
+  imports: [CommonModule, NotificationsModule, RouterModule.forRoot([])],
   declarations: [
     WorkspaceShellComponent,
     PrimaryRailComponent,
@@ -62,6 +64,7 @@ describe('WorkspaceShellComponent', () => {
     TestBed.configureTestingModule({
       imports: [WorkspaceShellTestModule],
       providers: [
+        { provide: CommandNotificationBridgeService, useValue: {} },
         { provide: WorkspaceNavigationService, useValue: navigation }
       ]
     });
@@ -73,6 +76,12 @@ describe('WorkspaceShellComponent', () => {
     expect(fixture.nativeElement.querySelector('app-primary-rail')).not.toBeNull();
     expect(fixture.nativeElement.querySelector('app-section-nav')).not.toBeNull();
     expect(fixture.nativeElement.querySelector('app-support-panel')).not.toBeNull();
+  });
+
+  it('mounts notification toasts in the main workspace grid area', () => {
+    const region = fixture.nativeElement.querySelector('.v1-workspace__notifications');
+
+    expect(region.querySelector('app-notification-toast-host')).not.toBeNull();
   });
 
   it('applies motion classes from the current v1 route transition', () => {

--- a/src/app/v1/shell/workspace-shell/workspace-shell.component.ts
+++ b/src/app/v1/shell/workspace-shell/workspace-shell.component.ts
@@ -1,4 +1,5 @@
 import { Component, inject } from '@angular/core';
+import { CommandNotificationBridgeService } from '../../shared/notifications/command-notification-bridge.service';
 import { WorkspaceNavigationService } from '../workspace-navigation.service';
 
 @Component({
@@ -8,5 +9,6 @@ import { WorkspaceNavigationService } from '../workspace-navigation.service';
   standalone: false
 })
 export class WorkspaceShellComponent {
+  private readonly commandNotificationBridge = inject(CommandNotificationBridgeService);
   readonly navigation = inject(WorkspaceNavigationService);
 }

--- a/src/app/v1/v1.module.ts
+++ b/src/app/v1/v1.module.ts
@@ -10,6 +10,7 @@ import { FacilitySettingsModule } from './facility/settings/facility-settings.mo
 import { ShellHeaderComponent } from './shell/header/shell-header.component';
 import { PrimaryRailComponent } from './shell/primary-rail/primary-rail.component';
 import { SectionNavComponent } from './shell/section-nav/section-nav.component';
+import { NotificationsModule } from './shared/notifications/notifications.module';
 import { ShellComponent } from './shell/shell.component';
 import { SupportPanelComponent } from './shell/support-panel/support-panel.component';
 import { WorkspaceShellComponent } from './shell/workspace-shell/workspace-shell.component';
@@ -29,6 +30,7 @@ import { WelcomeComponent } from './welcome/welcome.component';
   ],
   imports: [
     CommonModule,
+    NotificationsModule,
     PortalModule,
     AccountSettingsModule,
     FacilitySettingsModule,

--- a/src/app/v1/welcome/create-account/create-account.component.ts
+++ b/src/app/v1/welcome/create-account/create-account.component.ts
@@ -136,7 +136,13 @@ export class CreateAccountComponent {
       name: account.name
     };
     const result = await this.commandBoundary.execute(
-      { entityKind: 'facility', changeKind: 'add', entityGuid: facility.guid, label: 'Adding starter site' },
+      {
+        entityKind: 'facility',
+        changeKind: 'add',
+        entityGuid: facility.guid,
+        label: 'Adding starter site',
+        notification: { suppressSuccessToast: true }
+      },
       () => this.facilityHandler.add(
         facility,
         account.guid,

--- a/src/app/v1/welcome/welcome.component.css
+++ b/src/app/v1/welcome/welcome.component.css
@@ -6,6 +6,15 @@
   padding: clamp(1rem, 3vw, 2.5rem) 0 3rem;
 }
 
+.v1-welcome__notifications {
+  position: fixed;
+  right: clamp(.75rem, 2vw, 1.25rem);
+  bottom: clamp(.75rem, 2vw, 1.25rem);
+  z-index: 80;
+  width: min(24rem, calc(100vw - 1.5rem));
+  pointer-events: none;
+}
+
 .v1-welcome__hero {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(18rem, 1fr);

--- a/src/app/v1/welcome/welcome.component.html
+++ b/src/app/v1/welcome/welcome.component.html
@@ -1,6 +1,10 @@
 @let recent = recentAccount();
 
 <main class="v1-welcome" aria-labelledby="v1-welcome-title">
+  <div class="v1-welcome__notifications">
+    <app-notification-toast-host></app-notification-toast-host>
+  </div>
+
   <section class="v1-welcome__hero v1-welcome__motion-card">
     <div class="v1-welcome__copy">
       <p class="v1-eyebrow">Utility tracking and analysis</p>

--- a/src/app/v1/welcome/welcome.component.spec.ts
+++ b/src/app/v1/welcome/welcome.component.spec.ts
@@ -7,6 +7,7 @@ import { ApplicationLifecycleService } from '@app/application-lifecycle/applicat
 import { EmailListSubscribeService } from '@shared/email-list-subscribe/email-list-subscribe.service';
 import { BehaviorSubject, of } from 'rxjs';
 import { WorkspaceNavigationService } from '../shell/workspace-navigation.service';
+import { NotificationService } from '../shared/notifications/notification.service';
 import { WelcomeComponent } from './welcome.component';
 
 describe('WelcomeComponent', () => {
@@ -46,6 +47,10 @@ describe('WelcomeComponent', () => {
     fixture.detectChanges();
   });
 
+  afterEach(() => {
+    TestBed.inject(NotificationService).dismissAll();
+  });
+
   it('opens the selected welcome panel from its graphic tile', () => {
     const importTile: HTMLButtonElement | undefined = Array.from<HTMLButtonElement>(fixture.nativeElement.querySelectorAll('button.v1-welcome__action'))
       .find(button => button.textContent?.includes('Import'));
@@ -64,6 +69,18 @@ describe('WelcomeComponent', () => {
 
     expect(navigation.openFacility).toHaveBeenCalledWith('facility-new');
     expect(navigation.openWorkspace).not.toHaveBeenCalled();
+  });
+
+  it('mounts the notification host and shows account creation feedback', async () => {
+    await fixture.componentInstance.openCreatedOrImportedAccount({
+      path: 'portfolio',
+      account: { guid: 'account-new', name: 'New Portfolio' } as any
+    });
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelector('app-notification-toast-host')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('.v1-toast--success')?.textContent).toContain('Account created');
+    expect(fixture.nativeElement.querySelector('.v1-toast--success')?.textContent).toContain('New Portfolio');
   });
 
   it('opens the workspace default after portfolio creation or existing import paths', async () => {

--- a/src/app/v1/welcome/welcome.component.ts
+++ b/src/app/v1/welcome/welcome.component.ts
@@ -3,6 +3,8 @@ import { RouterModule } from '@angular/router';
 import { ApplicationLifecycleService } from '@app/application-lifecycle/application-lifecycle.service';
 import { IdbAccount } from '@data/models/idbModels/account';
 import { WorkspaceNavigationService } from '../shell/workspace-navigation.service';
+import { NotificationService } from '../shared/notifications/notification.service';
+import { NotificationsModule } from '../shared/notifications/notifications.module';
 import { CreateAccountComponent } from './create-account/create-account.component';
 import { EmailListSignupComponent } from './email-list-signup/email-list-signup.component';
 import { ExampleAccountComponent } from './example-account/example-account.component';
@@ -18,12 +20,14 @@ import { CreateAccountResult, WELCOME_ACTIONS } from './welcome.models';
     CreateAccountComponent,
     ImportAccountBackupComponent,
     ExampleAccountComponent,
-    EmailListSignupComponent
+    EmailListSignupComponent,
+    NotificationsModule
   ],
   standalone: true
 })
 export class WelcomeComponent {
   private readonly lifecycle = inject(ApplicationLifecycleService);
+  private readonly notifications = inject(NotificationService);
   readonly navigation = inject(WorkspaceNavigationService);
   readonly actions = signal(WELCOME_ACTIONS);
   readonly loadingAccountGuid = signal<string | undefined>(undefined);
@@ -66,6 +70,7 @@ export class WelcomeComponent {
   async openCreatedOrImportedAccount(result: IdbAccount | CreateAccountResult): Promise<void> {
     this.closePanel();
     if (isCreateAccountResult(result)) {
+      this.notifications.success('Account created', { message: result.account.name });
       if (result.path === 'singleFacility' && result.facility) {
         await this.navigation.openFacility(result.facility.guid);
         return;
@@ -73,6 +78,7 @@ export class WelcomeComponent {
       await this.openAccount(result.account);
       return;
     }
+    this.notifications.success('Account imported', { message: result.name });
     await this.openAccount(result);
   }
 


### PR DESCRIPTION
This pull request introduces a new system for handling user feedback via toast notifications after workspace operations, and provides a flexible notification mechanism for workspace commands. It adds optional notification hints to workspace command events, centralizes toast notification handling with a new service, and updates relevant UI components to use these features. Additionally, comprehensive tests are included to ensure correct notification behavior.

**Notification System Enhancements**

* Added a new `WorkspaceCommandNotificationOptions` interface and extended `WorkspaceCommittedChange` and `WorkspaceCommandOptions` to support optional notification hints, such as custom toast titles/messages, entity name overrides, and success toast suppression. [[1]](diffhunk://#diff-6c5c4962d94957cfd208e26a443426e2242dd43a636cfd33f4d2e7ed42a22dcdR33-R43) [[2]](diffhunk://#diff-6c5c4962d94957cfd208e26a443426e2242dd43a636cfd33f4d2e7ed42a22dcdR54) [[3]](diffhunk://#diff-f642c3270dfe2debd527dbd9421f5b024f1af783747439dbc459bc305525f086R21) [[4]](diffhunk://#diff-f642c3270dfe2debd527dbd9421f5b024f1af783747439dbc459bc305525f086R35) [[5]](diffhunk://#diff-f642c3270dfe2debd527dbd9421f5b024f1af783747439dbc459bc305525f086L169-R172)
* Updated the documentation to specify best practices for using toast notifications for user feedback.
* Introduced the `CommandNotificationBridgeService`, which listens for committed workspace changes and triggers toast notifications according to the new notification options. This service centralizes notification logic and supports custom and default messages.
* Added comprehensive tests for the new notification bridge service, covering default and custom messages, entity name overrides, and suppression behavior.

**UI Component Integration**

* Updated account and facility settings components to provide notification options when executing workspace commands, including suppression of redundant toasts and support for custom messages. Also, added direct toast calls for certain destructive actions. [[1]](diffhunk://#diff-30afb238f42162fb3d7d62cbd52fd7345cd4bad6d0b3bc879b231cfd867ba8d8R45) [[2]](diffhunk://#diff-26ae553450e6d1d874146bebd3e2a1f26ad9e6d082606d8117b3e1c716cf0dc1R160) [[3]](diffhunk://#diff-0a5e45102845fe98abbb56418e3863277a6175c21ee512b6095b0d615a6ea16cR64) [[4]](diffhunk://#diff-0a5e45102845fe98abbb56418e3863277a6175c21ee512b6095b0d615a6ea16cR77) [[5]](diffhunk://#diff-91a8a3a3c6dc63778d659092829c4320c9a478e7edf217bd3be1be3310e53e0bR78) [[6]](diffhunk://#diff-91a8a3a3c6dc63778d659092829c4320c9a478e7edf217bd3be1be3310e53e0bR90) [[7]](diffhunk://#diff-91a8a3a3c6dc63778d659092829c4320c9a478e7edf217bd3be1be3310e53e0bL114-R124) [[8]](diffhunk://#diff-873bc2a6971a031281f8b1290a1ea900015756946424d96219f91938d350f5e7R61) [[9]](diffhunk://#diff-f857f35681f4cb500b2df567c9802112cf9863fc6277e9e465990a3f818fa465R66) [[10]](diffhunk://#diff-21d4e980c2d36372bdb6648df3d89869be51ea6af5000566b7510bcd5564dee2R106-R109) [[11]](diffhunk://#diff-0a5e45102845fe98abbb56418e3863277a6175c21ee512b6095b0d615a6ea16cR3) [[12]](diffhunk://#diff-0a5e45102845fe98abbb56418e3863277a6175c21ee512b6095b0d615a6ea16cR16) [[13]](diffhunk://#diff-91a8a3a3c6dc63778d659092829c4320c9a478e7edf217bd3be1be3310e53e0bR6) [[14]](diffhunk://#diff-91a8a3a3c6dc63778d659092829c4320c9a478e7edf217bd3be1be3310e53e0bR19)

**Testing and Quality Assurance**

* Added a new test to ensure that notification hints are passed through committed-change events in the workspace command boundary.

These changes collectively provide a robust, flexible, and consistent notification experience for workspace-related actions across the application.