### PR TITLE
Issue 2598 - auto add zero for missing predictor months

### DIFF
--- a/src/app/v0/shared/shared-meter-content/meter-data/meter-data-table/meter-data-table.component.ts
+++ b/src/app/v0/shared/shared-meter-content/meter-data/meter-data-table/meter-data-table.component.ts
@@ -210,6 +210,7 @@ export class MeterDataTableComponent {
 
     this.loadingService.setLoadingMessage("Filling Missing Meter Data...");
     this.loadingService.setLoadingStatus(true);
+    this.cancelFillMissingDataModal();
     try {
       const accountMeterData = [...this.accountWorkspaceStore.meterData()];
       await this.commandBoundary.execute(
@@ -240,7 +241,6 @@ export class MeterDataTableComponent {
           return addedMeterData;
         }
       );
-      this.cancelFillMissingDataModal();
       this.toastNoticationService.showToast(
         `${missingMonths.length} Missing Month${missingMonths.length === 1 ? '' : 's'} Filled!`,
         undefined,

--- a/src/app/v0/shared/shared-predictors-content/predictors-data-table/predictors-data-table.component.html
+++ b/src/app/v0/shared/shared-predictors-content/predictors-data-table/predictors-data-table.component.html
@@ -48,7 +48,8 @@
       Update</button>
   </div>
   }
-  @if (_predictorStatusCheck && (_predictorStatusCheck.hasWeatherDataWarning || _predictorStatusCheck.hasNegativeData)) {
+  @if (_predictorStatusCheck && (_predictorStatusCheck.hasWeatherDataWarning || _predictorStatusCheck.hasNegativeData))
+  {
   <div class="ps-1 pe-1 mb-2">
     <button class="btn action-btn" (click)="toggleFilterErrors()">
       <i class="fa fa-filter"></i>
@@ -80,8 +81,8 @@
     data with gaps of twelve hours or more or missing source readings. The results
     may not be accurate. To inspect the weather data for that month, click the <span
       class="fa fa-thermometer-half"></span> button. To manually override the values click the <span
-      class="fa fa-pencil"></span> button. If you have several <span
-      class="fa fa-exclamation-circle"></span>, it may be best to select a different weather station for this
+      class="fa fa-pencil"></span> button. If you have several <span class="fa fa-exclamation-circle"></span>, it may be
+    best to select a different weather station for this
     facility - use the <a (click)="goToWeatherData()">Weather Data</a> page to explore other stations in the area
     of this facility.
   </div>
@@ -108,6 +109,11 @@
   @for (monthYear of _predictorStatusCheck.missingEntryMonths; track monthYear.date) {
   <span class="badge bg-danger ms-1">{{monthYear.date | date:'MMM, yyyy'}}</span>
   }
+  <div class="mt-2">
+    <button class="btn btn-sm btn-danger" (click)="openFillMissingDataModal()">
+      Fill Missing Months with Zeros
+    </button>
+  </div>
 </div>
 }
 
@@ -122,8 +128,9 @@
 
 @if(_predictorStatusCheck && _predictorStatusCheck.hasNegativeData){
 <div class="alert alert-danger text-center p-1 fw-bold">
-  <span class="fa fa-triangle-exclamation"></span> Negative predictor entries found. To allow negative entries, edit the predictor setup by clicking
-    <a class="click-link" (click)="editPredictor()">here</a> and enabling the "Allow Negative Data" option.
+  <span class="fa fa-triangle-exclamation"></span> Negative predictor entries found. To allow negative entries, edit the
+  predictor setup by clicking
+  <a class="click-link" (click)="editPredictor()">here</a> and enabling the "Allow Negative Data" option.
 </div>
 }
 
@@ -188,14 +195,13 @@
           data-bs-html="true"></span>
         }
         @if (pData.amount != undefined) {
-          @if(pData.amount < 0 && !_predictor.canBeNegative) {
-            <span class="fa fa-exclamation-triangle"></span>  
+        @if(pData.amount < 0 && !_predictor.canBeNegative) { <span class="fa fa-exclamation-triangle"></span>
           }
           {{pData.amount | customNumber}}
-        }
-        @if (pData.amount == undefined) {
-        &mdash;
-        }
+          }
+          @if (pData.amount == undefined) {
+          &mdash;
+          }
       </td>
       @if (!copyingTable) {
       <td class="actions">
@@ -259,7 +265,9 @@
 }
 
 
-<div [ngClass]="{'windowOverlay': predictorDataToDelete || showBulkDelete || showIgnoreWarningModal}"></div>
+<div
+  [ngClass]="{'windowOverlay': predictorDataToDelete || showBulkDelete || showIgnoreWarningModal || showFillMissingDataModal }">
+</div>
 <div class="popup" [class.open]="predictorDataToDelete">
   @if(predictorDataToDelete) {
   <div class="popup-header">
@@ -315,6 +323,28 @@
     <button class="btn btn-secondary" (click)="cancelIgnoreWarningModal()">Cancel</button>
     <button class="btn btn-warning" (click)="confirmIgnoreWarningModal()"><i class="fa fa-eye-slash"></i> Dismiss
       Warning</button>
+  </div>
+  }
+</div>
+<div class="popup" [class.open]="showFillMissingDataModal">
+  @if (showFillMissingDataModal) {
+  <div class="popup-header">
+    Fill Missing Predictor Data
+    <button class="item-right" (click)="closeFillMissingDataModal()">x</button>
+  </div>
+  <div class="popup-body">
+    <p>
+      Zero-valued predictor entries will be added for the following months:
+    </p>
+    <div class="mb-3">
+      @for (monthYear of _predictorStatusCheck.missingEntryMonths; track monthYear.date) {
+      <span class="badge bg-secondary me-1 mb-1">{{monthYear.date | date:'MMMM, yyyy'}}</span>
+      }
+    </div>
+  </div>
+  <div class="saveCancel popup-footer text-end">
+    <button class="btn btn-secondary" (click)="closeFillMissingDataModal()">Cancel</button>
+    <button class="btn btn-danger" (click)="fillMissingDataWithZeros()">Fill with Zeros</button>
   </div>
   }
 </div>

--- a/src/app/v0/shared/shared-predictors-content/predictors-data-table/predictors-data-table.component.ts
+++ b/src/app/v0/shared/shared-predictors-content/predictors-data-table/predictors-data-table.component.ts
@@ -127,6 +127,7 @@ export class PredictorsDataTableComponent {
   allChecked: boolean = false;
   showBulkDelete: boolean = false;
   showIgnoreWarningModal: boolean = false;
+  showFillMissingDataModal: boolean = false;
 
   ngOnInit() {
     this.inDataManagement = this.router.url.includes('data-management');
@@ -388,6 +389,86 @@ export class PredictorsDataTableComponent {
       this.router.navigateByUrl('data-management/' + predictor.accountId + '/facilities/' + predictor.facilityId + '/predictors/' + predictor.guid);
     } else {
       this.router.navigateByUrl('/data-evaluation/facility/' + predictor.facilityId + '/utility/predictors/manage/edit-predictor/' + predictor.guid);
+    }
+  }
+
+  openFillMissingDataModal() {
+    if (!this.predictorStatusCheck()?.missingEntryMonths?.length) {
+      return;
+    }
+    this.sharedDataService.modalOpen.next(true);
+    this.showFillMissingDataModal = true;
+  }
+
+  closeFillMissingDataModal() {
+    this.sharedDataService.modalOpen.next(false);
+    this.showFillMissingDataModal = false;
+  }
+
+  async fillMissingDataWithZeros() {
+    const selectedPredictor = this.predictor();
+    const predictorStatusCheck = this.predictorStatusCheck();
+    if (!selectedPredictor || !predictorStatusCheck?.missingEntryMonths?.length) {
+      this.closeFillMissingDataModal();
+      return;
+    }
+
+    const monthKeys = new Set(this.predictorData().map(data => `${data.year}-${data.month}`));
+    const missingMonths = predictorStatusCheck.missingEntryMonths.filter(({ month, year }) =>
+      !monthKeys.has(`${year}-${month}`)
+    );
+    if (missingMonths.length === 0) {
+      this.closeFillMissingDataModal();
+      return;
+    }
+
+    this.loadingService.setLoadingMessage("Filling Missing Predictor Data...");
+    this.loadingService.setLoadingStatus(true);
+    this.closeFillMissingDataModal();
+
+    try {
+      const accountPredictorData = [...this.accountWorkspaceStore.predictorData()];
+      await this.commandBoundary.execute(
+        {
+          entityKind: 'predictorData',
+          changeKind: 'bulk',
+          label: 'Fill Missing Predictor Data',
+          publication: {
+            mode: 'patch',
+            buildPatch: value => upsertWorkspaceRecords('predictorData', value)
+          }
+        },
+        async () => {
+          const addedPredictorData: IdbPredictorData[] = [];
+          for (const missingMonth of missingMonths) {
+            const newEntry = getNewIdbPredictorData(selectedPredictor, accountPredictorData);
+            delete newEntry.id;
+            newEntry.month = missingMonth.month;
+            newEntry.year = missingMonth.year;
+            newEntry.amount = 0;
+            const added = await this.predictorHandler.addPredictorData(newEntry, this.accountWorkspaceStore.account()?.guid);
+            addedPredictorData.push(added);
+          }
+          return addedPredictorData;
+        }
+      );
+      this.toastNotificationService.showToast(
+        `${missingMonths.length} Missing Month${missingMonths.length > 1 ? 's' : ''} Filled!`,
+        undefined,
+        undefined,
+        false,
+        "alert-success"
+      );
+    } catch {
+      this.toastNotificationService.showToast(
+        'Unable to Fill Missing Predictor Data.',
+        'Some missing months may not have been added. Review the list and try again',
+        undefined,
+        false,
+        "alert-danger"
+      );
+    } finally {
+      this.loadingService.setLoadingStatus(false);
     }
   }
 }


### PR DESCRIPTION
connects #2598 

This pull request introduces a new feature that allows users to fill missing predictor data months with zero values directly from the predictors data table. It also makes minor UI improvements and bug fixes related to modal handling and text formatting. The most significant changes are grouped below.

**New Feature: Fill Missing Predictor Data with Zeros**

* Added a "Fill Missing Months with Zeros" button and modal dialog to the predictors data table UI, allowing users to bulk-add zero-valued entries for months with missing predictor data. 
* Implemented `showFillMissingDataModal` state and associated methods (`openFillMissingDataModal`, `closeFillMissingDataModal`, `fillMissingDataWithZeros`) in `PredictorsDataTableComponent` to handle modal display and the logic for filling missing data. 
* Updated the overlay logic to include the new modal, ensuring proper UI blocking when the modal is open.

**UI and Text Improvements**

* Improved conditional rendering and formatting in the predictors data table for better readability and consistency, including minor fixes to warning and info messages. 

**Bug Fixes**

* Fixed the timing of modal closure in the meter data table component to ensure the modal is closed before starting the fill operation, preventing UI glitches. 