### PR TITLE
Issue 2668 - add emissions sections in pdf and ppt reports for data quality report

### DIFF
--- a/src/app/v0/data-evaluation/account/account-reports/data-overview-report/data-overview-account-report/account-section-report/account-section-report.component.ts
+++ b/src/app/v0/data-evaluation/account/account-reports/data-overview-report/data-overview-account-report/account-section-report/account-section-report.component.ts
@@ -16,6 +16,8 @@ import { AccountWaterUsageDonutComponent } from '@v0/shared/data-overview/accoun
 import { FacilitiesUsageStackedBarChartComponent } from '@v0/shared/data-overview/facilities-usage-stacked-bar-chart/facilities-usage-stacked-bar-chart.component';
 import { AccountWaterStackedBarChartComponent } from '@v0/shared/data-overview/account-water-stacked-bar-chart/account-water-stacked-bar-chart.component';
 import { MonthlyUtilityUsageLineChartComponent } from '@v0/shared/data-overview/monthly-utility-usage-line-chart/monthly-utility-usage-line-chart.component';
+import { EmissionsDonutComponent } from '@app/v0/shared/data-overview/emissions-donut/emissions-donut.component';
+import { FacilitiesEmissionsStackedBarChartComponent } from '@app/v0/shared/data-overview/facilities-emissions-stacked-bar-chart/facilities-emissions-stacked-bar-chart.component';
 
 @Component({
     selector: 'app-account-section-report',
@@ -61,8 +63,10 @@ export class AccountSectionReportComponent {
   @ViewChild(FacilityUsageDonutComponent) facilityUsageDonut: FacilityUsageDonutComponent;
   @ViewChild(AccountUtilityUsageDonutComponent) accountUtilityUsageDonut: AccountUtilityUsageDonutComponent;
   @ViewChild(AccountWaterUsageDonutComponent) accountWaterUsageDonut: AccountWaterUsageDonutComponent;
+  @ViewChild(EmissionsDonutComponent) emissionsUsageDonut: EmissionsDonutComponent;
   @ViewChild(FacilitiesUsageStackedBarChartComponent) usageStackedBarChart: FacilitiesUsageStackedBarChartComponent;
   @ViewChild(AccountWaterStackedBarChartComponent) accountWaterStackedBarChart: AccountWaterStackedBarChartComponent;
+  @ViewChild(FacilitiesEmissionsStackedBarChartComponent) accountEmissionsStackedBarChart: FacilitiesEmissionsStackedBarChartComponent;
   @ViewChild(MonthlyUtilityUsageLineChartComponent) monthlyUsageLineChart: MonthlyUtilityUsageLineChartComponent;
 
   constructor(
@@ -118,9 +122,25 @@ export class AccountSectionReportComponent {
     return '';
   }
 
+  async getEmissionsUsageDonutImage(): Promise<string> {
+    if (this.emissionsUsageDonut) {
+      const base64Str = await this.emissionsUsageDonut.getChartAsBase64Image();
+      return base64Str;
+    }
+    return '';
+  }
+
   async getUtilityUsageStackedBarImage(): Promise<string> {
     if (this.usageStackedBarChart) {
       const base64Str = await this.usageStackedBarChart.getChartAsBase64Image();
+      return base64Str;
+    }
+    return '';
+  }
+
+  async getEmissionsUsageStackedBarImage(): Promise<string> {
+    if (this.accountEmissionsStackedBarChart) {
+      const base64Str = await this.accountEmissionsStackedBarChart.getChartAsBase64Image();
       return base64Str;
     }
     return '';

--- a/src/app/v0/data-evaluation/account/account-reports/data-overview-report/data-overview-account-report/data-overview-account-report.component.html
+++ b/src/app/v0/data-evaluation/account/account-reports/data-overview-report/data-overview-account-report/data-overview-account-report.component.html
@@ -55,7 +55,7 @@
             </div>
           </div>
         }
-        @if (overviewReport.includeEmissionsSection) {
+        @if (accountData.account.displayEmissions && overviewReport.includeEmissionsSection) {
           <hr>
             <!--account emissions-->
             <div class="row justify-content-center print-break-before">

--- a/src/app/v0/data-evaluation/account/account-reports/data-overview-report/data-overview-account-report/data-overview-account-report.component.ts
+++ b/src/app/v0/data-evaluation/account/account-reports/data-overview-report/data-overview-account-report/data-overview-account-report.component.ts
@@ -6,7 +6,7 @@ import { DataEvaluationService } from '@v0/data-evaluation/data-evaluation.servi
 import { AccountSectionReportComponent } from '@v0/data-evaluation/account/account-reports/data-overview-report/data-overview-account-report/account-section-report/account-section-report.component';
 
 type SectionType = 'usageDonut' | 'map' | 'utilityUsageDonut' | 'utilityUsageStackedBar' | 'monthlyUsageLineChart';
-type DataType = 'energyUse' | 'cost' | 'water';
+type DataType = 'energyUse' | 'cost' | 'water' | 'emissions';
 
 @Component({
   selector: 'app-data-overview-account-report',
@@ -51,12 +51,16 @@ export class DataOverviewAccountReportComponent {
       return await section.getUsageDonutImage();
     } else if (sectionType === 'map') {
       return await section.getMapImage();
-    } else if (sectionType === 'utilityUsageDonut' && dataType !== 'water') {
+    } else if (sectionType === 'utilityUsageDonut' && (dataType !== 'water' && dataType !== 'emissions')) {
       return await section.getUtilityUsageDonutImage();
     } else if (sectionType === 'utilityUsageDonut' && dataType === 'water') {
       return await section.getWaterUsageDonutImage();
-    } else if (sectionType === 'utilityUsageStackedBar' && dataType !== 'water') {
+    } else if (sectionType === 'utilityUsageDonut' && dataType === 'emissions') {
+      return await section.getEmissionsUsageDonutImage();
+    } else if (sectionType === 'utilityUsageStackedBar' && (dataType !== 'water' && dataType !== 'emissions')) {
       return await section.getUtilityUsageStackedBarImage();
+    } else if (sectionType === 'utilityUsageStackedBar' && dataType === 'emissions') {
+      return await section.getEmissionsUsageStackedBarImage();
     } else if (sectionType === 'utilityUsageStackedBar' && dataType === 'water') {
       return await section.getWaterUsageStackedBarImage();
     } else if (sectionType === 'monthlyUsageLineChart') {

--- a/src/app/v0/data-evaluation/account/account-reports/data-overview-report/data-overview-facility-report/data-overview-facility-report.component.html
+++ b/src/app/v0/data-evaluation/account/account-reports/data-overview-report/data-overview-facility-report/data-overview-facility-report.component.html
@@ -62,7 +62,7 @@
               </div>
             </div>
           }
-          @if (overviewReport.includeEmissionsSection) {
+          @if (account?.displayEmissions && overviewReport.includeEmissionsSection) {
             <hr>
               <!--account emissions-->
               <div class="row justify-content-center print-break-before">

--- a/src/app/v0/data-evaluation/account/account-reports/data-overview-report/data-overview-facility-report/data-overview-facility-report.component.ts
+++ b/src/app/v0/data-evaluation/account/account-reports/data-overview-report/data-overview-facility-report/data-overview-facility-report.component.ts
@@ -1,9 +1,11 @@
-import { Component, Input, QueryList, ViewChildren } from '@angular/core';
+import { Component, inject, Input, QueryList, ViewChildren } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { DataOverviewReportSetup } from '@data/models/overview-report';
 import { DataOverviewFacility } from '@v0/data-evaluation/account/account-reports/data-overview-report/data-overview-report.component';
 import { DataEvaluationService } from '@v0/data-evaluation/data-evaluation.service';
 import { FacilitySectionReportComponent } from '@v0/shared/data-overview/facility-section-report/facility-section-report.component';
+import { AccountWorkspaceStore } from '@app/data/account-workspace/account-workspace.store';
+import { IdbAccount } from '@app/data/models/idbModels/account';
 
 @Component({
   selector: 'app-data-overview-facility-report',
@@ -12,6 +14,7 @@ import { FacilitySectionReportComponent } from '@v0/shared/data-overview/facilit
   standalone: false
 })
 export class DataOverviewFacilityReportComponent {
+  private readonly accountWorkspaceStore = inject(AccountWorkspaceStore);
   @Input()
   dataOverviewFacility: DataOverviewFacility;
   @Input()
@@ -19,12 +22,14 @@ export class DataOverviewFacilityReportComponent {
 
   printSub: Subscription;
   print: boolean;
+  account: IdbAccount;
 
   @ViewChildren(FacilitySectionReportComponent) sectionReports !: QueryList<FacilitySectionReportComponent>;
 
   constructor(private dataEvaluationService: DataEvaluationService) { }
 
   ngOnInit(): void {
+    this.account = this.accountWorkspaceStore.account();
     this.printSub = this.dataEvaluationService.print.subscribe(print => {
       this.print = print;
     });
@@ -34,12 +39,12 @@ export class DataOverviewFacilityReportComponent {
     this.printSub.unsubscribe();
   }
 
-  getSectionByType(type: 'energyUse' | 'cost' | 'water'): FacilitySectionReportComponent | undefined {
+  getSectionByType(type: 'energyUse' | 'cost' | 'water' | 'emissions'): FacilitySectionReportComponent | undefined {
     return this.sectionReports.find(section => section.dataType === type);
   }
 
-  async getImage(type: 'energyUse' | 'cost' | 'water',
-    chartType: 'meterStackedLineChart' | 'meterBarChart' | 'annualBarChart' | 'monthlyUsageLineChart'
+  async getImage(type: 'energyUse' | 'cost' | 'water' | 'emissions',
+    chartType: 'meterStackedLineChart' | 'meterBarChart' | 'annualBarChart' | 'monthlyUsageLineChart' | 'meterStackedLineChartEmissions' | 'emissionsBarChart' | 'annualBarChartEmissions' | 'monthlyUsageLineChartEmissions'
   ): Promise<string> {
     const section = this.getSectionByType(type);
     if (!section) {
@@ -53,6 +58,14 @@ export class DataOverviewFacilityReportComponent {
       case 'annualBarChart':
         return await section.getAnnualBarChartImage();
       case 'monthlyUsageLineChart':
+        return await section.getMonthlyUsageLineChartImage();
+      case 'meterStackedLineChartEmissions':
+        return await section.getMeterStackedLineChartEmissionsImage();
+      case 'emissionsBarChart':
+        return await section.getEmissionsBarChartImage();
+      case 'annualBarChartEmissions':
+        return await section.getAnnualBarChartEmissionsImage();
+      case 'monthlyUsageLineChartEmissions':
         return await section.getMonthlyUsageLineChartImage();
       default:
         return '';

--- a/src/app/v0/data-evaluation/account/account-reports/data-overview-report/data-overview-report-ppt.adapter.ts
+++ b/src/app/v0/data-evaluation/account/account-reports/data-overview-report/data-overview-report-ppt.adapter.ts
@@ -17,6 +17,8 @@ import { AnnualSourceData, FacilityOverviewMeter } from '@domain/calculations/da
 import { YearMonthData } from '@data/models/dashboard';
 import { Month, Months } from '@shared/form-data/months';
 import { AccountOverviewData, AccountOverviewFacility } from '@domain/calculations/dashboard-calculations/accountOverviewClass';
+import { EmissionsResults, EmissionsTypes, getEmissionsTypeColor, getEmissionsTypes } from '@app/data/models/eGridEmissions';
+import { MonthlyData } from '@app/data/models/calanderization';
 
 export interface DataOverviewReportPptInput {
     account: IdbAccount;
@@ -24,6 +26,7 @@ export interface DataOverviewReportPptInput {
     reportSettings: DataOverviewReportSetup;
     accountData: DataOverviewAccount;
     facilitiesData: Array<DataOverviewFacility>;
+    emissionsDisplay: "location" | "market";
     usageDonutImages?: {
         energyUse?: string;
         water?: string;
@@ -38,7 +41,7 @@ export interface DataOverviewReportPptInput {
 
 @Injectable({ providedIn: 'root' })
 export class DataOverviewReportPptAdapter {
-  private readonly accountWorkspaceQuery = inject(AccountWorkspaceQueryService);
+    private readonly accountWorkspaceQuery = inject(AccountWorkspaceQueryService);
     customNumberPipe: CustomNumberPipe = inject(CustomNumberPipe);
     naicsDisplayPipe = inject(NaicsDisplayPipe);
 
@@ -51,16 +54,19 @@ export class DataOverviewReportPptAdapter {
         energyUse?: string;
         water?: string;
         cost?: string;
+        emissions?: string;
     };
     mapImages: {
         energyUse?: string;
         water?: string;
         cost?: string;
+        emissions?: string;
     };
     chartSeriesPalette: string[] = [
         '1F77B4', 'FF7F0E', '2CA02C', 'D62728', '9467BD', '8C564B',
         'E377C2', '7F7F7F', 'BCBD22', '17BECF', '4E79A7', 'F28E2B'
     ];
+    emissionsDisplay: "location" | "market";
 
     buildDocument(data: DataOverviewReportPptInput): PptDocument {
         const slides: PptSlide[] = [];
@@ -71,6 +77,7 @@ export class DataOverviewReportPptAdapter {
         this.facilitiesData = data.facilitiesData;
         this.usageDonutImages = data.usageDonutImages ?? {};
         this.mapImages = data.mapImages ?? {};
+        this.emissionsDisplay = data.emissionsDisplay;
 
         if (this.reportSettings.includeAccountReport) {
             if (this.reportSettings.includeEnergySection || this.reportSettings.includeWaterSection || this.reportSettings.includeCostsSection) {
@@ -117,6 +124,19 @@ export class DataOverviewReportPptAdapter {
                     slides.push(...costSlides);
                 }
             }
+
+            if (this.accountData.account.displayEmissions && this.reportSettings.includeEmissionsSection) {
+                const emissionSlides: PptSlide[] = [];
+                this.buildAccountEmissionSections(emissionSlides);
+                if (emissionSlides.length > 0) {
+                    slides.push({
+                        type: 'title',
+                        title: 'Emissions',
+                        layout: 'section'
+                    });
+                    slides.push(...emissionSlides);
+                }
+            }
         }
         for (const facilityData of this.facilitiesData) {
             if (this.reportSettings.includeFacilityReports) {
@@ -161,6 +181,18 @@ export class DataOverviewReportPptAdapter {
                             layout: 'section'
                         });
                         slides.push(...costSlides);
+                    }
+                }
+                if (this.account.displayEmissions && this.reportSettings.includeEmissionsSection) {
+                    const emissionsSlides: PptSlide[] = [];
+                    this.buildFacilityReportEmissionsSections(facilityData, emissionsSlides);
+                    if (emissionsSlides.length > 0) {
+                        slides.push({
+                            type: 'title',
+                            title: 'Emissions',
+                            layout: 'section'
+                        });
+                        slides.push(...emissionsSlides);
                     }
                 }
             }
@@ -272,6 +304,60 @@ export class DataOverviewReportPptAdapter {
         }
     }
 
+    private buildAccountEmissionSections(slides: PptSlide[]) {
+        if (this.reportSettings.includeMap) {
+            const imageSlide: ImageSlide = this.buildMapImageSlide('emissions');
+            if (imageSlide) {
+                slides.push(imageSlide);
+            }
+        }
+        if (this.reportSettings.includeFacilityTable) {
+            const tableSlide: TableSlide = this.buildFacilityUsageTable('emissions');
+            if (tableSlide) {
+                slides.push(tableSlide);
+            }
+        }
+        if (this.reportSettings.includeFacilityDonut) {
+            const imageSlide: ImageSlide = this.buildFacilityUsageImageSlide('emissions');
+            if (imageSlide) {
+                slides.push(imageSlide);
+            }
+        }
+        if (this.reportSettings.includeFacilityTable) {
+            const tableSlide: TableSlide = this.buildEmissionsUsageTable(this.accountData.accountOverviewData.emissionsTotals);
+            if (tableSlide) {
+                slides.push(tableSlide);
+            }
+        }
+        if (this.reportSettings.includeFacilityDonut) {
+            const chartSlide: ChartSlide = this.buildEmissionsUsageChart(this.accountData.accountOverviewData.facilitiesCost);
+            if (chartSlide) {
+                slides.push(chartSlide);
+            }
+        }
+
+        let useAndCostTotal: { end: IUseAndCost; average: IUseAndCost; previousYear: IUseAndCost; } = this.accountData.utilityUseAndCost.allSourcesTotal;
+        if (this.reportSettings.includeUtilityTable) {
+            const tableSlide: TableSlide = this.buildEmissionsConsumptionTable(useAndCostTotal, this.accountData.utilityUseAndCost.previousYear);
+            if (tableSlide) {
+                slides.push(tableSlide);
+            }
+        }
+        if (this.reportSettings.includeStackedBarChart) {
+            const chartSlide: ChartSlide = this.buildEmissionsComparisonChart();
+            if (chartSlide) {
+                slides.push(chartSlide);
+            }
+        }
+        const yearMonthData = this.accountData.accountOverviewData.allSourcesYearMonthData;
+        if (this.reportSettings.includeMonthlyLineChart) {
+            const chartSlide: ChartSlide = this.buildMonthlyLineChart('emissions', yearMonthData, this.account);
+            if (chartSlide) {
+                slides.push(chartSlide);
+            }
+        }
+    }
+
     private buildFacilityReportSections(facilityData: DataOverviewFacility, slides: PptSlide[], sectionType: 'energyUse' | 'cost' | 'water') {
         const facilityOverviewMeters = sectionType === 'energyUse' ? facilityData.facilityOverviewData.energyMeters : sectionType === 'water' ? facilityData.facilityOverviewData.waterMeters : facilityData.facilityOverviewData.costMeters;
         if (this.reportSettings.includeMeterUsageStackedLineChart && facilityData.facilityOverviewData.calanderizedMeters?.length > 0) {
@@ -335,8 +421,205 @@ export class DataOverviewReportPptAdapter {
         }
     }
 
-    private buildMapImageSlide(sectionType: 'energyUse' | 'cost' | 'water'): ImageSlide {
-        const imageUrl = sectionType === 'energyUse' ? this.mapImages?.energyUse : sectionType === 'water' ? this.mapImages?.water : this.mapImages?.cost;
+    private buildFacilityReportEmissionsSections(facilityData: DataOverviewFacility, slides: PptSlide[]) {
+        const facilityOverviewMeters = facilityData.facilityOverviewData.costMeters;
+        if (this.reportSettings.includeMeterUsageStackedLineChart && facilityData.facilityOverviewData.calanderizedMeters?.length > 0) {
+            const chartSlide: ChartSlide = this.buildEmissionsStackedLineChart(facilityData);
+            if (chartSlide) {
+                slides.push(chartSlide);
+            }
+        }
+        if (this.reportSettings.includeMeterUsageTable && facilityData.facilityOverviewData.calanderizedMeters?.length > 0 && facilityOverviewMeters?.length > 0) {
+            const tableSlide: TableSlide = this.buildEmissionsUsageTable(facilityData.facilityOverviewData.emissionsTotals);
+            if (tableSlide) {
+                slides.push(tableSlide);
+            }
+        }
+        if (this.reportSettings.includeMeterUsageDonut && facilityOverviewMeters?.length > 0) {
+            const chartSlide: ChartSlide = this.buildEmissionsUsageChart(facilityData.facilityOverviewData.costMeters);
+            if (chartSlide) {
+                slides.push(chartSlide);
+            }
+        }
+        let useAndCostTotal: { end: IUseAndCost; average: IUseAndCost; previousYear: IUseAndCost; } = facilityData.utilityUseAndCost.allSourcesTotal;
+        if (this.reportSettings.includeUtilityTableForFacility && useAndCostTotal) {
+            const tableSlide: TableSlide = this.buildEmissionsConsumptionTable(useAndCostTotal, facilityData.utilityUseAndCost.previousYear);
+            if (tableSlide) {
+                slides.push(tableSlide);
+            }
+        }
+
+        if (this.reportSettings.includeAnnualBarChart && facilityData.facilityOverviewData.annualSourceData?.length > 0) {
+            const annualBarChartSlide: ChartSlide = this.buildAnnualEmissionsBarChart(facilityData.facilityOverviewData.annualSourceData, facilityData.facility);
+            if (annualBarChartSlide) {
+                slides.push(annualBarChartSlide);
+            }
+        }
+        const yearMonthData = facilityData.facilityOverviewData.allSourcesYearMonthData;
+        if (this.reportSettings.includeMonthlyLineChartForFacility && yearMonthData?.length > 0) {
+            const monthlyLineChartSlide: ChartSlide = this.buildMonthlyLineChart('emissions', yearMonthData, facilityData.facility);
+            if (monthlyLineChartSlide) {
+                slides.push(monthlyLineChartSlide);
+            }
+        }
+    }
+
+    private buildEmissionsStackedLineChart(facilityData: DataOverviewFacility): ChartSlide {
+        const monthlyData = facilityData.calanderizedMeters
+            .flatMap(cm => cm.monthlyData)
+            .filter(item => {
+                const date = new Date(item.date);
+                return date >= this.accountData.dateRange.startDate && date <= this.accountData.dateRange.endDate;
+            });
+
+        const months: Date[] = [];
+        for (let date = new Date(this.accountData.dateRange.startDate); date <= this.accountData.dateRange.endDate; date.setMonth(date.getMonth() + 1)) {
+            months.push(new Date(date));
+        }
+
+        const getValue = (type: EmissionsTypes, data: MonthlyData): number => {
+            switch (type) {
+                case 'Scope 1: Fugitive': return data.fugitiveEmissions ?? 0;
+                case 'Scope 2: Electricity (Location)': return data.locationElectricityEmissions ?? 0;
+                case 'Scope 2: Electricity (Market)': return data.marketElectricityEmissions ?? 0;
+                case 'Scope 1: Mobile': return data.mobileTotalEmissions ?? 0;
+                case 'Scope 1: Process': return data.processEmissions ?? 0;
+                case 'Scope 1: Stationary': return data.stationaryEmissions ?? 0;
+                case 'Scope 2: Other': return data.otherScope2Emissions ?? 0;
+            }
+        };
+
+        const series: PptChartSeries[] = getEmissionsTypes(this.emissionsDisplay)
+            .map(type => ({
+                name: type,
+                type: 'area' as const,
+                data: months.map(month => _.sumBy(
+                    monthlyData.filter(item =>
+                        item.monthNumValue === month.getMonth() && item.year === month.getFullYear()
+                    ),
+                    item => getValue(type, item)
+                )),
+                color: getEmissionsTypeColor(type).replace('#', '')
+            }))
+            .filter(item => item.data.some(value => value !== 0));
+
+        if (!series.length) {
+            return null;
+        }
+        const totals = months.map((_, index) =>
+            series.reduce((sum, item) => sum + item.data[index], 0)
+        );
+        const axis = getPptAxisSpec(totals);
+
+        return {
+            type: 'chart',
+            title: 'Utility Emissions (tonne CO2e)',
+            chartType: 'combo',
+            labels: months.map(month =>
+                month.toLocaleString('en-US', { month: 'short', year: 'numeric' })
+            ),
+            series,
+            yAxisUnit: '',
+            valAxisMinVal: axis.min,
+            valAxisMaxVal: axis.max,
+            valAxisMajorUnit: axis.majorUnit,
+            valAxisLabelFormatCode: axis.labelFormat,
+            showLegend: true
+        };
+    }
+
+    private buildAnnualEmissionsBarChart(annualSourceData: Array<AnnualSourceData>, facility: IdbFacility): ChartSlide {
+        const annualSourceDataItems = annualSourceData.flatMap(sourceData =>
+            sourceData.annualSourceDataItems ?? []
+        );
+
+        const years = _.chain(annualSourceDataItems)
+            .map(item => item.fiscalYear)
+            .uniq()
+            .sortBy()
+            .value();
+
+        if (!years.length) {
+            return null;
+        }
+
+        const getValue = (emissionsType: EmissionsTypes, item: AnnualSourceData['annualSourceDataItems'][number]): number => {
+            const emissions = item.totalEmissions;
+
+            if (emissionsType === 'Scope 1: Fugitive') {
+                return emissions.fugitiveEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 2: Electricity (Location)') {
+                return emissions.locationElectricityEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 2: Electricity (Market)') {
+                return emissions.marketElectricityEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 1: Mobile') {
+                return emissions.mobileTotalEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 1: Process') {
+                return emissions.processEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 1: Stationary') {
+                return emissions.stationaryEmissions ?? 0;
+            }
+
+            return emissions.otherScope2Emissions ?? 0;
+        };
+
+        const series: PptChartSeries[] = getEmissionsTypes(this.emissionsDisplay)
+            .map(emissionsType => ({
+                name: emissionsType,
+                data: years.map(year => {
+                    const dataForYear = annualSourceDataItems.filter(item =>
+                        item.fiscalYear === year
+                    );
+
+                    return _.sumBy(dataForYear, item =>
+                        getValue(emissionsType, item)
+                    );
+                }),
+                color: getEmissionsTypeColor(emissionsType).replace('#', '')
+            }))
+            .filter(chartSeries => chartSeries.data.some(value => value !== 0));
+
+        if (!series.length) {
+            return null;
+        }
+
+        const values = series
+            .flatMap(chartSeries => chartSeries.data)
+            .filter(value => Number.isFinite(value));
+
+        const axis = getPptAxisSpec(values);
+
+        return {
+            type: 'chart',
+            title: 'Annual Utility Emissions (tonne CO2e)',
+            chartType: 'bar',
+            labels: years.map(year =>
+                facility.fiscalYear === 'nonCalendarYear'
+                    ? `FY - ${year}`
+                    : year.toString()
+            ),
+            series,
+            yAxisUnit: 'tonne CO2e',
+            valAxisMinVal: axis.min,
+            valAxisMaxVal: axis.max,
+            valAxisMajorUnit: axis.majorUnit,
+            valAxisLabelFormatCode: axis.labelFormat,
+            showLegend: true
+        };
+    }
+
+    private buildMapImageSlide(sectionType: 'energyUse' | 'cost' | 'water' | 'emissions'): ImageSlide {
+        const imageUrl = sectionType === 'energyUse' ? this.mapImages?.energyUse : sectionType === 'water' ? this.mapImages?.water : sectionType === 'emissions' ? this.mapImages?.emissions : this.mapImages?.cost;
         if (!imageUrl) {
             return null;
         }
@@ -347,11 +630,364 @@ export class DataOverviewReportPptAdapter {
         };
     }
 
-    private buildFacilityUsageTable(sectionType: 'energyUse' | 'cost' | 'water'): TableSlide {
+    private buildEmissionsUsageTable(emissionTotals: EmissionsResults): TableSlide {
+        const title = 'Emissions Usage Breakdown';
+        let headers = ['Emissions Type', `Total With Market Emissions\n(tonne CO2e)`, `Total With Location Emissions\n(tonne CO2e)`];
+        let rows: string[][] = [];
+
+        if (emissionTotals.stationaryEmissions) {
+            rows.push([
+                'Scope 1: Stationary',
+                this.formatValue(emissionTotals.stationaryEmissions, false),
+                this.formatValue(emissionTotals.stationaryEmissions, false)
+            ]);
+        }
+        if (emissionTotals.mobileTotalEmissions) {
+            rows.push([
+                'Scope 1: Mobile',
+                this.formatValue(emissionTotals.mobileTotalEmissions, false),
+                this.formatValue(emissionTotals.mobileTotalEmissions, false)
+            ]);
+        }
+        if (emissionTotals.fugitiveEmissions) {
+            rows.push([
+                'Scope 1: Fugitive',
+                this.formatValue(emissionTotals.fugitiveEmissions, false),
+                this.formatValue(emissionTotals.fugitiveEmissions, false)
+            ]);
+        }
+        if (emissionTotals.processEmissions) {
+            rows.push([
+                'Scope 1: Process',
+                this.formatValue(emissionTotals.processEmissions, false),
+                this.formatValue(emissionTotals.processEmissions, false)
+            ]);
+        }
+        if (emissionTotals.marketElectricityEmissions || emissionTotals.locationElectricityEmissions) {
+            rows.push([
+                'Scope 2: Electricity',
+                this.formatValue(emissionTotals.marketElectricityEmissions, false),
+                this.formatValue(emissionTotals.locationElectricityEmissions, false)
+            ]);
+        }
+        if (emissionTotals.otherScope2Emissions) {
+            rows.push([
+                'Scope 2: Other',
+                this.formatValue(emissionTotals.otherScope2Emissions, false),
+                this.formatValue(emissionTotals.otherScope2Emissions, false)
+            ]);
+        }
+        rows.push([
+            'Total',
+            this.formatValue(emissionTotals.totalWithMarketEmissions, false),
+            this.formatValue(emissionTotals.totalWithLocationEmissions, false)
+        ]);
+
+        return {
+            type: 'table',
+            headers,
+            rows,
+            title
+        };
+    }
+
+    private buildEmissionsConsumptionTable(
+        useAndCostTotal: { end: IUseAndCost; average: IUseAndCost; previousYear: IUseAndCost; },
+        previousYear: Date): TableSlide {
+        let headers: string[] = [];
+        let subHeaders: string[] = [];
+        let rows: string[][] = [];
+
+        const endDate = this.accountData.dateRange.endDate ? this.accountData.dateRange.endDate.toLocaleString('en-US', { month: 'short', year: 'numeric' }) : '';
+        const previousYearDate = previousYear ? previousYear.toLocaleString('en-US', { month: 'short', year: 'numeric' }) : '';
+        const averageDate = this.accountData.dateRange.startDate && this.accountData.dateRange.endDate ? `${this.accountData.dateRange.startDate.toLocaleString('en-US', { month: 'short', year: 'numeric' })} - ${this.accountData.dateRange.endDate.toLocaleString('en-US', { month: 'short', year: 'numeric' })}` : '';
+
+        headers = ['', `Latest Month\n(${endDate})`, `Previous Year\n(${previousYearDate})`, `Monthly Average\n(${averageDate})`];
+        subHeaders = ['', '(tonne CO2e)', '(tonne CO2e)', '(tonne CO2e)'];
+
+        let showMobile = false, showFugitive = false, showProcess = false, showStationary = false, showScope2LocationElectricity = false, showScope2MarketElectricity = false, showScope2Other = false;
+        if (useAndCostTotal) {
+            showMobile = (this.checkValue(useAndCostTotal.average.mobileTotalEmissions) || this.checkValue(useAndCostTotal.end.mobileTotalEmissions) || this.checkValue(useAndCostTotal.previousYear.mobileTotalEmissions));
+            showFugitive = (this.checkValue(useAndCostTotal.average.fugitiveEmissions) || this.checkValue(useAndCostTotal.end.fugitiveEmissions) || this.checkValue(useAndCostTotal.previousYear.fugitiveEmissions));
+            showProcess = (this.checkValue(useAndCostTotal.average.processEmissions) || this.checkValue(useAndCostTotal.end.processEmissions) || this.checkValue(useAndCostTotal.previousYear.processEmissions));
+            showStationary = (this.checkValue(useAndCostTotal.average.stationaryEmissions) || this.checkValue(useAndCostTotal.end.stationaryEmissions) || this.checkValue(useAndCostTotal.previousYear.stationaryEmissions));
+            showScope2LocationElectricity = (this.checkValue(useAndCostTotal.average.locationElectricityEmissions) || this.checkValue(useAndCostTotal.end.locationElectricityEmissions) || this.checkValue(useAndCostTotal.previousYear.locationElectricityEmissions));
+            showScope2MarketElectricity = (this.checkValue(useAndCostTotal.average.marketElectricityEmissions) || this.checkValue(useAndCostTotal.end.marketElectricityEmissions) || this.checkValue(useAndCostTotal.previousYear.marketElectricityEmissions));
+            showScope2Other = (this.checkValue(useAndCostTotal.average.otherScope2Emissions) || this.checkValue(useAndCostTotal.end.otherScope2Emissions) || this.checkValue(useAndCostTotal.previousYear.otherScope2Emissions));
+        }
+
+        if (showMobile) {
+            rows.push([
+                'Scope 1: Mobile',
+                this.formatValue(useAndCostTotal.end.mobileTotalEmissions, false),
+                this.formatValue(useAndCostTotal.previousYear.mobileTotalEmissions, false),
+                this.formatValue(useAndCostTotal.average.mobileTotalEmissions, false),
+            ]);
+        }
+        if (showFugitive) {
+            rows.push([
+                'Scope 1: Fugitive',
+                this.formatValue(useAndCostTotal.end.fugitiveEmissions, false),
+                this.formatValue(useAndCostTotal.previousYear.fugitiveEmissions, false),
+                this.formatValue(useAndCostTotal.average.fugitiveEmissions, false),
+            ]);
+        }
+        if (showProcess) {
+            rows.push([
+                'Scope 1: Process',
+                this.formatValue(useAndCostTotal.end.processEmissions, false),
+                this.formatValue(useAndCostTotal.previousYear.processEmissions, false),
+                this.formatValue(useAndCostTotal.average.processEmissions, false),
+            ]);
+        }
+        if (showStationary) {
+            rows.push([
+                'Scope 1: Stationary',
+                this.formatValue(useAndCostTotal.end.stationaryEmissions, false),
+                this.formatValue(useAndCostTotal.previousYear.stationaryEmissions, false),
+                this.formatValue(useAndCostTotal.average.stationaryEmissions, false),
+            ]);
+        }
+        if (this.emissionsDisplay === 'location' && showScope2LocationElectricity) {
+            rows.push([
+                'Scope 2: Electricity (Location)',
+                this.formatValue(useAndCostTotal.end.locationElectricityEmissions, false),
+                this.formatValue(useAndCostTotal.previousYear.locationElectricityEmissions, false),
+                this.formatValue(useAndCostTotal.average.locationElectricityEmissions, false),
+            ]);
+        }
+        if (this.emissionsDisplay === 'market' && showScope2MarketElectricity) {
+            rows.push([
+                'Scope 2: Electricity (Market)',
+                this.formatValue(useAndCostTotal.end.marketElectricityEmissions, false),
+                this.formatValue(useAndCostTotal.previousYear.marketElectricityEmissions, false),
+                this.formatValue(useAndCostTotal.average.marketElectricityEmissions, false),
+            ]);
+        }
+        if (showScope2Other) {
+            rows.push([
+                'Scope 2: Other',
+                this.formatValue(useAndCostTotal.end.otherScope2Emissions, false),
+                this.formatValue(useAndCostTotal.previousYear.otherScope2Emissions, false),
+                this.formatValue(useAndCostTotal.average.otherScope2Emissions, false),
+            ]);
+        }
+        let endVal: number, prevVal: number, avgVal: number;
+        if (this.emissionsDisplay === 'market') {
+            endVal = useAndCostTotal.end.totalWithMarketEmissions;
+            prevVal = useAndCostTotal.previousYear.totalWithMarketEmissions;
+            avgVal = useAndCostTotal.average.totalWithMarketEmissions;
+        }
+        if (this.emissionsDisplay === 'location') {
+            endVal = useAndCostTotal.end.totalWithLocationEmissions;
+            prevVal = useAndCostTotal.previousYear.totalWithLocationEmissions;
+            avgVal = useAndCostTotal.average.totalWithLocationEmissions;
+        }
+
+        rows.push([
+            'Total',
+            this.formatValue(endVal, false),
+            this.formatValue(prevVal, false),
+            this.formatValue(avgVal, false),
+        ]);
+
+        return {
+            type: 'table',
+            headers,
+            subHeaders,
+            rows,
+            title: 'Emissions Comparison'
+        }
+    }
+
+    private buildEmissionsUsageChart(facilitiesCost: Array<AccountOverviewFacility> | Array<FacilityOverviewMeter>): ChartSlide {
+        const emissionsTypes = getEmissionsTypes(this.emissionsDisplay).reverse();
+        const allEmissions = facilitiesCost
+            .map(facilityOverviewMeter => facilityOverviewMeter.emissions);
+
+        const labels: string[] = [];
+        const values: number[] = [];
+        const barColors: string[] = [];
+
+        const getValue = (emissionsType: EmissionsTypes, emissions: MonthlyData): number => {
+            if (emissionsType === 'Scope 1: Fugitive') {
+                return emissions.fugitiveEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 2: Electricity (Location)') {
+                return emissions.locationElectricityEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 2: Electricity (Market)') {
+                return Math.max(emissions.marketElectricityEmissions ?? 0, 0);
+            }
+
+            if (emissionsType === 'Scope 1: Mobile') {
+                return emissions.mobileTotalEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 1: Process') {
+                return emissions.processEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 1: Stationary') {
+                return emissions.stationaryEmissions ?? 0;
+            }
+
+            return emissions.otherScope2Emissions ?? 0;
+        };
+
+        emissionsTypes.forEach(emissionsType => {
+            const value = _.sumBy(
+                allEmissions,
+                emissions => getValue(emissionsType, emissions as MonthlyData)
+            );
+
+            if (value !== 0) {
+                labels.push(emissionsType);
+                values.push(value);
+                barColors.push(getEmissionsTypeColor(emissionsType).replace('#', ''));
+            }
+        });
+
+        if (!values.length) {
+            return null;
+        }
+
+        const total = values.reduce((sum, value) => sum + value, 0);
+
+        const labelsWithPercentages = labels.map((label, index) => {
+            const percentage = total === 0
+                ? 0
+                : (values[index] / total) * 100;
+
+            return `${label} (${percentage.toFixed(1)}%)`;
+        });
+
+        const axis = getPptAxisSpec(
+            values.filter(value => Number.isFinite(value))
+        );
+
+        return {
+            type: 'chart',
+            title: 'Emission Breakdown',
+            chartType: 'bar',
+            barDir: 'bar',
+            labels: labelsWithPercentages,
+            series: [{
+                name: 'Emissions',
+                data: values
+            }],
+            barColors,
+            yAxisUnit: 'tonne CO2e',
+            valAxisMinVal: axis.min,
+            valAxisMaxVal: axis.max,
+            valAxisMajorUnit: axis.majorUnit,
+            valAxisLabelFormatCode: axis.labelFormat,
+            showLegend: false,
+            showDataLabels: true
+        };
+    }
+
+    private buildEmissionsComparisonChart(): ChartSlide {
+        const facilities = this.accountData.accountOverviewData.facilitiesCost ?? [];
+
+        if (!facilities.length) {
+            return null;
+        }
+
+        const getValue = (
+            emissionsType: EmissionsTypes,
+            facility: AccountOverviewFacility
+        ): number => {
+            const emissions = facility.emissions;
+
+            if (emissionsType === 'Scope 1: Fugitive') {
+                return emissions.fugitiveEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 2: Electricity (Location)') {
+                return emissions.locationElectricityEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 2: Electricity (Market)') {
+                return emissions.marketElectricityEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 1: Mobile') {
+                return emissions.mobileTotalEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 1: Process') {
+                return emissions.processEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 1: Stationary') {
+                return emissions.stationaryEmissions ?? 0;
+            }
+
+            return emissions.otherScope2Emissions ?? 0;
+        };
+
+        const orderedFacilities = [...facilities]
+            .map(facility => ({
+                facility,
+                total: getEmissionsTypes(this.emissionsDisplay).reduce(
+                    (sum, emissionsType) => sum + getValue(emissionsType, facility),
+                    0
+                )
+            }))
+            .sort((first, second) => second.total - first.total);
+
+        const labels = orderedFacilities.map(item => item.facility.facility.name);
+
+        const series: PptChartSeries[] = getEmissionsTypes(this.emissionsDisplay)
+            .map(emissionsType => ({
+                name: emissionsType,
+                data: orderedFacilities.map(item =>
+                    getValue(emissionsType, item.facility)
+                ),
+                color: getEmissionsTypeColor(emissionsType).replace('#', '')
+            }))
+            .filter(chartSeries =>
+                chartSeries.data.some(value => Number.isFinite(value) && value !== 0)
+            );
+
+        if (!series.length) {
+            return null;
+        }
+
+        const stackedTotals = labels.map((_, index) =>
+            series.reduce((sum, chartSeries) =>
+                sum + (chartSeries.data[index] ?? 0), 0
+            )
+        );
+
+        const axis = getPptAxisSpec(
+            stackedTotals.filter(value => Number.isFinite(value))
+        );
+
+        return {
+            type: 'chart',
+            title: 'Emissions by Facility',
+            chartType: 'bar',
+            barGrouping: 'stacked',
+            labels,
+            series,
+            yAxisUnit: '',
+            valAxisMinVal: 0,
+            valAxisMaxVal: axis.max,
+            valAxisMajorUnit: axis.majorUnit,
+            valAxisLabelFormatCode: axis.labelFormat,
+            showLegend: true
+        };
+    }
+
+    private buildFacilityUsageTable(sectionType: 'energyUse' | 'cost' | 'water' | 'emissions'): TableSlide {
         const accountOverviewFacilities: Array<AccountOverviewFacility> = sectionType === 'energyUse' ? this.accountData.accountOverviewData.facilitiesEnergy : sectionType === 'water' ? this.accountData.accountOverviewData.facilitiesWater : this.accountData.accountOverviewData.facilitiesCost;
         const accountOverviewData: AccountOverviewData = this.accountData.accountOverviewData;
         const unit = sectionType === 'energyUse' ? this.account.energyUnit : sectionType === 'water' ? this.account.volumeLiquidUnit : '';
-        const title = sectionType === 'cost' ? 'Cost Breakdown by Facility' : 'Consumption Breakdown by Facility';
+        const title = sectionType === 'cost' ? 'Cost Breakdown by Facility' : sectionType === 'emissions' ? 'Emissions Breakdown' : 'Consumption Breakdown by Facility';
         let headers: string[] = [];
         if (sectionType === 'energyUse') {
             headers = ['Facility', `Utility Usage (${unit})`, 'Utility Cost'];
@@ -362,18 +998,30 @@ export class DataOverviewReportPptAdapter {
         if (sectionType === 'cost') {
             headers = ['Facility', '# of Meters', 'Utility Cost'];
         }
+        if (sectionType === 'emissions') {
+            headers = ['Facility', 'Total With Market Emissions\n(tonne CO2e)', 'Total With Location Emissions\n(tonne CO2e)'];
+        }
+
         let rows: string[][] = [];
         accountOverviewFacilities.forEach(summary => {
             let row: string[] = [];
-            row.push(summary.facility.name);
-            if (sectionType === 'energyUse' || sectionType === 'water') {
-                row.push(this.formatValue(summary.totalUsage, false));
+            if (sectionType !== 'emissions') {
+                row.push(summary.facility.name);
+                if (sectionType === 'energyUse' || sectionType === 'water') {
+                    row.push(this.formatValue(summary.totalUsage, false));
+                }
+                if (sectionType === 'cost') {
+                    row.push(summary.numberOfMeters.toString());
+                }
+                row.push(this.formatValue(summary.totalCost, true));
+                rows.push(row);
             }
-            if (sectionType === 'cost') {
-                row.push(summary.numberOfMeters.toString());
+            else {
+                row.push(summary.facility.name);
+                row.push(this.formatValue(summary.emissions.totalWithMarketEmissions, false));
+                row.push(this.formatValue(summary.emissions.totalWithLocationEmissions, false));
+                rows.push(row);
             }
-            row.push(this.formatValue(summary.totalCost, true));
-            rows.push(row);
         });
         let totalRow: string[] = ['Total'];
         if (sectionType === 'energyUse') {
@@ -388,6 +1036,10 @@ export class DataOverviewReportPptAdapter {
             totalRow.push(accountOverviewData.numberOfMeters.toString());
             totalRow.push(this.formatValue(accountOverviewData.totalAccountCost, true));
         }
+        if (sectionType === 'emissions') {
+            totalRow.push(this.formatValue(accountOverviewData.emissionsTotals.totalWithMarketEmissions, false));
+            totalRow.push(this.formatValue(accountOverviewData.emissionsTotals.totalWithLocationEmissions, false));
+        }
         rows.push(totalRow);
         return {
             type: 'table',
@@ -397,12 +1049,12 @@ export class DataOverviewReportPptAdapter {
         };
     }
 
-    private buildFacilityUsageImageSlide(sectionType: 'energyUse' | 'cost' | 'water'): ImageSlide {
-        const imageUrl = sectionType === 'energyUse' ? this.usageDonutImages?.energyUse : sectionType === 'water' ? this.usageDonutImages?.water : this.usageDonutImages?.cost;
+    private buildFacilityUsageImageSlide(sectionType: 'energyUse' | 'cost' | 'water' | 'emissions'): ImageSlide {
+        const imageUrl = sectionType === 'energyUse' ? this.usageDonutImages?.energyUse : sectionType === 'water' ? this.usageDonutImages?.water : sectionType === 'emissions' ? this.usageDonutImages?.emissions : this.usageDonutImages?.cost;
         if (!imageUrl) {
             return null;
         }
-        const title = sectionType === 'cost' ? 'Cost Breakdown by Facility' : 'Consumption Breakdown by Facility';
+        const title = sectionType === 'cost' ? 'Cost Breakdown by Facility' : sectionType === 'emissions' ? 'Company Emissions Breakdown' : 'Consumption Breakdown by Facility';
         return {
             type: 'image',
             title: title,
@@ -824,55 +1476,96 @@ export class DataOverviewReportPptAdapter {
 
         if (!filteredMeters.length) return null;
 
-        const allKeys = new Set<string>();
-        filteredMeters.forEach(cMeter => {
-            cMeter.monthlyData.forEach(d => {
-                const date = new Date(d.date);
-                if (date >= facilityData.dateRange.startDate && date <= facilityData.dateRange.endDate) {
-                    allKeys.add(`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`);
-                }
-            });
-        });
+        const monthKeys: string[] = [];
+        const startDate = new Date(facilityData.dateRange.startDate.getFullYear(), facilityData.dateRange.startDate.getMonth(), 1);
+        const endDate = new Date(facilityData.dateRange.endDate.getFullYear(), facilityData.dateRange.endDate.getMonth(), 1);
 
-        const sortedKeys = Array.from(allKeys).sort();
-        const labels = sortedKeys.map(k => {
-            const [y, m] = k.split('-');
-            return new Date(+y, +m - 1, 1).toLocaleString('en-US', { month: 'short', year: 'numeric' });
-        });
+        for (const date = new Date(startDate); date <= endDate; date.setMonth(date.getMonth() + 1)) {
+            monthKeys.push(`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`);
+        }
+        if (!monthKeys.length) return null;
+
+        const getValue = (monthlyData: MonthlyData): number => {
+            if (sectionType === 'energyUse') {
+                return monthlyData.energyUse ?? 0;
+            }
+
+            if (sectionType === 'water') {
+                return monthlyData.energyConsumption ?? 0;
+            }
+
+            return monthlyData.energyCost ?? 0;
+        };
 
         const series: PptChartSeries[] = filteredMeters.map(cMeter => {
-            const valueByKey = new Map<string, number>();
-            cMeter.monthlyData.forEach(d => {
-                const date = new Date(d.date);
-                if (date >= facilityData.dateRange.startDate && date <= facilityData.dateRange.endDate) {
-                    const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
-                    const value = sectionType === 'cost' ? d.energyCost : sectionType === 'water' ? d.energyConsumption : d.energyUse;
-                    valueByKey.set(key, value ?? 0);
+            const valueByMonth = new Map<string, number>();
+
+            cMeter.monthlyData.forEach(monthlyData => {
+                const date = new Date(monthlyData.date);
+
+                if (date < startDate || date > endDate) {
+                    return;
                 }
+
+                const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+                valueByMonth.set(key, (valueByMonth.get(key) ?? 0) + getValue(monthlyData));
             });
+
             return {
                 name: cMeter.meter.name,
                 type: 'area',
-                data: sortedKeys.map(k => valueByKey.get(k) ?? 0),
+                data: monthKeys.map(key => valueByMonth.get(key) ?? 0),
                 color: UtilityColors[cMeter.meter.source]?.color?.replace('#', '') ?? '999999'
             };
         });
 
-        const stackedTotals = sortedKeys.map((i) => series.reduce((sum, s) => sum + (s.data[i] ?? 0), 0));
-        const axis = getPptAxisSpec(stackedTotals.filter(v => isFinite(v) && !isNaN(v)));
-        const yAxisUnit = sectionType === 'water' ? facilityData.facility.volumeLiquidUnit : sectionType === 'cost' ? 'Cost ($)' : facilityData.facility.energyUnit;
+        const hasData = series.some(chartSeries =>
+            chartSeries.data.some(value => value !== 0)
+        );
+
+        if (!hasData) {
+            return null;
+        }
+
+        const stackedTotals = monthKeys.map((_, index) =>
+            series.reduce((total, chartSeries) => total + (chartSeries.data[index] ?? 0), 0)
+        );
+
+        const axis = getPptAxisSpec(
+            stackedTotals.filter(value => Number.isFinite(value))
+        );
+
+        const yAxisUnit = sectionType === 'water'
+            ? facilityData.facility.volumeLiquidUnit
+            : sectionType === 'cost'
+                ? 'Cost ($)'
+                : facilityData.facility.energyUnit;
+
+        const title = sectionType === 'water'
+            ? `Water Usage (${yAxisUnit})`
+            : sectionType === 'cost'
+                ? 'Utility Costs'
+                : `Utility Usage (${yAxisUnit})`;
 
         return {
             type: 'chart',
-            title: sectionType === 'water' ? `Water Usage (${yAxisUnit})` : sectionType === 'cost' ? 'Utility Costs' : `Utility Usage (${yAxisUnit})`,
+            title,
             chartType: 'combo',
-            labels,
+            labels: monthKeys.map(key => {
+                const [year, month] = key.split('-');
+                return new Date(+year, +month - 1, 1).toLocaleString('en-US', {
+                    month: 'short',
+                    year: 'numeric'
+                });
+            }),
             series,
             yAxisUnit,
             valAxisMinVal: axis.min,
             valAxisMaxVal: axis.max,
             valAxisMajorUnit: axis.majorUnit,
-            valAxisLabelFormatCode: axis.labelFormat,
+            valAxisLabelFormatCode: sectionType === 'cost'
+                ? '$#,##0'
+                : axis.labelFormat,
             showLegend: true
         };
     }
@@ -1099,7 +1792,7 @@ export class DataOverviewReportPptAdapter {
         }
     }
 
-    private buildMonthlyLineChart(sectionType: 'energyUse' | 'cost' | 'water', yearMonthData: Array<YearMonthData>, accountOrFacility: IdbAccount | IdbFacility): ChartSlide {
+    private buildMonthlyLineChart(sectionType: 'energyUse' | 'cost' | 'water' | 'emissions', yearMonthData: Array<YearMonthData>, accountOrFacility: IdbAccount | IdbFacility): ChartSlide {
         let years: Array<number> = yearMonthData.flatMap(data => { return data.yearMonth.fiscalYear });
         years = _.uniq(years);
         years = _.orderBy(years, (year) => { return year }, 'asc');
@@ -1125,6 +1818,14 @@ export class DataOverviewReportPptAdapter {
                 if (sectionType === 'cost') {
                     return row.energyCost ?? 0;
                 }
+                if (sectionType === 'emissions') {
+                    if (this.emissionsDisplay === 'location') {
+                        return row.totalWithLocationEmissions ?? 0;
+                    }
+                    if (this.emissionsDisplay === 'market') {
+                        return row.totalWithMarketEmissions ?? 0;
+                    }
+                }
             });
             const name: string = accountOrFacility.fiscalYear === 'nonCalendarYear' ? `FY - ${year}` : year.toString();
             return {
@@ -1136,8 +1837,8 @@ export class DataOverviewReportPptAdapter {
 
         const allValues = series.flatMap(s => s.data).filter(v => isFinite(v) && !isNaN(v));
         const axis = getPptAxisSpec(allValues);
-        const yAxisUnit = sectionType === 'water' ? accountOrFacility.volumeLiquidUnit : sectionType === 'cost' ? 'Cost ($)' : accountOrFacility.energyUnit;
-        const title = sectionType === 'cost' ? 'Utility Costs' : sectionType === 'water' ? `Water Usage (${yAxisUnit})` : `Utility Usage (${yAxisUnit})`;
+        const yAxisUnit = sectionType === 'emissions' ? '' : sectionType === 'water' ? accountOrFacility.volumeLiquidUnit : sectionType === 'cost' ? 'Cost ($)' : accountOrFacility.energyUnit;
+        const title = sectionType === 'emissions' ? 'Utility Emissions (tonne CO2e)' : sectionType === 'cost' ? 'Utility Costs' : sectionType === 'water' ? `Water Usage (${yAxisUnit})` : `Utility Usage (${yAxisUnit})`;
         return {
             type: 'chart',
             title,
@@ -1163,5 +1864,12 @@ export class DataOverviewReportPptAdapter {
         return [address, city, [state, zip].filter(Boolean).join(' '), country]
             .filter(Boolean)
             .join(', ');
+    }
+
+    checkValue(value: number): boolean {
+        if (value) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/app/v0/data-evaluation/account/account-reports/data-overview-report/data-overview-report.adapter.ts
+++ b/src/app/v0/data-evaluation/account/account-reports/data-overview-report/data-overview-report.adapter.ts
@@ -1,4 +1,5 @@
 import { inject, Injectable } from "@angular/core";
+import * as _ from "lodash";
 import { DataOverviewFacilityReportSettings, IdbFacilityReport } from "@data/models/idbModels/facilityReport";
 import { ReportDocument, ReportMetaData } from "@v0/shared/pdf-report/models/report-document.model";
 import { BaseSection, ChartSection, HeadingSection, StyledTextSection, TableHeaderCell, TableSection } from "@v0/shared/pdf-report/models/report-section.model";
@@ -11,6 +12,8 @@ import { IdbAccountReport } from "@data/models/idbModels/accountReport";
 import { NaicsDisplayPipe } from "@v0/shared/helper-pipes/naics-display.pipe";
 import { AccountOverviewFacility } from "@domain/calculations/dashboard-calculations/accountOverviewClass";
 import { FacilityOverviewReportAdapter } from "@v0/data-evaluation/facility/facility-reports/report-results/facility-overview-report-results/facility-overview-report.adapter";
+import { EmissionsResults } from "@app/data/models/eGridEmissions";
+import { formatDate } from "@angular/common";
 
 @Injectable({ providedIn: 'root' })
 export class DataOverviewReportAdapter {
@@ -26,6 +29,7 @@ export class DataOverviewReportAdapter {
     chartImageProviders?: any;
     energyUnit: string;
     waterUnit: string;
+    emissionsDisplay: "location" | "market";
 
     private mapAccountToFacilitySettings(): DataOverviewFacilityReportSettings {
         return {
@@ -79,6 +83,7 @@ export class DataOverviewReportAdapter {
         this.chartImageProviders = input.chartImageProviders;
         this.waterUnit = this.account.volumeLiquidUnit;
         this.energyUnit = this.account.energyUnit;
+        this.emissionsDisplay = input.emissionsDisplay;
 
         let metadata: ReportMetaData = {
             title: '',
@@ -115,6 +120,14 @@ export class DataOverviewReportAdapter {
                     sections.push(headingSection);
                     sections.push(...this.buildSection('cost', 'Account Costs'));
                 }
+                if (this.account.displayEmissions && this.reportSettings.includeEmissionsSection) {
+                    const headingSection: HeadingSection = {
+                        type: 'heading',
+                        title: 'Account Emissions'
+                    };
+                    sections.push(headingSection);
+                    sections.push(...this.buildAccountEmissionSection());
+                }
             }
         }
 
@@ -127,7 +140,9 @@ export class DataOverviewReportAdapter {
                     facilityOverviewData: facilityData.facilityOverviewData,
                     utilityUseAndCost: facilityData.utilityUseAndCost,
                     dateRange: facilityData.dateRange,
-                    chartImageProviders: input.facilityChartImageProviders?.[facilityData.facility.guid]
+                    emissionsDisplay: input.emissionsDisplay,
+                    chartImageProviders: input.facilityChartImageProviders?.[facilityData.facility.guid],
+                    emissionsChartImageProviders: input.facilityEmissionsChartImageProviders?.[facilityData.facility.guid]
                 });
                 sections.push(...facilityDocument.sections);
             }
@@ -184,7 +199,7 @@ export class DataOverviewReportAdapter {
             ],
             pageBreakAfter: true,
             tocInclude: isAccountReport ? true : false,
-            tocLabel: isAccountReport ? 'Account Overview': '',
+            tocLabel: isAccountReport ? 'Account Overview' : '',
             bookmarkLevel: 0
         };
         return [titleSection];
@@ -278,7 +293,94 @@ export class DataOverviewReportAdapter {
         return sections;
     }
 
-    private buildFacilityTableSection(type: 'energyUse' | 'cost' | 'water', title: string): TableSection | undefined {
+    private buildAccountEmissionSection(): BaseSection[] {
+        let sections: BaseSection[] = [];
+        if (this.reportSettings.includeMap) {
+            let chartSection = this.createChartSection(this.chartImageProviders?.utilityUsageMap?.['emissions'], '');
+            if (chartSection) {
+                chartSection.tocInclude = true;
+                chartSection.tocLabel = 'Account Emissions Map';
+                chartSection.bookmarkLevel = 1;
+                chartSection.pageBreakAfter = true;
+                sections.push(chartSection);
+            }
+        }
+        if (this.reportSettings.includeFacilityTable) {
+            let tableSection = this.buildFacilityTableSection('emissions', `Emissions Breakdown By Facility`);
+            if (tableSection) {
+                tableSection.tocInclude = true;
+                tableSection.tocLabel = `Emissions Breakdown By Facility Table`;
+                tableSection.bookmarkLevel = 1;
+                tableSection.pageBreakAfter = true;
+                sections.push(tableSection);
+            }
+        }
+        if (this.reportSettings.includeFacilityDonut) {
+            let chartSection = this.createChartSection(this.chartImageProviders?.usageDonut?.['emissions'], '');
+            if (chartSection) {
+                chartSection.tocInclude = true;
+                chartSection.tocLabel = `Emissions Breakdown By Facility Chart`;
+                chartSection.bookmarkLevel = 1;
+                chartSection.pageBreakAfter = true;
+                sections.push(chartSection);
+            }
+        }
+        if (this.reportSettings.includeFacilityTable) {
+            let tableSection: TableSection | undefined;
+            tableSection = this.buildEmissionsUsageTableSection();
+            if (tableSection) {
+                tableSection.tocInclude = true;
+                tableSection.tocLabel = `$Emissions Breakdown Table`;
+                tableSection.bookmarkLevel = 1;
+                tableSection.pageBreakAfter = true;
+                sections.push(tableSection);
+            }
+        }
+        if (this.reportSettings.includeFacilityDonut) {
+            let chartSection: ChartSection | undefined;
+            chartSection = this.createChartSection(this.chartImageProviders?.utilityUsageDonut?.['emissions'], '');
+            if (chartSection) {
+                chartSection.tocInclude = true;
+                chartSection.tocLabel = `Emissions Breakdown Chart`;
+                chartSection.bookmarkLevel = 1;
+                chartSection.pageBreakAfter = true;
+                sections.push(chartSection);
+            }
+        }
+        if (this.reportSettings.includeUtilityTable) {
+            let tableSection = this.buildEmissionsUtilityTableSection();
+            if (tableSection) {
+                tableSection.tocInclude = true;
+                tableSection.tocLabel = `Account Emissions Comparison Table`;
+                tableSection.bookmarkLevel = 1;
+                tableSection.pageBreakAfter = true;
+                sections.push(tableSection);
+            }
+        }
+        if (this.reportSettings.includeStackedBarChart) {
+            let chartSection = this.createChartSection(this.chartImageProviders?.utilityUsageStackedBar?.['emissions'], '');
+            if (chartSection) {
+                chartSection.tocInclude = true;
+                chartSection.tocLabel = `Emissions Stacked Bar Chart`;
+                chartSection.bookmarkLevel = 1;
+                chartSection.pageBreakAfter = true;
+                sections.push(chartSection);
+            }
+        }
+        if (this.reportSettings.includeMonthlyLineChart) {
+            let chartSection = this.createChartSection(this.chartImageProviders?.monthlyUsageLineChart?.['emissions'], '');
+            if (chartSection) {
+                chartSection.tocInclude = true;
+                chartSection.tocLabel = `Monthly Emissions Chart`;
+                chartSection.bookmarkLevel = 1;
+                chartSection.pageBreakAfter = true;
+                sections.push(chartSection);
+            }
+        }
+        return sections;
+    }
+
+    private buildFacilityTableSection(type: 'energyUse' | 'cost' | 'water' | 'emissions', title: string): TableSection | undefined {
         let headers: string[] = [];
         let rows: string[][] = [];
         let accountOverviewFacilities: Array<AccountOverviewFacility> = [];
@@ -297,28 +399,58 @@ export class DataOverviewReportAdapter {
             totalConsumption = this.accountData.accountOverviewData.numberOfMeters;
             totalCost = this.accountData.accountOverviewData.totalAccountCost;
         }
-
         if (type === 'water') {
             headers = ['Facility', `Water Consumption (${this.waterUnit})`, 'Utility Cost'];
             accountOverviewFacilities = this.accountData.accountOverviewData.facilitiesWater;
             totalConsumption = this.accountData.accountOverviewData.totalWaterConsumption;
             totalCost = this.accountData.accountOverviewData.totalWaterCost;
         }
+        if (type === 'emissions') {
+            headers = ['Facility', 'Total With Market Emissions (tonne CO2e)', 'Total With Location Emissions (tonne CO2e)'];
+            if (this.emissionsDisplay === 'location') {
+                accountOverviewFacilities = _.orderBy(this.accountData.accountOverviewData.facilitiesCost, (accountOverviewFacility: AccountOverviewFacility) => {
+                    return accountOverviewFacility.emissions.totalWithLocationEmissions
+                }, 'desc');
+            } else {
+                accountOverviewFacilities = _.orderBy(this.accountData.accountOverviewData.facilitiesCost, (accountOverviewFacility: AccountOverviewFacility) => {
+                    return accountOverviewFacility.emissions.totalWithMarketEmissions
+                }, 'desc');
+            }
+        }
+
 
         if (accountOverviewFacilities) {
             for (let summary of accountOverviewFacilities) {
-                rows.push([
-                    summary.facility.name,
-                    type === 'cost' ? summary.numberOfMeters.toString() : this.checkNumber(summary.totalUsage),
-                    this.checkCurrency(summary.totalCost)
-                ]);
+                if (type !== 'emissions') {
+                    rows.push([
+                        summary.facility.name,
+                        type === 'cost' ? summary.numberOfMeters.toString() : this.checkNumber(summary.totalUsage),
+                        this.checkCurrency(summary.totalCost)
+                    ]);
+                }
+                else {
+                    rows.push([
+                        summary.facility.name,
+                        this.checkNumber(summary.emissions.totalWithMarketEmissions),
+                        this.checkNumber(summary.emissions.totalWithLocationEmissions)
+                    ]);
+                }
             }
         }
-        rows.push([
-            'Total',
-            this.checkNumber(totalConsumption),
-            this.checkCurrency(totalCost)
-        ]);
+        if (type !== 'emissions') {
+            rows.push([
+                'Total',
+                this.checkNumber(totalConsumption),
+                this.checkCurrency(totalCost)
+            ]);
+        }
+        else {
+            rows.push([
+                'Total',
+                this.checkNumber(this.accountData.accountOverviewData.emissionsTotals.totalWithMarketEmissions),
+                this.checkNumber(this.accountData.accountOverviewData.emissionsTotals.totalWithLocationEmissions)
+            ]);
+        }
 
         return {
             type: 'table',
@@ -400,6 +532,71 @@ export class DataOverviewReportAdapter {
         };
         return tableSection;
     }
+
+    private buildEmissionsUsageTableSection(): TableSection {
+        let headers: string[] = ['Emissions Type', 'Total With Market Emissions (tonne CO2e)', 'Total With Location Emissions (tonne CO2e)'];
+        let rows: string[][] = [];
+
+        const emissionTotals: EmissionsResults = this.accountData.accountOverviewData.emissionsTotals;
+
+        if (emissionTotals.stationaryEmissions) {
+            rows.push([
+                'Scope 1: Stationary',
+                this.checkNumber(emissionTotals.stationaryEmissions),
+                this.checkNumber(emissionTotals.stationaryEmissions)
+            ]);
+        }
+        if (emissionTotals.mobileTotalEmissions) {
+            rows.push([
+                'Scope 1: Mobile',
+                this.checkNumber(emissionTotals.mobileTotalEmissions),
+                this.checkNumber(emissionTotals.mobileTotalEmissions)
+            ]);
+        }
+        if (emissionTotals.fugitiveEmissions) {
+            rows.push([
+                'Scope 1: Fugitive',
+                this.checkNumber(emissionTotals.fugitiveEmissions),
+                this.checkNumber(emissionTotals.fugitiveEmissions)
+            ]);
+        }
+        if (emissionTotals.processEmissions) {
+            rows.push([
+                'Scope 1: Process',
+                this.checkNumber(emissionTotals.processEmissions),
+                this.checkNumber(emissionTotals.processEmissions)
+            ]);
+        }
+        if (emissionTotals.marketElectricityEmissions || emissionTotals.locationElectricityEmissions) {
+            rows.push([
+                'Scope 2: Electricity',
+                this.checkNumber(emissionTotals.marketElectricityEmissions),
+                this.checkNumber(emissionTotals.locationElectricityEmissions)
+            ]);
+        }
+        if (emissionTotals.otherScope2Emissions) {
+            rows.push([
+                'Scope 2: Other',
+                this.checkNumber(emissionTotals.otherScope2Emissions),
+                this.checkNumber(emissionTotals.otherScope2Emissions)
+            ]);
+        }
+        rows.push([
+            'Total',
+            this.checkNumber(emissionTotals.totalWithMarketEmissions),
+            this.checkNumber(emissionTotals.totalWithLocationEmissions)
+        ]);
+
+        const tableSection: TableSection = {
+            type: 'table',
+            title: 'Emissions Breakdown',
+            headers: headers,
+            rows: rows
+        };
+
+        return tableSection;
+    }
+
 
     private buildUtilityConsumptionTableSection(type: 'energyUse' | 'cost' | 'water', title: string): TableSection | undefined {
         let headers: Array<string | TableHeaderCell> = [];
@@ -492,6 +689,111 @@ export class DataOverviewReportAdapter {
         return tableSection;
     }
 
+    private buildEmissionsUtilityTableSection(): TableSection {
+        const endDate: string = this.accountData.dateRange.endDate ? '(' + this.formatDate(this.accountData.dateRange.endDate) + ')' : '';
+        const previousYear: string = this.accountData.utilityUseAndCost.previousYear ? '(' + this.formatDate(this.accountData.utilityUseAndCost.previousYear) + ')' : '';
+        const dateRange: string = this.accountData.dateRange.startDate ? '(' + this.formatDate(this.accountData.dateRange.startDate) + ' - ' + this.formatDate(this.accountData.dateRange.endDate) + ')' : '';
+        let headers = ['', `Latest Month \n${endDate}`, `Previous Year \n${previousYear}`, `Monthly Average \n${dateRange}`];
+        let subheaders = ['', '(tonne CO2e)', '(tonne CO2e)', '(tonne CO2e)'];
+        let rows: string[][] = [];
+
+        let showMobile = false, showFugitive = false, showProcess = false, showStationary = false, showScope2LocationElectricity = false, showScope2MarketElectricity = false, showScope2Other = false;
+        let useAndCostTotal = this.accountData.utilityUseAndCost.allSourcesTotal;
+        if (useAndCostTotal) {
+            showMobile = (this.checkValue(useAndCostTotal.average.mobileTotalEmissions) || this.checkValue(useAndCostTotal.end.mobileTotalEmissions) || this.checkValue(useAndCostTotal.previousYear.mobileTotalEmissions));
+            showFugitive = (this.checkValue(useAndCostTotal.average.fugitiveEmissions) || this.checkValue(useAndCostTotal.end.fugitiveEmissions) || this.checkValue(useAndCostTotal.previousYear.fugitiveEmissions));
+            showProcess = (this.checkValue(useAndCostTotal.average.processEmissions) || this.checkValue(useAndCostTotal.end.processEmissions) || this.checkValue(useAndCostTotal.previousYear.processEmissions));
+            showStationary = (this.checkValue(useAndCostTotal.average.stationaryEmissions) || this.checkValue(useAndCostTotal.end.stationaryEmissions) || this.checkValue(useAndCostTotal.previousYear.stationaryEmissions));
+            showScope2LocationElectricity = (this.checkValue(useAndCostTotal.average.locationElectricityEmissions) || this.checkValue(useAndCostTotal.end.locationElectricityEmissions) || this.checkValue(useAndCostTotal.previousYear.locationElectricityEmissions));
+            showScope2MarketElectricity = (this.checkValue(useAndCostTotal.average.marketElectricityEmissions) || this.checkValue(useAndCostTotal.end.marketElectricityEmissions) || this.checkValue(useAndCostTotal.previousYear.marketElectricityEmissions));
+            showScope2Other = (this.checkValue(useAndCostTotal.average.otherScope2Emissions) || this.checkValue(useAndCostTotal.end.otherScope2Emissions) || this.checkValue(useAndCostTotal.previousYear.otherScope2Emissions));
+        }
+
+        if (showMobile) {
+            rows.push([
+                'Scope 1: Mobile',
+                this.checkNumber(useAndCostTotal.end.mobileTotalEmissions),
+                this.checkNumber(useAndCostTotal.previousYear.mobileTotalEmissions),
+                this.checkNumber(useAndCostTotal.average.mobileTotalEmissions)
+            ]);
+        }
+        if (showFugitive) {
+            rows.push([
+                'Scope 1: Fugitive',
+                this.checkNumber(useAndCostTotal.end.fugitiveEmissions),
+                this.checkNumber(useAndCostTotal.previousYear.fugitiveEmissions),
+                this.checkNumber(useAndCostTotal.average.fugitiveEmissions)
+            ]);
+        }
+        if (showProcess) {
+            rows.push([
+                'Scope 1: Process',
+                this.checkNumber(useAndCostTotal.end.processEmissions),
+                this.checkNumber(useAndCostTotal.previousYear.processEmissions),
+                this.checkNumber(useAndCostTotal.average.processEmissions)
+            ]);
+        }
+        if (showStationary) {
+            rows.push([
+                'Scope 1: Stationary',
+                this.checkNumber(useAndCostTotal.end.stationaryEmissions),
+                this.checkNumber(useAndCostTotal.previousYear.stationaryEmissions),
+                this.checkNumber(useAndCostTotal.average.stationaryEmissions)
+            ]);
+        }
+        if (this.emissionsDisplay === 'location' && showScope2LocationElectricity) {
+            rows.push([
+                'Scope 2: Electricity (Location)',
+                this.checkNumber(useAndCostTotal.end.locationElectricityEmissions),
+                this.checkNumber(useAndCostTotal.previousYear.locationElectricityEmissions),
+                this.checkNumber(useAndCostTotal.average.locationElectricityEmissions)
+            ]);
+        }
+        if (this.emissionsDisplay === 'market' && showScope2MarketElectricity) {
+            rows.push([
+                'Scope 2: Electricity (Market)',
+                this.checkNumber(useAndCostTotal.end.marketElectricityEmissions),
+                this.checkNumber(useAndCostTotal.previousYear.marketElectricityEmissions),
+                this.checkNumber(useAndCostTotal.average.marketElectricityEmissions)
+            ]);
+        }
+        if (showScope2Other) {
+            rows.push([
+                'Scope 2: Other',
+                this.checkNumber(useAndCostTotal.end.otherScope2Emissions),
+                this.checkNumber(useAndCostTotal.previousYear.otherScope2Emissions),
+                this.checkNumber(useAndCostTotal.average.otherScope2Emissions)
+            ]);
+        }
+        let totalEnd: string, totalPrevious: string, totalAverage: string;
+        if (this.emissionsDisplay === 'market') {
+            totalEnd = this.checkNumber(useAndCostTotal.end.totalWithMarketEmissions);
+            totalPrevious = this.checkNumber(useAndCostTotal.previousYear.totalWithMarketEmissions);
+            totalAverage = this.checkNumber(useAndCostTotal.average.totalWithMarketEmissions);
+        }
+        if (this.emissionsDisplay === 'location') {
+            totalEnd = this.checkNumber(useAndCostTotal.end.totalWithLocationEmissions);
+            totalPrevious = this.checkNumber(useAndCostTotal.previousYear.totalWithLocationEmissions);
+            totalAverage = this.checkNumber(useAndCostTotal.average.totalWithLocationEmissions);
+        }
+        rows.push([
+            'Total',
+            totalEnd,
+            totalPrevious,
+            totalAverage
+        ]);
+
+        const tableSection: TableSection = {
+            type: 'table',
+            title: 'Utility Emissions Comparison',
+            headers: headers,
+            subHeaders: subheaders,
+            rows: rows
+        };
+
+        return tableSection;
+    }
+
     private createChartSection(chartImageProvider: any, title: string) {
         const chartSection: ChartSection = {
             type: 'chart',
@@ -499,6 +801,20 @@ export class DataOverviewReportAdapter {
             imageDataProvider: chartImageProvider ? chartImageProvider : undefined
         };
         return chartSection;
+    }
+
+    formatDate(date: Date): string {
+        if (!date) {
+            return '-';
+        }
+        return formatDate(date, 'MMM, yyyy', 'en-US');
+    }
+
+    checkValue(value: number): boolean {
+        if (value) {
+            return true;
+        }
+        return false;
     }
 
     checkNumber(value: number): string {
@@ -528,6 +844,7 @@ export interface DataOverviewReportData {
     overviewReport: DataOverviewReportSetup;
     accountData: DataOverviewAccount;
     facilitiesData: Array<DataOverviewFacility>;
+    emissionsDisplay: "market" | "location";
     chartImageProviders?: {
         utilityUsageMap?: Record<string, () => Promise<string>>;
         usageDonut?: Record<string, () => Promise<string>>;
@@ -540,5 +857,11 @@ export interface DataOverviewReportData {
         meterBarChart?: Record<string, () => Promise<string>>;
         annualBarChart?: Record<string, () => Promise<string>>;
         monthlyUsageLineChart?: Record<string, () => Promise<string>>;
+    }>;
+    facilityEmissionsChartImageProviders?: Record<string, {
+        meterStackedLineChartEmissions?: () => Promise<string>;
+        emissionsBarChart?: () => Promise<string>;
+        annualBarChartEmissions?: () => Promise<string>;
+        monthlyUsageLineChartEmissions?: () => Promise<string>;
     }>;
 }

--- a/src/app/v0/data-evaluation/account/account-reports/data-overview-report/data-overview-report.component.ts
+++ b/src/app/v0/data-evaluation/account/account-reports/data-overview-report/data-overview-report.component.ts
@@ -403,11 +403,13 @@ export class DataOverviewReportComponent {
       energyUse: await this.dataOverviewAccountReport?.getChartImageProviders('usageDonut', 'energyUse') ?? '',
       cost: await this.dataOverviewAccountReport?.getChartImageProviders('usageDonut', 'cost') ?? '',
       water: await this.dataOverviewAccountReport?.getChartImageProviders('usageDonut', 'water') ?? '',
+      emissions: await this.dataOverviewAccountReport?.getChartImageProviders('usageDonut', 'emissions') ?? ''
     }
     const mapImages = {
       energyUse: await this.dataOverviewAccountReport?.getChartImageProviders('map', 'energyUse') ?? '',
       cost: await this.dataOverviewAccountReport?.getChartImageProviders('map', 'cost') ?? '',
       water: await this.dataOverviewAccountReport?.getChartImageProviders('map', 'water') ?? '',
+      emissions: await this.dataOverviewAccountReport?.getChartImageProviders('map', 'emissions') ?? ''
     }
     const document = this.dataOverviewReportPptAdapter.buildDocument({
       account: this.account,
@@ -417,6 +419,7 @@ export class DataOverviewReportComponent {
       facilitiesData: this.facilitiesData,
       usageDonutImages: usageDonutImages,
       mapImages: mapImages,
+      emissionsDisplay: this.emissionsDisplay
     });
     await this.pptReportService.buildPowerpoint(document, `Data Overview Report - ${selectedReport?.name}.pptx`);
   }

--- a/src/app/v0/data-evaluation/account/account-reports/data-overview-report/data-overview-report.component.ts
+++ b/src/app/v0/data-evaluation/account/account-reports/data-overview-report/data-overview-report.component.ts
@@ -23,6 +23,7 @@ import { DataOverviewAccountReportComponent } from '@v0/data-evaluation/account/
 import { DataOverviewFacilityReportComponent } from '@v0/data-evaluation/account/account-reports/data-overview-report/data-overview-facility-report/data-overview-facility-report.component';
 import { DataOverviewReportPptAdapter } from '@v0/data-evaluation/account/account-reports/data-overview-report/data-overview-report-ppt.adapter';
 import { PptReportService } from '@v0/shared/ppt-report/ppt-report.service';
+import { AccountOverviewService } from '@v0/data-evaluation/account/account-overview/account-overview.service';
 
 @Component({
   selector: 'app-data-overview-report',
@@ -52,6 +53,9 @@ export class DataOverviewReportComponent {
   calculatingAccounts: boolean = true;
   isExportingPdf: boolean = false;
 
+  emissionsDisplaySub: Subscription;
+  emissionsDisplay: "market" | "location";
+
   @ViewChild(DataOverviewAccountReportComponent) dataOverviewAccountReport: DataOverviewAccountReportComponent;
   @ViewChildren(DataOverviewFacilityReportComponent) dataOverviewFacilityReports!: QueryList<DataOverviewFacilityReportComponent>;
 
@@ -61,7 +65,8 @@ export class DataOverviewReportComponent {
     private exportReportPdfService: ExportReportPdfService,
     private dataOverviewReportAdapter: DataOverviewReportAdapter,
     private dataOverviewReportPptAdapter: DataOverviewReportPptAdapter,
-    private pptReportService: PptReportService
+    private pptReportService: PptReportService,
+    private accountOverviewService: AccountOverviewService
   ) {
 
   }
@@ -105,10 +110,17 @@ export class DataOverviewReportComponent {
     } else {
       this.calculatingFacilities = false;
     }
+
+    this.emissionsDisplaySub = this.accountOverviewService.emissionsDisplay.subscribe(display => {
+      this.emissionsDisplay = display;
+    });
   }
 
   ngOnDestroy() {
     this.printSub.unsubscribe();
+    if (this.emissionsDisplaySub) {
+      this.emissionsDisplaySub.unsubscribe();
+    }
   }
 
   //recursively function to calculate all facilities one at a time
@@ -281,8 +293,10 @@ export class DataOverviewReportComponent {
         overviewReport: this.overviewReport,
         accountData: this.accountData,
         facilitiesData: this.facilitiesData,
+        emissionsDisplay: this.emissionsDisplay,
         chartImageProviders: this.getChartImageProviders(),
-        facilityChartImageProviders: this.getFacilityChartImageProviders()
+        facilityChartImageProviders: this.getFacilityChartImageProviders(),
+        facilityEmissionsChartImageProviders: this.getFacilityEmissionsChartImageProviders()
       });
       await this.exportReportPdfService.export(document, `${selectedReport.name} - Data Overview Report`);
     } finally {
@@ -296,26 +310,31 @@ export class DataOverviewReportComponent {
         energyUse: async () => this.dataOverviewAccountReport?.getChartImageProviders('map', 'energyUse') ?? '',
         cost: async () => this.dataOverviewAccountReport?.getChartImageProviders('map', 'cost') ?? '',
         water: async () => this.dataOverviewAccountReport?.getChartImageProviders('map', 'water') ?? '',
+        emissions: async () => this.dataOverviewAccountReport?.getChartImageProviders('map', 'emissions') ?? '',
       },
       usageDonut: {
         energyUse: async () => this.dataOverviewAccountReport?.getChartImageProviders('usageDonut', 'energyUse') ?? '',
         cost: async () => this.dataOverviewAccountReport?.getChartImageProviders('usageDonut', 'cost') ?? '',
         water: async () => this.dataOverviewAccountReport?.getChartImageProviders('usageDonut', 'water') ?? '',
+        emissions: async () => this.dataOverviewAccountReport?.getChartImageProviders('usageDonut', 'emissions') ?? '',
       },
       utilityUsageDonut: {
         energyUse: async () => this.dataOverviewAccountReport?.getChartImageProviders('utilityUsageDonut', 'energyUse') ?? '',
         cost: async () => this.dataOverviewAccountReport?.getChartImageProviders('utilityUsageDonut', 'cost') ?? '',
         water: async () => this.dataOverviewAccountReport?.getChartImageProviders('utilityUsageDonut', 'water') ?? '',
+        emissions: async () => this.dataOverviewAccountReport?.getChartImageProviders('utilityUsageDonut', 'emissions') ?? '',
       },
       utilityUsageStackedBar: {
         energyUse: async () => this.dataOverviewAccountReport?.getChartImageProviders('utilityUsageStackedBar', 'energyUse') ?? '',
         cost: async () => this.dataOverviewAccountReport?.getChartImageProviders('utilityUsageStackedBar', 'cost') ?? '',
         water: async () => this.dataOverviewAccountReport?.getChartImageProviders('utilityUsageStackedBar', 'water') ?? '',
+        emissions: async() => this.dataOverviewAccountReport?.getChartImageProviders('utilityUsageStackedBar', 'emissions') ?? '',
       },
       monthlyUsageLineChart: {
         energyUse: async () => this.dataOverviewAccountReport?.getChartImageProviders('monthlyUsageLineChart', 'energyUse') ?? '',
         cost: async () => this.dataOverviewAccountReport?.getChartImageProviders('monthlyUsageLineChart', 'cost') ?? '',
         water: async () => this.dataOverviewAccountReport?.getChartImageProviders('monthlyUsageLineChart', 'water') ?? '',
+        emissions: async () => this.dataOverviewAccountReport?.getChartImageProviders('monthlyUsageLineChart', 'emissions') ?? '',
       }
     };
   }
@@ -343,6 +362,25 @@ export class DataOverviewReportComponent {
         cost: async () => facilityReport.getImage('cost', 'monthlyUsageLineChart'),
         water: async () => facilityReport.getImage('water', 'monthlyUsageLineChart')
       }
+    });
+
+    this.dataOverviewFacilityReports.forEach(facilityReport => {
+      const facilityId = facilityReport?.dataOverviewFacility?.facility?.guid;
+      if (facilityId) {
+        map[facilityId] = buildChartProviders(facilityReport);
+      }
+    });
+
+    return map;
+  }
+
+  getFacilityEmissionsChartImageProviders() {
+    const map: Record<string, any> = {};
+    const buildChartProviders = (facilityReport: DataOverviewFacilityReportComponent) => ({
+      meterStackedLineChartEmissions: async () => facilityReport.getImage('emissions', 'meterStackedLineChartEmissions'),
+      emissionsBarChart: async () => facilityReport.getImage('emissions', 'emissionsBarChart'),
+      annualBarChartEmissions: async () => facilityReport.getImage('emissions', 'annualBarChartEmissions'),
+      monthlyUsageLineChartEmissions: async () => facilityReport.getImage('emissions', 'monthlyUsageLineChart')
     });
 
     this.dataOverviewFacilityReports.forEach(facilityReport => {

--- a/src/app/v0/data-evaluation/facility/facility-reports/report-results/facility-overview-report-results/facility-overview-report-ppt.adapter.ts
+++ b/src/app/v0/data-evaluation/facility/facility-reports/report-results/facility-overview-report-results/facility-overview-report-ppt.adapter.ts
@@ -12,6 +12,10 @@ import { UtilityColors } from '@shared/utilityColors';
 import { AllSources, EnergySources, MeterSource, WaterSources } from '@data/models/constantsAndTypes';
 import { YearMonthData } from '@data/models/dashboard';
 import { Month, Months } from '@shared/form-data/months';
+import { IdbAccount } from '@app/data/models/idbModels/account';
+import { AccountWorkspaceStore } from '@app/data/account-workspace/account-workspace.store';
+import { EmissionsTypes, getEmissionsTypeColor, getEmissionsTypes } from '@app/data/models/eGridEmissions';
+import { MonthlyData } from '@app/data/models/calanderization';
 
 export interface FacilityOverviewReportPptInput {
     facility: IdbFacility;
@@ -22,11 +26,13 @@ export interface FacilityOverviewReportPptInput {
         startDate: Date,
         endDate: Date
     };
+    emissionsDisplay: "location" | "market";
 }
 
 @Injectable({ providedIn: 'root' })
 export class FacilityOverviewReportPptAdapter {
-  private readonly accountWorkspaceQuery = inject(AccountWorkspaceQueryService);
+    private readonly accountWorkspaceQuery = inject(AccountWorkspaceQueryService);
+    private readonly accountWorkspaceStore = inject(AccountWorkspaceStore);
     customNumberPipe: CustomNumberPipe = inject(CustomNumberPipe);
 
     reportSettings: DataOverviewFacilityReportSettings;
@@ -38,6 +44,9 @@ export class FacilityOverviewReportPptAdapter {
         '1F77B4', 'FF7F0E', '2CA02C', 'D62728', '9467BD', '8C564B',
         'E377C2', '7F7F7F', 'BCBD22', '17BECF', '4E79A7', 'F28E2B'
     ];
+
+    account: IdbAccount;
+    emissionsDisplay: "location" | "market";
 
     buildDocument(data: FacilityOverviewReportPptInput): PptDocument {
         const slides: PptSlide[] = [];
@@ -52,6 +61,8 @@ export class FacilityOverviewReportPptAdapter {
         this.dateRange = data.dateRange;
         this.facilityOverviewData = data.facilityOverviewData;
         this.utilityUseAndCost = data.utilityUseAndCost;
+        this.account = this.accountWorkspaceStore.account();
+        this.emissionsDisplay = data.emissionsDisplay;
 
         if (this.reportSettings.includeEnergySection) {
             const energySlides: PptSlide[] = [];
@@ -87,6 +98,18 @@ export class FacilityOverviewReportPptAdapter {
                     layout: 'section'
                 });
                 slides.push(...costSlides);
+            }
+        }
+        if (this.account.displayEmissions && this.reportSettings.includeEmissionsSection) {
+            const emissionsSlides: PptSlide[] = [];
+            this.buildEmissionsSections(emissionsSlides);
+            if (emissionsSlides.length > 0) {
+                slides.push({
+                    type: 'title',
+                    title: 'Emissions',
+                    layout: 'section'
+                });
+                slides.push(...emissionsSlides);
             }
         }
         return {
@@ -158,6 +181,464 @@ export class FacilityOverviewReportPptAdapter {
         }
     }
 
+    private buildEmissionsSections(slides: PptSlide[]) {
+        const facilityOverviewMeters = this.facilityOverviewData.costMeters;
+        if (this.reportSettings.includeMeterUsageStackedLineChart && this.facilityOverviewData.calanderizedMeters?.length > 0) {
+            const chartSlide: ChartSlide = this.buildEmissionsStackedLineChart();
+            if (chartSlide) {
+                slides.push(chartSlide);
+            }
+        }
+        if (this.reportSettings.includeMeterUsageTable && this.facilityOverviewData.calanderizedMeters?.length > 0 && facilityOverviewMeters?.length > 0) {
+            const tableSlide: TableSlide = this.buildEmissionsUsageTable();
+            if (tableSlide) {
+                slides.push(tableSlide);
+            }
+        }
+        if (this.reportSettings.includeMeterUsageDonut && facilityOverviewMeters?.length > 0) {
+            const chartSlide: ChartSlide = this.buildEmissionsUsageChart();
+            if (chartSlide) {
+                slides.push(chartSlide);
+            }
+        }
+        let sourcesUseAndCost: Array<UseAndCost> = this.utilityUseAndCost.allSourcesUseAndCost;
+        let useAndCostTotal: { end: IUseAndCost; average: IUseAndCost; previousYear: IUseAndCost; } = this.utilityUseAndCost.allSourcesTotal;
+        if (this.reportSettings.includeUtilityTableForFacility && sourcesUseAndCost?.length > 0 && useAndCostTotal) {
+            const tableSlide: TableSlide = this.buildEmissionsConsumptionTable(useAndCostTotal, this.utilityUseAndCost.previousYear);
+            if (tableSlide) {
+                slides.push(tableSlide);
+            }
+        }
+        if (this.reportSettings.includeAnnualBarChart && this.facilityOverviewData.annualSourceData?.length > 0) {
+            const annualBarChartSlide: ChartSlide = this.buildAnnualEmissionsBarChart(this.facilityOverviewData.annualSourceData);
+            if (annualBarChartSlide) {
+                slides.push(annualBarChartSlide);
+            }
+        }
+        const yearMonthData = this.facilityOverviewData.allSourcesYearMonthData;
+        if (this.reportSettings.includeMonthlyLineChartForFacility && yearMonthData?.length > 0) {
+            const monthlyLineChartSlide: ChartSlide = this.buildMonthlyLineChart('emissions', yearMonthData);
+            if (monthlyLineChartSlide) {
+                slides.push(monthlyLineChartSlide);
+            }
+        }
+    }
+
+    private buildEmissionsStackedLineChart(): ChartSlide {
+        const monthlyData = this.facilityOverviewData.calanderizedMeters
+            .flatMap(cm => cm.monthlyData)
+            .filter(item => {
+                const date = new Date(item.date);
+                return date >= this.dateRange.startDate && date <= this.dateRange.endDate;
+            });
+
+        const months: Date[] = [];
+        for (let date = new Date(this.dateRange.startDate); date <= this.dateRange.endDate; date.setMonth(date.getMonth() + 1)) {
+            months.push(new Date(date));
+        }
+
+        const getValue = (type: EmissionsTypes, data: MonthlyData): number => {
+            switch (type) {
+                case 'Scope 1: Fugitive': return data.fugitiveEmissions ?? 0;
+                case 'Scope 2: Electricity (Location)': return data.locationElectricityEmissions ?? 0;
+                case 'Scope 2: Electricity (Market)': return data.marketElectricityEmissions ?? 0;
+                case 'Scope 1: Mobile': return data.mobileTotalEmissions ?? 0;
+                case 'Scope 1: Process': return data.processEmissions ?? 0;
+                case 'Scope 1: Stationary': return data.stationaryEmissions ?? 0;
+                case 'Scope 2: Other': return data.otherScope2Emissions ?? 0;
+            }
+        };
+
+        const series: PptChartSeries[] = getEmissionsTypes(this.emissionsDisplay)
+            .map(type => ({
+                name: type,
+                type: 'area' as const,
+                data: months.map(month => _.sumBy(
+                    monthlyData.filter(item =>
+                        item.monthNumValue === month.getMonth() && item.year === month.getFullYear()
+                    ),
+                    item => getValue(type, item)
+                )),
+                color: getEmissionsTypeColor(type).replace('#', '')
+            }))
+            .filter(item => item.data.some(value => value !== 0));
+
+        if (!series.length) {
+            return null;
+        }
+        const totals = months.map((_, index) =>
+            series.reduce((sum, item) => sum + item.data[index], 0)
+        );
+        const axis = getPptAxisSpec(totals);
+
+        return {
+            type: 'chart',
+            title: 'Utility Emissions (tonne CO2e)',
+            chartType: 'combo',
+            labels: months.map(month =>
+                month.toLocaleString('en-US', { month: 'short', year: 'numeric' })
+            ),
+            series,
+            yAxisUnit: 'tonne CO2e',
+            valAxisMinVal: axis.min,
+            valAxisMaxVal: axis.max,
+            valAxisMajorUnit: axis.majorUnit,
+            valAxisLabelFormatCode: axis.labelFormat,
+            showLegend: true
+        };
+    }
+
+    private buildEmissionsUsageTable(): TableSlide {
+        const title = 'Emissions Usage Breakdown';
+        let headers = ['Emissions Type', `Total With Market Emissions\n(tonne CO2e)`, `Total With Location Emissions\n(tonne CO2e)`];
+        let rows: string[][] = [];
+
+        const emissionTotals = this.facilityOverviewData.emissionsTotals;
+
+        if (emissionTotals.stationaryEmissions) {
+            rows.push([
+                'Scope 1: Stationary',
+                this.formatValue(emissionTotals.stationaryEmissions, false),
+                this.formatValue(emissionTotals.stationaryEmissions, false)
+            ]);
+        }
+        if (emissionTotals.mobileTotalEmissions) {
+            rows.push([
+                'Scope 1: Mobile',
+                this.formatValue(emissionTotals.mobileTotalEmissions, false),
+                this.formatValue(emissionTotals.mobileTotalEmissions, false)
+            ]);
+        }
+        if (emissionTotals.fugitiveEmissions) {
+            rows.push([
+                'Scope 1: Fugitive',
+                this.formatValue(emissionTotals.fugitiveEmissions, false),
+                this.formatValue(emissionTotals.fugitiveEmissions, false)
+            ]);
+        }
+        if (emissionTotals.processEmissions) {
+            rows.push([
+                'Scope 1: Process',
+                this.formatValue(emissionTotals.processEmissions, false),
+                this.formatValue(emissionTotals.processEmissions, false)
+            ]);
+        }
+        if (emissionTotals.marketElectricityEmissions || emissionTotals.locationElectricityEmissions) {
+            rows.push([
+                'Scope 2: Electricity',
+                this.formatValue(emissionTotals.marketElectricityEmissions, false),
+                this.formatValue(emissionTotals.locationElectricityEmissions, false)
+            ]);
+        }
+        if (emissionTotals.otherScope2Emissions) {
+            rows.push([
+                'Scope 2: Other',
+                this.formatValue(emissionTotals.otherScope2Emissions, false),
+                this.formatValue(emissionTotals.otherScope2Emissions, false)
+            ]);
+        }
+        rows.push([
+            'Total',
+            this.formatValue(emissionTotals.totalWithMarketEmissions, false),
+            this.formatValue(emissionTotals.totalWithLocationEmissions, false)
+        ]);
+
+        return {
+            type: 'table',
+            headers,
+            rows,
+            title
+        };
+    }
+
+    private buildEmissionsUsageChart(): ChartSlide {
+        const emissionsTypes = getEmissionsTypes(this.emissionsDisplay).reverse();
+        const allEmissions = this.facilityOverviewData.costMeters
+            .map(facilityOverviewMeter => facilityOverviewMeter.emissions);
+
+        const labels: string[] = [];
+        const values: number[] = [];
+        const barColors: string[] = [];
+
+        const getValue = (emissionsType: EmissionsTypes, emissions: MonthlyData): number => {
+            if (emissionsType === 'Scope 1: Fugitive') {
+                return emissions.fugitiveEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 2: Electricity (Location)') {
+                return emissions.locationElectricityEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 2: Electricity (Market)') {
+                return Math.max(emissions.marketElectricityEmissions ?? 0, 0);
+            }
+
+            if (emissionsType === 'Scope 1: Mobile') {
+                return emissions.mobileTotalEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 1: Process') {
+                return emissions.processEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 1: Stationary') {
+                return emissions.stationaryEmissions ?? 0;
+            }
+
+            return emissions.otherScope2Emissions ?? 0;
+        };
+
+        emissionsTypes.forEach(emissionsType => {
+            const value = _.sumBy(
+                allEmissions,
+                emissions => getValue(emissionsType, emissions as MonthlyData)
+            );
+
+            if (value !== 0) {
+                labels.push(emissionsType);
+                values.push(value);
+                barColors.push(getEmissionsTypeColor(emissionsType).replace('#', ''));
+            }
+        });
+
+        if (!values.length) {
+            return null;
+        }
+
+        const total = values.reduce((sum, value) => sum + value, 0);
+
+        const labelsWithPercentages = labels.map((label, index) => {
+            const percentage = total === 0
+                ? 0
+                : (values[index] / total) * 100;
+
+            return `${label} (${percentage.toFixed(1)}%)`;
+        });
+
+        const axis = getPptAxisSpec(
+            values.filter(value => Number.isFinite(value))
+        );
+
+        return {
+            type: 'chart',
+            title: 'Emission Breakdown',
+            chartType: 'bar',
+            barDir: 'bar',
+            labels: labelsWithPercentages,
+            series: [{
+                name: 'Emissions',
+                data: values
+            }],
+            barColors,
+            yAxisUnit: 'tonne CO2e',
+            valAxisMinVal: axis.min,
+            valAxisMaxVal: axis.max,
+            valAxisMajorUnit: axis.majorUnit,
+            valAxisLabelFormatCode: axis.labelFormat,
+            showLegend: false,
+            showDataLabels: true
+        };
+    }
+
+    private buildEmissionsConsumptionTable(
+        useAndCostTotal: { end: IUseAndCost; average: IUseAndCost; previousYear: IUseAndCost; },
+        previousYear: Date): TableSlide {
+        let headers: string[] = [];
+        let subHeaders: string[] = [];
+        let rows: string[][] = [];
+
+        const endDate = this.dateRange.endDate ? this.dateRange.endDate.toLocaleString('en-US', { month: 'short', year: 'numeric' }) : '';
+        const previousYearDate = previousYear ? previousYear.toLocaleString('en-US', { month: 'short', year: 'numeric' }) : '';
+        const averageDate = this.dateRange.startDate && this.dateRange.endDate ? `${this.dateRange.startDate.toLocaleString('en-US', { month: 'short', year: 'numeric' })} - ${this.dateRange.endDate.toLocaleString('en-US', { month: 'short', year: 'numeric' })}` : '';
+
+        headers = ['', `Latest Month\n(${endDate})`, `Previous Year\n(${previousYearDate})`, `Monthly Average\n(${averageDate})`];
+        subHeaders = ['', '(tonne CO2e)', '(tonne CO2e)', '(tonne CO2e)'];
+
+        let showMobile = false, showFugitive = false, showProcess = false, showStationary = false, showScope2LocationElectricity = false, showScope2MarketElectricity = false, showScope2Other = false;
+        if (useAndCostTotal) {
+            showMobile = (this.checkValue(useAndCostTotal.average.mobileTotalEmissions) || this.checkValue(useAndCostTotal.end.mobileTotalEmissions) || this.checkValue(useAndCostTotal.previousYear.mobileTotalEmissions));
+            showFugitive = (this.checkValue(useAndCostTotal.average.fugitiveEmissions) || this.checkValue(useAndCostTotal.end.fugitiveEmissions) || this.checkValue(useAndCostTotal.previousYear.fugitiveEmissions));
+            showProcess = (this.checkValue(useAndCostTotal.average.processEmissions) || this.checkValue(useAndCostTotal.end.processEmissions) || this.checkValue(useAndCostTotal.previousYear.processEmissions));
+            showStationary = (this.checkValue(useAndCostTotal.average.stationaryEmissions) || this.checkValue(useAndCostTotal.end.stationaryEmissions) || this.checkValue(useAndCostTotal.previousYear.stationaryEmissions));
+            showScope2LocationElectricity = (this.checkValue(useAndCostTotal.average.locationElectricityEmissions) || this.checkValue(useAndCostTotal.end.locationElectricityEmissions) || this.checkValue(useAndCostTotal.previousYear.locationElectricityEmissions));
+            showScope2MarketElectricity = (this.checkValue(useAndCostTotal.average.marketElectricityEmissions) || this.checkValue(useAndCostTotal.end.marketElectricityEmissions) || this.checkValue(useAndCostTotal.previousYear.marketElectricityEmissions));
+            showScope2Other = (this.checkValue(useAndCostTotal.average.otherScope2Emissions) || this.checkValue(useAndCostTotal.end.otherScope2Emissions) || this.checkValue(useAndCostTotal.previousYear.otherScope2Emissions));
+        }
+
+        if (showMobile) {
+            rows.push([
+                'Scope 1: Mobile',
+                this.formatValue(useAndCostTotal.end.mobileTotalEmissions, false),
+                this.formatValue(useAndCostTotal.previousYear.mobileTotalEmissions, false),
+                this.formatValue(useAndCostTotal.average.mobileTotalEmissions, false),
+            ]);
+        }
+        if (showFugitive) {
+            rows.push([
+                'Scope 1: Fugitive',
+                this.formatValue(useAndCostTotal.end.fugitiveEmissions, false),
+                this.formatValue(useAndCostTotal.previousYear.fugitiveEmissions, false),
+                this.formatValue(useAndCostTotal.average.fugitiveEmissions, false),
+            ]);
+        }
+        if (showProcess) {
+            rows.push([
+                'Scope 1: Process',
+                this.formatValue(useAndCostTotal.end.processEmissions, false),
+                this.formatValue(useAndCostTotal.previousYear.processEmissions, false),
+                this.formatValue(useAndCostTotal.average.processEmissions, false),
+            ]);
+        }
+        if (showStationary) {
+            rows.push([
+                'Scope 1: Stationary',
+                this.formatValue(useAndCostTotal.end.stationaryEmissions, false),
+                this.formatValue(useAndCostTotal.previousYear.stationaryEmissions, false),
+                this.formatValue(useAndCostTotal.average.stationaryEmissions, false),
+            ]);
+        }
+        if (this.emissionsDisplay === 'location' && showScope2LocationElectricity) {
+            rows.push([
+                'Scope 2: Electricity (Location)',
+                this.formatValue(useAndCostTotal.end.locationElectricityEmissions, false),
+                this.formatValue(useAndCostTotal.previousYear.locationElectricityEmissions, false),
+                this.formatValue(useAndCostTotal.average.locationElectricityEmissions, false),
+            ]);
+        }
+        if (this.emissionsDisplay === 'market' && showScope2MarketElectricity) {
+            rows.push([
+                'Scope 2: Electricity (Market)',
+                this.formatValue(useAndCostTotal.end.marketElectricityEmissions, false),
+                this.formatValue(useAndCostTotal.previousYear.marketElectricityEmissions, false),
+                this.formatValue(useAndCostTotal.average.marketElectricityEmissions, false),
+            ]);
+        }
+        if (showScope2Other) {
+            rows.push([
+                'Scope 2: Other',
+                this.formatValue(useAndCostTotal.end.otherScope2Emissions, false),
+                this.formatValue(useAndCostTotal.previousYear.otherScope2Emissions, false),
+                this.formatValue(useAndCostTotal.average.otherScope2Emissions, false),
+            ]);
+        }
+        let endVal: number, prevVal: number, avgVal: number;
+        if (this.emissionsDisplay === 'market') {
+            endVal = useAndCostTotal.end.totalWithMarketEmissions;
+            prevVal = useAndCostTotal.previousYear.totalWithMarketEmissions;
+            avgVal = useAndCostTotal.average.totalWithMarketEmissions;
+        }
+        if (this.emissionsDisplay === 'location') {
+            endVal = useAndCostTotal.end.totalWithLocationEmissions;
+            prevVal = useAndCostTotal.previousYear.totalWithLocationEmissions;
+            avgVal = useAndCostTotal.average.totalWithLocationEmissions;
+        }
+
+        rows.push([
+            'Total',
+            this.formatValue(endVal, false),
+            this.formatValue(prevVal, false),
+            this.formatValue(avgVal, false),
+        ]);
+
+        return {
+            type: 'table',
+            headers,
+            subHeaders,
+            rows,
+            title: 'Emissions Comparison'
+        }
+    }
+
+    private buildAnnualEmissionsBarChart(annualSourceData: Array<AnnualSourceData>): ChartSlide {
+        const annualSourceDataItems = annualSourceData.flatMap(sourceData =>
+            sourceData.annualSourceDataItems ?? []
+        );
+
+        const years = _.chain(annualSourceDataItems)
+            .map(item => item.fiscalYear)
+            .uniq()
+            .sortBy()
+            .value();
+
+        if (!years.length) {
+            return null;
+        }
+
+        const getValue = (emissionsType: EmissionsTypes, item: AnnualSourceData['annualSourceDataItems'][number]): number => {
+            const emissions = item.totalEmissions;
+
+            if (emissionsType === 'Scope 1: Fugitive') {
+                return emissions.fugitiveEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 2: Electricity (Location)') {
+                return emissions.locationElectricityEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 2: Electricity (Market)') {
+                return emissions.marketElectricityEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 1: Mobile') {
+                return emissions.mobileTotalEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 1: Process') {
+                return emissions.processEmissions ?? 0;
+            }
+
+            if (emissionsType === 'Scope 1: Stationary') {
+                return emissions.stationaryEmissions ?? 0;
+            }
+
+            return emissions.otherScope2Emissions ?? 0;
+        };
+
+        const series: PptChartSeries[] = getEmissionsTypes(this.emissionsDisplay)
+            .map(emissionsType => ({
+                name: emissionsType,
+                data: years.map(year => {
+                    const dataForYear = annualSourceDataItems.filter(item =>
+                        item.fiscalYear === year
+                    );
+
+                    return _.sumBy(dataForYear, item =>
+                        getValue(emissionsType, item)
+                    );
+                }),
+                color: getEmissionsTypeColor(emissionsType).replace('#', '')
+            }))
+            .filter(chartSeries => chartSeries.data.some(value => value !== 0));
+
+        if (!series.length) {
+            return null;
+        }
+
+        const values = series
+            .flatMap(chartSeries => chartSeries.data)
+            .filter(value => Number.isFinite(value));
+
+        const axis = getPptAxisSpec(values);
+
+        return {
+            type: 'chart',
+            title: 'Annual Utility Emissions (tonne CO2e)',
+            chartType: 'bar',
+            labels: years.map(year =>
+                this.facility.fiscalYear === 'nonCalendarYear'
+                    ? `FY - ${year}`
+                    : year.toString()
+            ),
+            series,
+            yAxisUnit: 'tonne CO2e',
+            valAxisMinVal: axis.min,
+            valAxisMaxVal: axis.max,
+            valAxisMajorUnit: axis.majorUnit,
+            valAxisLabelFormatCode: axis.labelFormat,
+            showLegend: true
+        };
+    }
+
     private buildStackedLineChart(sectionType: 'energyUse' | 'cost' | 'water'): ChartSlide {
         const includedSources: Array<MeterSource> = sectionType === 'energyUse' ? EnergySources : sectionType === 'water' ? WaterSources : AllSources;
 
@@ -171,55 +652,96 @@ export class FacilityOverviewReportPptAdapter {
 
         if (!filteredMeters.length) return null;
 
-        const allKeys = new Set<string>();
-        filteredMeters.forEach(cMeter => {
-            cMeter.monthlyData.forEach(d => {
-                const date = new Date(d.date);
-                if (date >= this.dateRange.startDate && date <= this.dateRange.endDate) {
-                    allKeys.add(`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`);
-                }
-            });
-        });
+        const monthKeys: string[] = [];
+        const startDate = new Date(this.dateRange.startDate.getFullYear(), this.dateRange.startDate.getMonth(), 1);
+        const endDate = new Date(this.dateRange.endDate.getFullYear(), this.dateRange.endDate.getMonth(), 1);
 
-        const sortedKeys = Array.from(allKeys).sort();
-        const labels = sortedKeys.map(k => {
-            const [y, m] = k.split('-');
-            return new Date(+y, +m - 1, 1).toLocaleString('en-US', { month: 'short', year: 'numeric' });
-        });
+        for (const date = new Date(startDate); date <= endDate; date.setMonth(date.getMonth() + 1)) {
+            monthKeys.push(`${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`);
+        }
+        if (!monthKeys.length) return null;
+
+        const getValue = (monthlyData: MonthlyData): number => {
+            if (sectionType === 'energyUse') {
+                return monthlyData.energyUse ?? 0;
+            }
+
+            if (sectionType === 'water') {
+                return monthlyData.energyConsumption ?? 0;
+            }
+
+            return monthlyData.energyCost ?? 0;
+        };
 
         const series: PptChartSeries[] = filteredMeters.map(cMeter => {
-            const valueByKey = new Map<string, number>();
-            cMeter.monthlyData.forEach(d => {
-                const date = new Date(d.date);
-                if (date >= this.dateRange.startDate && date <= this.dateRange.endDate) {
-                    const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
-                    const value = sectionType === 'cost' ? d.energyCost : sectionType === 'water' ? d.energyConsumption : d.energyUse;
-                    valueByKey.set(key, value ?? 0);
+            const valueByMonth = new Map<string, number>();
+
+            cMeter.monthlyData.forEach(monthlyData => {
+                const date = new Date(monthlyData.date);
+
+                if (date < startDate || date > endDate) {
+                    return;
                 }
+
+                const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}`;
+                valueByMonth.set(key, (valueByMonth.get(key) ?? 0) + getValue(monthlyData));
             });
+
             return {
                 name: cMeter.meter.name,
                 type: 'area',
-                data: sortedKeys.map(k => valueByKey.get(k) ?? 0),
+                data: monthKeys.map(key => valueByMonth.get(key) ?? 0),
                 color: UtilityColors[cMeter.meter.source]?.color?.replace('#', '') ?? '999999'
             };
         });
 
-        const stackedTotals = sortedKeys.map((i) => series.reduce((sum, s) => sum + (s.data[i] ?? 0), 0));
-        const axis = getPptAxisSpec(stackedTotals.filter(v => isFinite(v) && !isNaN(v)));
-        const yAxisUnit = sectionType === 'water' ? this.facility.volumeLiquidUnit : sectionType === 'cost' ? 'Cost ($)' : this.facility.energyUnit;
+        const hasData = series.some(chartSeries =>
+            chartSeries.data.some(value => value !== 0)
+        );
+
+        if (!hasData) {
+            return null;
+        }
+
+        const stackedTotals = monthKeys.map((_, index) =>
+            series.reduce((total, chartSeries) => total + (chartSeries.data[index] ?? 0), 0)
+        );
+
+        const axis = getPptAxisSpec(
+            stackedTotals.filter(value => Number.isFinite(value))
+        );
+
+        const yAxisUnit = sectionType === 'water'
+            ? this.facility.volumeLiquidUnit
+            : sectionType === 'cost'
+                ? 'Cost ($)'
+                : this.facility.energyUnit;
+
+        const title = sectionType === 'water'
+            ? `Water Usage (${yAxisUnit})`
+            : sectionType === 'cost'
+                ? 'Utility Costs'
+                : `Utility Usage (${yAxisUnit})`;
 
         return {
             type: 'chart',
-            title: sectionType === 'water' ? `Water Usage (${yAxisUnit})` : sectionType === 'cost' ? 'Utility Costs' : `Utility Usage (${yAxisUnit})`,
+            title,
             chartType: 'combo',
-            labels,
+            labels: monthKeys.map(key => {
+                const [year, month] = key.split('-');
+                return new Date(+year, +month - 1, 1).toLocaleString('en-US', {
+                    month: 'short',
+                    year: 'numeric'
+                });
+            }),
             series,
             yAxisUnit,
             valAxisMinVal: axis.min,
             valAxisMaxVal: axis.max,
             valAxisMajorUnit: axis.majorUnit,
-            valAxisLabelFormatCode: axis.labelFormat,
+            valAxisLabelFormatCode: sectionType === 'cost'
+                ? '$#,##0'
+                : axis.labelFormat,
             showLegend: true
         };
     }
@@ -445,7 +967,7 @@ export class FacilityOverviewReportPptAdapter {
         }
     }
 
-    private buildMonthlyLineChart(sectionType: 'energyUse' | 'cost' | 'water', yearMonthData: Array<YearMonthData>): ChartSlide {
+    private buildMonthlyLineChart(sectionType: 'energyUse' | 'cost' | 'water' | 'emissions', yearMonthData: Array<YearMonthData>): ChartSlide {
         let years: Array<number> = yearMonthData.flatMap(data => { return data.yearMonth.fiscalYear });
         years = _.uniq(years);
         years = _.orderBy(years, (year) => { return year }, 'asc');
@@ -471,6 +993,14 @@ export class FacilityOverviewReportPptAdapter {
                 if (sectionType === 'cost') {
                     return row.energyCost ?? 0;
                 }
+                if (sectionType === 'emissions') {
+                    if (this.emissionsDisplay === 'location') {
+                        return row.totalWithLocationEmissions ?? 0;
+                    }
+                    if (this.emissionsDisplay === 'market') {
+                        return row.totalWithMarketEmissions ?? 0;
+                    }
+                }
             });
             const name: string = this.facility.fiscalYear === 'nonCalendarYear' ? `FY - ${year}` : year.toString();
             return {
@@ -482,8 +1012,8 @@ export class FacilityOverviewReportPptAdapter {
 
         const allValues = series.flatMap(s => s.data).filter(v => isFinite(v) && !isNaN(v));
         const axis = getPptAxisSpec(allValues);
-        const yAxisUnit = sectionType === 'water' ? this.facility.volumeLiquidUnit : sectionType === 'cost' ? 'Cost ($)' : this.facility.energyUnit;
-        const title = sectionType === 'cost' ? 'Utility Costs' : sectionType === 'water' ? `Water Usage (${yAxisUnit})` : `Utility Usage (${yAxisUnit})`;
+        const yAxisUnit = sectionType === 'emissions' ? '' : sectionType === 'water' ? this.facility.volumeLiquidUnit : sectionType === 'cost' ? 'Cost ($)' : this.facility.energyUnit;
+        const title = sectionType === 'emissions' ? 'Utility Emissions (tonne CO2e)' : sectionType === 'cost' ? 'Utility Costs' : sectionType === 'water' ? `Water Usage (${yAxisUnit})` : `Utility Usage (${yAxisUnit})`;
         return {
             type: 'chart',
             title,
@@ -503,5 +1033,12 @@ export class FacilityOverviewReportPptAdapter {
         if (value === null || isNaN(value) || value === 0 || value === undefined)
             return '—';
         return this.customNumberPipe.transform(value, isCurrrency);
+    }
+
+    checkValue(value: number): boolean {
+        if (value) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/app/v0/data-evaluation/facility/facility-reports/report-results/facility-overview-report-results/facility-overview-report-results.component.html
+++ b/src/app/v0/data-evaluation/facility/facility-reports/report-results/facility-overview-report-results/facility-overview-report-results.component.html
@@ -90,7 +90,7 @@
   </div>
 </div>
 }
-@if (overviewReportSettings.includeEmissionsSection) {
+@if (account.displayEmissions && overviewReportSettings.includeEmissionsSection) {
 <hr>
 <div class="report print-break-before" [ngClass]="{'print': print}">
   <!--facility emissions-->

--- a/src/app/v0/data-evaluation/facility/facility-reports/report-results/facility-overview-report-results/facility-overview-report-results.component.ts
+++ b/src/app/v0/data-evaluation/facility/facility-reports/report-results/facility-overview-report-results/facility-overview-report-results.component.ts
@@ -242,7 +242,8 @@ export class FacilityOverviewReportResultsComponent {
       facility: this.facility,
       facilityOverviewData: this.facilityOverviewData,
       utilityUseAndCost: this.utilityUseAndCost,
-      dateRange: this.dateRange
+      dateRange: this.dateRange,
+      emissionsDisplay: this.emissionsDisplay
     });
     await this.pptReportService.buildPowerpoint(document, `Data Overview Report - ${this.facilityReport.name}.pptx`);
   }

--- a/src/app/v0/data-evaluation/facility/facility-reports/report-results/facility-overview-report-results/facility-overview-report-results.component.ts
+++ b/src/app/v0/data-evaluation/facility/facility-reports/report-results/facility-overview-report-results/facility-overview-report-results.component.ts
@@ -21,6 +21,8 @@ import { ExportReportPdfService } from '@v0/shared/pdf-report/services/export-re
 import { FacilitySectionReportComponent } from '@v0/shared/data-overview/facility-section-report/facility-section-report.component';
 import { FacilityOverviewReportPptAdapter } from '@v0/data-evaluation/facility/facility-reports/report-results/facility-overview-report-results/facility-overview-report-ppt.adapter';
 import { PptReportService } from '@v0/shared/ppt-report/ppt-report.service';
+import { AccountOverviewService } from '@v0/data-evaluation/account/account-overview/account-overview.service';
+import { FacilityOverviewService } from '@v0/data-evaluation/facility/facility-overview/facility-overview.service';
 
 @Component({
   selector: 'app-facility-overview-report-results',
@@ -50,6 +52,10 @@ export class FacilityOverviewReportResultsComponent {
   worker: Worker;
   calculating: boolean | 'error' = true;
 
+  emissionsDisplaySub: Subscription;
+  emissionsDisplay: "market" | "location";
+  account: IdbAccount;
+
   @ViewChildren(FacilitySectionReportComponent) sectionReports !: QueryList<FacilitySectionReportComponent>;
 
   constructor(
@@ -59,13 +65,17 @@ export class FacilityOverviewReportResultsComponent {
     private exportReportPdfService: ExportReportPdfService,
     private pptReportService: PptReportService,
     private facilityOverviewReportPptAdapter: FacilityOverviewReportPptAdapter,
-    private injector: Injector
+    private injector: Injector,
+    private accountOverviewService: AccountOverviewService,
+    private facilityOverviewService: FacilityOverviewService
 
   ) {
 
   }
 
   ngOnInit() {
+    this.facility = this.accountWorkspaceStore.selectedFacility();
+    this.account = this.accountWorkspaceStore.account();
     this.facilityReportSub = toObservable(this.accountWorkspaceStore.selectedFacilityReport, { injector: this.injector }).subscribe(report => {
       this.facilityReport = report;
       this.overviewReportSettings = this.facilityReport.dataOverviewReportSettings;
@@ -73,7 +83,17 @@ export class FacilityOverviewReportResultsComponent {
     });
     this.printSub = this.dataEvaluationService.print.subscribe(print => {
       this.print = print;
-    })
+    });
+    if (this.facility.guid) {
+      this.emissionsDisplaySub = this.facilityOverviewService.emissionsDisplay.subscribe(display => {
+        this.emissionsDisplay = display;
+      });
+    }
+    else {
+      this.emissionsDisplaySub = this.accountOverviewService.emissionsDisplay.subscribe(display => {
+        this.emissionsDisplay = display;
+      });
+    }
   }
 
   ngOnDestroy() {
@@ -82,11 +102,13 @@ export class FacilityOverviewReportResultsComponent {
     if (this.worker) {
       this.worker.terminate();
     }
+    if (this.emissionsDisplaySub) {
+      this.emissionsDisplaySub.unsubscribe();
+    }
   }
 
   calculateFacilitiesSummary() {
     this.calculating = true;
-    this.facility = this.accountWorkspaceStore.selectedFacility();
     let facilityMeters: Array<IdbUtilityMeter> = this.accountWorkspaceQuery.getFacilityMeters(this.facilityReport.facilityId);
     let customGWPs: Array<IdbCustomGWP> = [...this.accountWorkspaceStore.customGWPs()];
     if (this.overviewReportSettings.includeAllMeterData == false) {
@@ -153,17 +175,19 @@ export class FacilityOverviewReportResultsComponent {
       facilityOverviewData: this.facilityOverviewData,
       utilityUseAndCost: this.utilityUseAndCost,
       dateRange: this.dateRange,
-      chartImageProviders: this.getChartImageProviders()
+      emissionsDisplay: this.emissionsDisplay,
+      chartImageProviders: this.getChartImageProviders(),
+      emissionsChartImageProviders: this.getEmissionsChartImageProviders()
     });
 
     this.exportReportPdfService.export(document, `${this.facilityReport.name} - Data Overview Report`);
   }
 
-  getSectionsByType(type: 'energyUse' | 'cost' | 'water') {
+  getSectionsByType(type: 'energyUse' | 'cost' | 'water' | 'emissions') {
     return this.sectionReports?.find(section => section.dataType == type);
   }
 
-  async getImage(type: 'energyUse' | 'cost' | 'water', chartType: 'meterStackedLineChart' | 'meterBarChart' | 'annualBarChart' | 'monthlyUsageLineChart'): Promise<string> {
+  async getImage(type: 'energyUse' | 'cost' | 'water' | 'emissions', chartType: 'meterStackedLineChart' | 'meterBarChart' | 'annualBarChart' | 'monthlyUsageLineChart' | 'meterStackedLineChartEmissions' | 'emissionsBarChart' | 'annualBarChartEmissions' | 'monthlyUsageLineChartEmissions'): Promise<string> {
     const section = this.getSectionsByType(type);
     if (!section) {
       return '';
@@ -176,6 +200,14 @@ export class FacilityOverviewReportResultsComponent {
       case 'annualBarChart':
         return await section.getAnnualBarChartImage();
       case 'monthlyUsageLineChart':
+        return await section.getMonthlyUsageLineChartImage();
+      case 'meterStackedLineChartEmissions':
+        return await section.getMeterStackedLineChartEmissionsImage();
+      case 'emissionsBarChart':
+        return await section.getEmissionsBarChartImage();
+      case 'annualBarChartEmissions':
+        return await section.getAnnualBarChartEmissionsImage();
+      case 'monthlyUsageLineChartEmissions':
         return await section.getMonthlyUsageLineChartImage();
     }
   }
@@ -190,7 +222,16 @@ export class FacilityOverviewReportResultsComponent {
       meterStackedLineChart: imageByType('meterStackedLineChart'),
       meterBarChart: imageByType('meterBarChart'),
       annualBarChart: imageByType('annualBarChart'),
-      monthlyUsageLineChart: imageByType('monthlyUsageLineChart')
+      monthlyUsageLineChart: imageByType('monthlyUsageLineChart'),
+    };
+  }
+
+  getEmissionsChartImageProviders() {
+    return {
+      meterStackedLineChartEmissions: async () => await this.getImage('emissions', 'meterStackedLineChartEmissions'),
+      emissionsBarChart: async () => await this.getImage('emissions', 'emissionsBarChart'),
+      annualBarChartEmissions: async () => await this.getImage('emissions', 'annualBarChartEmissions'),
+      monthlyUsageLineChartEmissions: async () => await this.getImage('emissions', 'monthlyUsageLineChart')
     };
   }
 

--- a/src/app/v0/data-evaluation/facility/facility-reports/report-results/facility-overview-report-results/facility-overview-report.adapter.ts
+++ b/src/app/v0/data-evaluation/facility/facility-reports/report-results/facility-overview-report-results/facility-overview-report.adapter.ts
@@ -2,17 +2,20 @@ import { AccountWorkspaceQueryService } from '@data/account-workspace/account-wo
 import { inject, Injectable } from '@angular/core';
 import { DataOverviewFacilityReportSettings, IdbFacilityReport } from "@data/models/idbModels/facilityReport";
 import { ReportDocument, ReportMetaData } from "@v0/shared/pdf-report/models/report-document.model";
-import { BaseSection, ChartSection, HeadingSection, TableHeaderCell, TableSection } from "@v0/shared/pdf-report/models/report-section.model";
+import { BaseSection, ChartSection, StyledTextSection, TableHeaderCell, TableSection } from "@v0/shared/pdf-report/models/report-section.model";
 import { CustomNumberPipe } from "@v0/shared/helper-pipes/custom-number.pipe";
 import { IdbFacility } from "@data/models/idbModels/facility";
 import { FacilityOverviewData, FacilityOverviewMeter } from "@domain/calculations/dashboard-calculations/facilityOverviewClass";
 import { UtilityUseAndCost } from "@domain/calculations/dashboard-calculations/useAndCostClass";
 import { formatDate } from "@angular/common";
 import { EnergySources, WaterSources } from "@data/models/constantsAndTypes";
+import { AccountWorkspaceStore } from '@app/data/account-workspace/account-workspace.store';
+import { IdbAccount } from '@app/data/models/idbModels/account';
 
 @Injectable({ providedIn: 'root' })
 export class FacilityOverviewReportAdapter {
-  private readonly accountWorkspaceQuery = inject(AccountWorkspaceQueryService);
+    private readonly accountWorkspaceQuery = inject(AccountWorkspaceQueryService);
+    private readonly accountWorkspaceStore = inject(AccountWorkspaceStore);
 
     private customNumberPipe: CustomNumberPipe = inject(CustomNumberPipe);
 
@@ -28,9 +31,12 @@ export class FacilityOverviewReportAdapter {
         endDate: Date
     };
     previousYear: Date;
+    emissionsDisplay: "market" | "location";
+    account: IdbAccount;
 
     buildDocument(input: FacilityOverviewReportData): ReportDocument {
         const sections: BaseSection[] = [];
+        this.account = this.accountWorkspaceStore.account();
         this.report = input.facilityReport;
         this.reportSettings = this.report.dataOverviewReportSettings;
         this.facility = input.facility;
@@ -39,6 +45,7 @@ export class FacilityOverviewReportAdapter {
         this.waterUnit = this.facility.volumeLiquidUnit;
         this.utilityUseAndCost = input.utilityUseAndCost;
         this.dateRange = input.dateRange;
+        this.emissionsDisplay = input.emissionsDisplay;
         this.previousYear = this.utilityUseAndCost.previousYear;
 
         let metadata: ReportMetaData = {
@@ -56,6 +63,9 @@ export class FacilityOverviewReportAdapter {
         }
         if (this.reportSettings.includeCostsSection) {
             sections.push(...this.buildSection(input.chartImageProviders, 'Costs', 'cost', 'Utility Costs'));
+        }
+        if (this.account.displayEmissions && this.reportSettings.includeEmissionsSection) {
+            sections.push(...this.buildEmissionSection(input.emissionsChartImageProviders));
         }
 
         return {
@@ -116,7 +126,7 @@ export class FacilityOverviewReportAdapter {
             if (chartSection) {
                 chartSection.tocInclude = true;
                 chartSection.tocLabel = `Annual ${tocLabel}`,
-                chartSection.bookmarkLevel = 1;
+                    chartSection.bookmarkLevel = 1;
                 chartSection.pageBreakAfter = true;
                 sections.push(chartSection);
             }
@@ -127,6 +137,79 @@ export class FacilityOverviewReportAdapter {
             if (chartSection) {
                 chartSection.tocInclude = true;
                 chartSection.tocLabel = `Monthly ${tocLabel}`,
+                    chartSection.bookmarkLevel = 1;
+                chartSection.pageBreakAfter = true;
+                sections.push(chartSection);
+            }
+        }
+
+        if (sections.length === 0) {
+            return [];
+        }
+
+        let titleSection: StyledTextSection = this.buildTitleSection(this.facility.name + ' ' + title);
+        return [titleSection, ...sections];
+    }
+
+    private buildEmissionSection(emissionsChartImageProviders: any): BaseSection[] {
+        let sections: BaseSection[] = [];
+        if (this.reportSettings.includeMeterUsageStackedLineChart) {
+            let chartSection = this.createChartSection(emissionsChartImageProviders?.meterStackedLineChartEmissions, '');
+            if (chartSection) {
+                chartSection.tocInclude = true;
+                chartSection.tocLabel = 'Utility Emissions (tonne CO2e)';
+                chartSection.bookmarkLevel = 1;
+                chartSection.pageBreakAfter = true;
+                sections.push(chartSection);
+            }
+        }
+        if (this.reportSettings.includeMeterUsageTable) {
+            let tableSection = this.createEmissionsUsageTable();
+            if (tableSection) {
+                tableSection.tocInclude = true;
+                tableSection.tocLabel = 'Emissions Breakdown Table';
+                tableSection.bookmarkLevel = 1;
+                tableSection.pageBreakAfter = true;
+                sections.push(tableSection);
+            }
+
+        }
+        if (this.reportSettings.includeMeterUsageDonut) {
+            let chartSection = this.createChartSection(emissionsChartImageProviders?.emissionsBarChart, '');
+            if (chartSection) {
+                chartSection.tocInclude = true;
+                chartSection.tocLabel = 'Emission Breakdown Chart';
+                chartSection.bookmarkLevel = 1;
+                chartSection.pageBreakAfter = true;
+                sections.push(chartSection);
+            }
+        }
+        if (this.reportSettings.includeUtilityTableForFacility) {
+            let tableSection = this.createEmissionsUtilityTable();
+            if (tableSection) {
+                tableSection.tocInclude = true;
+                tableSection.tocLabel = 'Utility Emissions Comparison Table';
+                tableSection.bookmarkLevel = 1;
+                tableSection.pageBreakAfter = true;
+                sections.push(tableSection);
+            }
+
+        }
+        if (this.reportSettings.includeAnnualBarChart) {
+            let chartSection = this.createChartSection(emissionsChartImageProviders?.annualBarChartEmissions, 'Annual Utility Emissions');
+            if (chartSection) {
+                chartSection.tocInclude = true;
+                chartSection.tocLabel = 'Annual Utility Emissions';
+                chartSection.bookmarkLevel = 1;
+                chartSection.pageBreakAfter = true;
+                sections.push(chartSection);
+            }
+        }
+        if (this.reportSettings.includeMonthlyLineChartForFacility) {
+            let chartSection = this.createChartSection(emissionsChartImageProviders?.monthlyUsageLineChartEmissions, '');
+            if (chartSection) {
+                chartSection.tocInclude = true;
+                chartSection.tocLabel = 'Monthly Utility Usage';
                 chartSection.bookmarkLevel = 1;
                 chartSection.pageBreakAfter = true;
                 sections.push(chartSection);
@@ -137,14 +220,196 @@ export class FacilityOverviewReportAdapter {
             return [];
         }
 
-        let titleSection: HeadingSection = {
-            type: 'heading',
-            title: this.facility.name + ' ' + title,
-            tocInclude: true,
-            tocLabel: this.facility.name + ' ' + title,
-            bookmarkLevel: 0,
-        };
+        let titleSection: StyledTextSection = this.buildTitleSection(this.facility.name + ' Emissions');
+
         return [titleSection, ...sections];
+    }
+
+    private buildTitleSection(title: string): StyledTextSection {
+        const headingSection: StyledTextSection = {
+            type: 'styledText',
+            verticalCenter: true,
+            content: [
+                {
+                    text: title,
+                    fontSize: 16,
+                    bold: true,
+                    align: 'center'
+                }
+            ],
+            pageBreakAfter: true,
+            tocInclude: true,
+            tocLabel: title,
+            bookmarkLevel: 0
+        };
+        return headingSection;
+    }
+
+    private createEmissionsUsageTable(): TableSection {
+        let headers: string[] = ['Emissions Type', 'Total With Market Emissions (tonne CO2e)', 'Total With Location Emissions (tonne CO2e)'];
+        let rows: string[][] = [];
+
+        if (this.facilityOverviewData.emissionsTotals.stationaryEmissions) {
+            rows.push([
+                'Scope 1: Stationary',
+                this.checkNumber(this.facilityOverviewData.emissionsTotals.stationaryEmissions),
+                this.checkNumber(this.facilityOverviewData.emissionsTotals.stationaryEmissions)
+            ]);
+        }
+        if (this.facilityOverviewData.emissionsTotals.mobileTotalEmissions) {
+            rows.push([
+                'Scope 1: Mobile',
+                this.checkNumber(this.facilityOverviewData.emissionsTotals.mobileTotalEmissions),
+                this.checkNumber(this.facilityOverviewData.emissionsTotals.mobileTotalEmissions)
+            ]);
+        }
+        if (this.facilityOverviewData.emissionsTotals.fugitiveEmissions) {
+            rows.push([
+                'Scope 1: Fugitive',
+                this.checkNumber(this.facilityOverviewData.emissionsTotals.fugitiveEmissions),
+                this.checkNumber(this.facilityOverviewData.emissionsTotals.fugitiveEmissions)
+            ]);
+        }
+        if (this.facilityOverviewData.emissionsTotals.processEmissions) {
+            rows.push([
+                'Scope 1: Process',
+                this.checkNumber(this.facilityOverviewData.emissionsTotals.processEmissions),
+                this.checkNumber(this.facilityOverviewData.emissionsTotals.processEmissions)
+            ]);
+        }
+        if (this.facilityOverviewData.emissionsTotals.marketElectricityEmissions || this.facilityOverviewData.emissionsTotals.locationElectricityEmissions) {
+            rows.push([
+                'Scope 2: Electricity',
+                this.checkNumber(this.facilityOverviewData.emissionsTotals.marketElectricityEmissions),
+                this.checkNumber(this.facilityOverviewData.emissionsTotals.locationElectricityEmissions)
+            ]);
+        }
+        if (this.facilityOverviewData.emissionsTotals.otherScope2Emissions) {
+            rows.push([
+                'Scope 2: Other',
+                this.checkNumber(this.facilityOverviewData.emissionsTotals.otherScope2Emissions),
+                this.checkNumber(this.facilityOverviewData.emissionsTotals.otherScope2Emissions)
+            ]);
+        }
+        rows.push([
+            'Total',
+            this.checkNumber(this.facilityOverviewData.emissionsTotals.totalWithMarketEmissions),
+            this.checkNumber(this.facilityOverviewData.emissionsTotals.totalWithLocationEmissions)
+        ]);
+
+        const tableSection: TableSection = {
+            type: 'table',
+            title: 'Emissions Breakdown',
+            headers: headers,
+            rows: rows
+        };
+
+        return tableSection;
+    }
+
+    private createEmissionsUtilityTable(): TableSection {
+        const endDate: string = this.dateRange.endDate ? '(' + this.formatDate(this.dateRange.endDate) + ')' : '';
+        const previousYear: string = this.previousYear ? '(' + this.formatDate(this.previousYear) + ')' : '';
+        const dateRange: string = this.dateRange.startDate ? '(' + this.formatDate(this.dateRange.startDate) + ' - ' + this.formatDate(this.dateRange.endDate) + ')' : '';
+        let headers = ['', `Latest Month \n${endDate}`, `Previous Year \n${previousYear}`, `Monthly Average \n${dateRange}`];
+        let subheaders = ['', '(tonne CO2e)', '(tonne CO2e)', '(tonne CO2e)'];
+        let rows: string[][] = [];
+
+        let showMobile = false, showFugitive = false, showProcess = false, showStationary = false, showScope2LocationElectricity = false, showScope2MarketElectricity = false, showScope2Other = false;
+        let useAndCostTotal = this.utilityUseAndCost.allSourcesTotal;
+        if (useAndCostTotal) {
+            showMobile = (this.checkValue(useAndCostTotal.average.mobileTotalEmissions) || this.checkValue(useAndCostTotal.end.mobileTotalEmissions) || this.checkValue(useAndCostTotal.previousYear.mobileTotalEmissions));
+            showFugitive = (this.checkValue(useAndCostTotal.average.fugitiveEmissions) || this.checkValue(useAndCostTotal.end.fugitiveEmissions) || this.checkValue(useAndCostTotal.previousYear.fugitiveEmissions));
+            showProcess = (this.checkValue(useAndCostTotal.average.processEmissions) || this.checkValue(useAndCostTotal.end.processEmissions) || this.checkValue(useAndCostTotal.previousYear.processEmissions));
+            showStationary = (this.checkValue(useAndCostTotal.average.stationaryEmissions) || this.checkValue(useAndCostTotal.end.stationaryEmissions) || this.checkValue(useAndCostTotal.previousYear.stationaryEmissions));
+            showScope2LocationElectricity = (this.checkValue(useAndCostTotal.average.locationElectricityEmissions) || this.checkValue(useAndCostTotal.end.locationElectricityEmissions) || this.checkValue(useAndCostTotal.previousYear.locationElectricityEmissions));
+            showScope2MarketElectricity = (this.checkValue(useAndCostTotal.average.marketElectricityEmissions) || this.checkValue(useAndCostTotal.end.marketElectricityEmissions) || this.checkValue(useAndCostTotal.previousYear.marketElectricityEmissions));
+            showScope2Other = (this.checkValue(useAndCostTotal.average.otherScope2Emissions) || this.checkValue(useAndCostTotal.end.otherScope2Emissions) || this.checkValue(useAndCostTotal.previousYear.otherScope2Emissions));
+        }
+
+        if (showMobile) {
+            rows.push([
+                'Scope 1: Mobile',
+                this.checkNumber(useAndCostTotal.end.mobileTotalEmissions),
+                this.checkNumber(useAndCostTotal.previousYear.mobileTotalEmissions),
+                this.checkNumber(useAndCostTotal.average.mobileTotalEmissions)
+            ]);
+        }
+        if (showFugitive) {
+            rows.push([
+                'Scope 1: Fugitive',
+                this.checkNumber(useAndCostTotal.end.fugitiveEmissions),
+                this.checkNumber(useAndCostTotal.previousYear.fugitiveEmissions),
+                this.checkNumber(useAndCostTotal.average.fugitiveEmissions)
+            ]);
+        }
+        if (showProcess) {
+            rows.push([
+                'Scope 1: Process',
+                this.checkNumber(useAndCostTotal.end.processEmissions),
+                this.checkNumber(useAndCostTotal.previousYear.processEmissions),
+                this.checkNumber(useAndCostTotal.average.processEmissions)
+            ]);
+        }
+        if (showStationary) {
+            rows.push([
+                'Scope 1: Stationary',
+                this.checkNumber(useAndCostTotal.end.stationaryEmissions),
+                this.checkNumber(useAndCostTotal.previousYear.stationaryEmissions),
+                this.checkNumber(useAndCostTotal.average.stationaryEmissions)
+            ]);
+        }
+        if (this.emissionsDisplay === 'location' && showScope2LocationElectricity) {
+            rows.push([
+                'Scope 2: Electricity (Location)',
+                this.checkNumber(useAndCostTotal.end.locationElectricityEmissions),
+                this.checkNumber(useAndCostTotal.previousYear.locationElectricityEmissions),
+                this.checkNumber(useAndCostTotal.average.locationElectricityEmissions)
+            ]);
+        }
+        if (this.emissionsDisplay === 'market' && showScope2MarketElectricity) {
+            rows.push([
+                'Scope 2: Electricity (Market)',
+                this.checkNumber(useAndCostTotal.end.marketElectricityEmissions),
+                this.checkNumber(useAndCostTotal.previousYear.marketElectricityEmissions),
+                this.checkNumber(useAndCostTotal.average.marketElectricityEmissions)
+            ]);
+        }
+        if (showScope2Other) {
+            rows.push([
+                'Scope 2: Other',
+                this.checkNumber(useAndCostTotal.end.otherScope2Emissions),
+                this.checkNumber(useAndCostTotal.previousYear.otherScope2Emissions),
+                this.checkNumber(useAndCostTotal.average.otherScope2Emissions)
+            ]);
+        }
+        let totalEnd: string, totalPrevious: string, totalAverage: string;
+        if (this.emissionsDisplay === 'market') {
+            totalEnd = this.checkNumber(useAndCostTotal.end.totalWithMarketEmissions);
+            totalPrevious = this.checkNumber(useAndCostTotal.previousYear.totalWithMarketEmissions);
+            totalAverage = this.checkNumber(useAndCostTotal.average.totalWithMarketEmissions);
+        }
+        if (this.emissionsDisplay === 'location') {
+            totalEnd = this.checkNumber(useAndCostTotal.end.totalWithLocationEmissions);
+            totalPrevious = this.checkNumber(useAndCostTotal.previousYear.totalWithLocationEmissions);
+            totalAverage = this.checkNumber(useAndCostTotal.average.totalWithLocationEmissions);
+        }
+        rows.push([
+            'Total',
+            totalEnd,
+            totalPrevious,
+            totalAverage
+        ]);
+
+        const tableSection: TableSection = {
+            type: 'table',
+            title: 'Utility Emissions Comparison',
+            headers: headers,
+            subHeaders: subheaders,
+            rows: rows
+        };
+
+        return tableSection;
     }
 
     private createMeterUsageTableSection(dataType: 'energyUse' | 'cost' | 'water', title: string): TableSection {
@@ -335,6 +600,13 @@ export class FacilityOverviewReportAdapter {
         return this.customNumberPipe.transform(value, true);
     }
 
+    checkValue(value: number): boolean {
+        if (value) {
+            return true;
+        }
+        return false;
+    }
+
     formatDate(date: Date): string {
         if (!date) {
             return '-';
@@ -390,10 +662,17 @@ export interface FacilityOverviewReportData {
         startDate: Date,
         endDate: Date
     };
+    emissionsDisplay: "market" | "location";
     chartImageProviders?: {
         meterStackedLineChart?: Record<string, () => Promise<string>>;
         meterBarChart?: Record<string, () => Promise<string>>;
         annualBarChart?: Record<string, () => Promise<string>>;
         monthlyUsageLineChart?: Record<string, () => Promise<string>>;
+    },
+    emissionsChartImageProviders?: {
+        meterStackedLineChartEmissions?: () => Promise<string>;
+        emissionsBarChart?: () => Promise<string>;
+        annualBarChartEmissions?: () => Promise<string>;
+        monthlyUsageLineChartEmissions?: () => Promise<string>;
     }
 }

--- a/src/app/v0/shared/data-overview/emissions-donut/emissions-donut.component.ts
+++ b/src/app/v0/shared/data-overview/emissions-donut/emissions-donut.component.ts
@@ -195,4 +195,20 @@ export class EmissionsDonutComponent {
     })
     return { values: values, includedEmissionsTypes: includedEmissionsTypes };
   }
+
+  async getChartAsBase64Image(): Promise<string> {
+    try {
+      if (!this.emissionsDonut?.nativeElement) {
+        return '';
+      }
+      const rawPlotly: any = await this.plotlyService.getPlotly();
+      if (!rawPlotly || typeof rawPlotly.toImage !== 'function') {
+        return '';
+      }
+      const dataUrl = await rawPlotly.toImage(this.emissionsDonut.nativeElement, { format: 'jpeg', height: 700, width: 1400, imageDataOnly: false });
+      return dataUrl;
+    } catch (error) {
+      return '';
+    }
+  }
 }

--- a/src/app/v0/shared/data-overview/emissions-stacked-line-chart/emissions-stacked-line-chart.component.ts
+++ b/src/app/v0/shared/data-overview/emissions-stacked-line-chart/emissions-stacked-line-chart.component.ts
@@ -8,10 +8,10 @@ import { EmissionsTypes, getEmissionsTypeColor, getEmissionsTypes } from '@data/
 
 
 @Component({
-    selector: 'app-emissions-stacked-line-chart',
-    templateUrl: './emissions-stacked-line-chart.component.html',
-    styleUrls: ['./emissions-stacked-line-chart.component.css'],
-    standalone: false
+  selector: 'app-emissions-stacked-line-chart',
+  templateUrl: './emissions-stacked-line-chart.component.html',
+  styleUrls: ['./emissions-stacked-line-chart.component.css'],
+  standalone: false
 })
 export class EmissionsStackedLineChartComponent {
   @Input()
@@ -149,7 +149,7 @@ export class EmissionsStackedLineChartComponent {
       }
       if (total) {
         y.push(total);
-      }else{
+      } else {
         y.push(0);
       }
       startDate.setMonth(startDate.getMonth() + 1);
@@ -171,4 +171,19 @@ export class EmissionsStackedLineChartComponent {
     return
   }
 
+  async getChartAsBase64Image(): Promise<string> {
+    try {
+      if (!this.stackedAreaChart?.nativeElement) {
+        return '';
+      }
+      const rawPlotly: any = await this.plotlyService.getPlotly();
+      if (!rawPlotly || typeof rawPlotly.toImage !== 'function') {
+        return '';
+      }
+      const dataUrl = await rawPlotly.toImage(this.stackedAreaChart.nativeElement, { format: 'jpeg', height: 700, width: 1400, imageDataOnly: false });
+      return dataUrl;
+    } catch (error) {
+      return '';
+    }
+  }
 }

--- a/src/app/v0/shared/data-overview/emissions-usage-chart/emissions-usage-chart.component.ts
+++ b/src/app/v0/shared/data-overview/emissions-usage-chart/emissions-usage-chart.component.ts
@@ -9,10 +9,10 @@ import { EmissionsTypes, getEmissionsTypeColor, getEmissionsTypes } from '@data/
 import { IdbFacility } from '@data/models/idbModels/facility';
 
 @Component({
-    selector: 'app-emissions-usage-chart',
-    templateUrl: './emissions-usage-chart.component.html',
-    styleUrls: ['./emissions-usage-chart.component.css'],
-    standalone: false
+  selector: 'app-emissions-usage-chart',
+  templateUrl: './emissions-usage-chart.component.html',
+  styleUrls: ['./emissions-usage-chart.component.css'],
+  standalone: false
 })
 export class EmissionsUsageChartComponent {
   private readonly accountWorkspaceStore = inject(AccountWorkspaceStore);
@@ -106,7 +106,7 @@ export class EmissionsUsageChartComponent {
               return dataItem.totalEmissions.otherScope2Emissions;
             });
           }
-          if(total != undefined){
+          if (total != undefined) {
             yValues.push(total);
           }
         });
@@ -158,6 +158,22 @@ export class EmissionsUsageChartComponent {
       };
 
       this.plotlyService.newPlot(this.utilityBarChart.nativeElement, traceData, layout, config);
+    }
+  }
+
+  async getChartAsBase64Image(): Promise<string> {
+    try {
+      if (!this.utilityBarChart?.nativeElement) {
+        return '';
+      }
+      const rawPlotly: any = await this.plotlyService.getPlotly();
+      if (!rawPlotly || typeof rawPlotly.toImage !== 'function') {
+        return '';
+      }
+      const dataUrl = await rawPlotly.toImage(this.utilityBarChart.nativeElement, { format: 'jpeg', height: 700, width: 1400, imageDataOnly: false });
+      return dataUrl;
+    } catch (error) {
+      return '';
     }
   }
 }

--- a/src/app/v0/shared/data-overview/facilities-emissions-stacked-bar-chart/facilities-emissions-stacked-bar-chart.component.ts
+++ b/src/app/v0/shared/data-overview/facilities-emissions-stacked-bar-chart/facilities-emissions-stacked-bar-chart.component.ts
@@ -7,10 +7,10 @@ import { AccountOverviewFacility } from '@domain/calculations/dashboard-calculat
 import { getEmissionsTypeColor } from '@data/models/eGridEmissions';
 
 @Component({
-    selector: 'app-facilities-emissions-stacked-bar-chart',
-    templateUrl: './facilities-emissions-stacked-bar-chart.component.html',
-    styleUrls: ['./facilities-emissions-stacked-bar-chart.component.css'],
-    standalone: false
+  selector: 'app-facilities-emissions-stacked-bar-chart',
+  templateUrl: './facilities-emissions-stacked-bar-chart.component.html',
+  styleUrls: ['./facilities-emissions-stacked-bar-chart.component.css'],
+  standalone: false
 })
 export class FacilitiesEmissionsStackedBarChartComponent {
   @Input()
@@ -168,5 +168,21 @@ export class FacilitiesEmissionsStackedBarChartComponent {
 
     data = _.orderBy(data, (d) => { return _.sum(d.y) }, 'desc');
     return data;
+  }
+
+  async getChartAsBase64Image(): Promise<string> {
+    try {
+      if (!this.stackedBarChart?.nativeElement) {
+        return '';
+      }
+      const rawPlotly: any = await this.plotlyService.getPlotly();
+      if (!rawPlotly || typeof rawPlotly.toImage !== 'function') {
+        return '';
+      }
+      const dataUrl = await rawPlotly.toImage(this.stackedBarChart.nativeElement, { format: 'jpeg', height: 700, width: 1400, imageDataOnly: false });
+      return dataUrl;
+    } catch (error) {
+      return '';
+    }
   }
 }

--- a/src/app/v0/shared/data-overview/facility-section-report/facility-section-report.component.html
+++ b/src/app/v0/shared/data-overview/facility-section-report/facility-section-report.component.html
@@ -2,7 +2,7 @@
   @if (sectionOptions.includeMeterUsageStackedLineChart) {
     <div class="col-12">
       @if (dataType == 'emissions') {
-        <app-emissions-stacked-line-chart [calanderizedMeters]="calanderizedMeters"
+        <app-emissions-stacked-line-chart #meterStackedLineChartEmissions [calanderizedMeters]="calanderizedMeters"
         [dateRange]="dateRange"></app-emissions-stacked-line-chart>
       }
       @if (dataType != 'emissions') {
@@ -40,7 +40,7 @@
   @if (sectionOptions.includeMeterUsageDonut) {
     <div [ngClass]="{'col-10': print, 'col-6': !print}">
       @if (dataType == 'emissions') {
-        <app-emissions-donut [facilityId]="facility.guid"
+        <app-emissions-donut #emissionsBarChart [facilityId]="facility.guid"
         [facilityOverviewMeters]="facilityOverviewMeters"></app-emissions-donut>
       }
       @if (dataType == 'energyUse') {
@@ -76,7 +76,7 @@
     <div class="row print-break-avoid">
       <div class="col-12">
         @if (dataType == 'emissions') {
-          <app-emissions-usage-chart [facilityId]="facility.guid"
+          <app-emissions-usage-chart #annualBarChartEmissions [facilityId]="facility.guid"
           [annualSourceData]="annualSourceData"></app-emissions-usage-chart>
         }
         @if (dataType != 'emissions') {

--- a/src/app/v0/shared/data-overview/facility-section-report/facility-section-report.component.ts
+++ b/src/app/v0/shared/data-overview/facility-section-report/facility-section-report.component.ts
@@ -14,6 +14,9 @@ import { MetersOverviewStackedLineChartComponent } from '@v0/shared/data-overvie
 import { MeterUsageDonutComponent } from '@v0/shared/data-overview/meter-usage-donut/meter-usage-donut.component';
 import { MonthlyUtilityUsageLineChartComponent } from '@v0/shared/data-overview/monthly-utility-usage-line-chart/monthly-utility-usage-line-chart.component';
 import { UtilitiesUsageChartComponent } from '@v0/shared/data-overview/utilities-usage-chart/utilities-usage-chart.component';
+import { EmissionsStackedLineChartComponent } from '../emissions-stacked-line-chart/emissions-stacked-line-chart.component';
+import { EmissionsDonutComponent } from '../emissions-donut/emissions-donut.component';
+import { EmissionsUsageChartComponent } from '../emissions-usage-chart/emissions-usage-chart.component';
 
 @Component({
   selector: 'app-facility-section-report',
@@ -62,6 +65,9 @@ export class FacilitySectionReportComponent {
   @ViewChild('meterBarChart') meterBarChart !: MeterUsageDonutComponent;
   @ViewChild('annualBarChart') annualBarChart !: UtilitiesUsageChartComponent;
   @ViewChild('monthlyUsageLineChart') monthlyUsageLineChart !: MonthlyUtilityUsageLineChartComponent;
+  @ViewChild('meterStackedLineChartEmissions') meterStackedLineChartEmissions !: EmissionsStackedLineChartComponent;
+  @ViewChild('emissionsBarChart') emissionsBarChart !: EmissionsDonutComponent;
+  @ViewChild('annualBarChartEmissions') annualBarChartEmissions !: EmissionsUsageChartComponent;
 
   constructor(
     private dataEvaluationService: DataEvaluationService
@@ -98,6 +104,18 @@ export class FacilitySectionReportComponent {
 
   async getMonthlyUsageLineChartImage(): Promise<string> {
     return this.monthlyUsageLineChart ? await this.monthlyUsageLineChart.getChartAsBase64Image() : '';
+  }
+
+  async getMeterStackedLineChartEmissionsImage(): Promise<string> {
+    return this.meterStackedLineChartEmissions ? await this.meterStackedLineChartEmissions.getChartAsBase64Image() : '';
+  }
+
+  async getEmissionsBarChartImage(): Promise<string> {
+    return this.emissionsBarChart ? await this.emissionsBarChart.getChartAsBase64Image() : '';
+  }
+
+  async getAnnualBarChartEmissionsImage(): Promise<string> {
+    return this.annualBarChartEmissions ? await this.annualBarChartEmissions.getChartAsBase64Image() : '';
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
connects #2668 

This pull request adds support for emissions data visualization and reporting throughout the account and facility data overview reports. The main changes introduce emissions charts, data types, and conditional display logic, as well as enhanced PDF report generation for emissions. Below are the most important changes grouped by theme:

**Emissions Data Integration and Visualization**

* Added new emissions chart components (`EmissionsDonutComponent`, `FacilitiesEmissionsStackedBarChartComponent`) to `AccountSectionReportComponent`, with new `@ViewChild` references and methods to retrieve their images for reporting. 
* Extended the `DataType` and related chart types to include `'emissions'`, and updated logic in `DataOverviewAccountReportComponent` to handle emissions chart image retrieval. 

**Conditional Display Logic**

* Updated HTML templates to display emissions sections only when the account has emissions enabled (`displayEmissions`) and the report is configured to include emissions. 
* Injected `AccountWorkspaceStore` into `DataOverviewFacilityReportComponent` to access the account and its `displayEmissions` property, which is now used to control emissions section rendering. 

**Facility Report and Chart Support**

* Extended facility section logic to support emissions as a data type, including new chart types and image retrieval methods for emissions charts in `DataOverviewFacilityReportComponent`. 

**PDF Report Generation Enhancements**

* Updated `DataOverviewReportAdapter` to add emissions display settings, pass emissions chart providers, and generate emissions-specific sections (charts and tables) in the PDF report if emissions are enabled. 

These changes collectively enable emissions reporting and visualization across the application's data overview features.