### PR TITLE
Issue 2673 - fixed data quality report tab bug

### DIFF
--- a/src/app/v0/data-evaluation/facility/facility-reports/facility-report-setup/facility-data-quality-report-setup/facility-data-quality-report-setup.component.ts
+++ b/src/app/v0/data-evaluation/facility/facility-reports/facility-report-setup/facility-data-quality-report-setup/facility-data-quality-report-setup.component.ts
@@ -163,15 +163,19 @@ export class FacilityDataQualityReportSetupComponent {
   }
 
   validateDataQualityReport() {
-    if (this.selectionMode === 'analysis' && !this.selectedAnalysisItem) {
-      this.reportSettings.missingSelection = true;
+    const missingSelection = this.computeMissingSelection();
+    if (missingSelection === this.reportSettings.missingSelection) {
+      return;
     }
-    else if (this.selectionMode === 'manual' && this.selectedMeters.length === 0 && this.selectedPredictors.length === 0) {
-      this.reportSettings.missingSelection = true;
-    }
-    else
-      this.reportSettings.missingSelection = false;
+    this.reportSettings.missingSelection = missingSelection;
     this.save();
+  }
+
+  computeMissingSelection(): boolean {
+    if (this.selectionMode === 'analysis') {
+      return !this.selectedAnalysisItem;
+    }
+    return this.selectionMode === 'manual' && this.selectedMeters.length === 0 && this.selectedPredictors.length === 0;
   }
 
   onIncludeMeterChange() {


### PR DESCRIPTION
connects #2673 

This pull request refactors the logic for validating data quality report selections in the `FacilityDataQualityReportSetupComponent`. The main improvement is the extraction of the missing selection check into a dedicated method, simplifying the validation process and making the code more maintainable.

**Validation logic refactor:**

* Extracted the logic for determining a missing selection into a new `computeMissingSelection` method, improving code clarity and reusability.
* Updated the `validateDataQualityReport` method to use `computeMissingSelection` and avoid unnecessary updates when the selection state hasn't changed.