### PR TITLE
Issue 1882 - add a column for % hourly coverage in weather data monthly table

### DIFF
--- a/src/app/v0/weather-data/annual-station-data/annual-station-data.component.ts
+++ b/src/app/v0/weather-data/annual-station-data/annual-station-data.component.ts
@@ -9,10 +9,10 @@ import { ToastNotificationsService } from '@shared/notifications/toast-notificat
 // import { DegreeDaysService } from '@shared/helper-services/degree-days.service';
 
 @Component({
-    selector: 'app-annual-station-data',
-    templateUrl: './annual-station-data.component.html',
-    styleUrls: ['./annual-station-data.component.css'],
-    standalone: false
+  selector: 'app-annual-station-data',
+  templateUrl: './annual-station-data.component.html',
+  styleUrls: ['./annual-station-data.component.css'],
+  standalone: false
 })
 export class AnnualStationDataComponent {
 
@@ -69,7 +69,7 @@ export class AnnualStationDataComponent {
         this.detailedDegreeDays = getMonthlyDataFromYear(parsedData, this.selectedYear, this.heatingTemp, this.coolingTemp, this.weatherStation);
         // this.detailedDegreeDays = await this.degreeDaysService.getMonthlyDataFromYear(this.selectedYear, this.heatingTemp, this.coolingTemp, this.weatherStation);
         this.setYearSummaryData();
-      }else{
+      } else {
         this.yearSummaryData = [];
         this.toastNotificationService.weatherDataErrorToast();
       }
@@ -90,6 +90,15 @@ export class AnnualStationDataComponent {
         let monthData: Array<DetailDegreeDay> = this.detailedDegreeDays.filter(day => {
           return day.time.getMonth() == startDate.getMonth();
         });
+        const daysInMonth: number = new Date(this.selectedYear, startDate.getMonth() + 1, 0).getDate();
+        const hoursInMonth: number = daysInMonth * 24;
+        const hoursWithData: Set<string> = new Set<string>();
+        monthData.forEach(degreeDay => {
+          const time: Date = new Date(degreeDay.time);
+          hoursWithData.add(`${time.getDate()}-${time.getHours()}`);
+        });
+        const hourlyCoverage: number = (hoursWithData.size / hoursInMonth) * 100;
+
         let totalHeatingDegreeDays: number = getDegreeDayAmount(monthData, 'HDD');
         let totalCoolingDegreeDays: number = getDegreeDayAmount(monthData, 'CDD');
         let relativeHumidity: number = getDegreeDayAmount(monthData, 'relativeHumidity');
@@ -112,7 +121,8 @@ export class AnnualStationDataComponent {
           dryBulbTemp: dryBulbTemp,
           wetBulbTemp: wetBulbTemp,
           dewPointTemp: dewPointTemp,
-          precipitation: precipitation
+          precipitation: precipitation,
+          hourlyCoverage: hourlyCoverage
         });
         startDate.setMonth(startDate.getMonth() + 1);
       }
@@ -149,4 +159,4 @@ export class AnnualStationDataComponent {
 }
 
 
-export interface AnnualStationDataSummary { date: Date, heatingDegreeDays: number, coolingDegreeDays: number, hasErrors: boolean, relativeHumidity: number, dryBulbTemp: number, wetBulbTemp: number, dewPointTemp: number, precipitation: number }
+export interface AnnualStationDataSummary { date: Date, heatingDegreeDays: number, coolingDegreeDays: number, hasErrors: boolean, relativeHumidity: number, dryBulbTemp: number, wetBulbTemp: number, dewPointTemp: number, precipitation: number, hourlyCoverage: number }

--- a/src/app/v0/weather-data/annual-station-data/annual-station-table/annual-station-table.component.html
+++ b/src/app/v0/weather-data/annual-station-data/annual-station-table/annual-station-table.component.html
@@ -4,95 +4,101 @@
     <tr>
       <th>Month</th>
       @if (weatherDataSelection == 'degreeDays' || weatherDataSelection == 'HDD') {
-        <th>Heating Degree Days</th>
+      <th>Heating Degree Days</th>
       }
       @if (weatherDataSelection == 'degreeDays' || weatherDataSelection == 'CDD') {
-        <th>Cooling Degree Days</th>
+      <th>Cooling Degree Days</th>
       }
       @if (weatherDataSelection == 'relativeHumidity') {
-        <th>Relative Humidity</th>
+      <th>Relative Humidity</th>
       }
       @if (weatherDataSelection == 'dryBulbTemp') {
-        <th>Dry Bulb Temp.</th>
+      <th>Dry Bulb Temp.</th>
       }
       @if (weatherDataSelection == 'wetBulbTemp') {
-        <th>Wet Bulb Temp.</th>
+      <th>Wet Bulb Temp.</th>
       }
       @if (weatherDataSelection == 'dewPointTemp') {
-        <th>Dew Point Temp.</th>
+      <th>Dew Point Temp.</th>
       }
       @if (weatherDataSelection == 'precipitation') {
-        <th>Precipitation</th>
+      <th>Precipitation</th>
       }
+      <th>% Hourly Coverage</th>
     </tr>
   </thead>
   <tbody class="table-group-divider">
     @for (degreeDay of yearSummaryData; track degreeDay) {
-      <tr>
-        <td>
-          @if (degreeDay.hasErrors) {
-            <span class="fa fa-exclamation-circle"></span>
-          }
-          <a class="click-link" (click)="gotToMonthSummary(degreeDay.date)">
-            {{degreeDay.date | date:'MMM. y'}}
-          </a>
-        </td>
-        @if (weatherDataSelection == 'degreeDays' || weatherDataSelection == 'HDD') {
-          <td>
-            {{degreeDay.heatingDegreeDays | number}}
-          </td>
+    <tr>
+      <td>
+        @if (degreeDay.hasErrors) {
+        <span class="fa fa-exclamation-circle"></span>
         }
-        @if (weatherDataSelection == 'degreeDays' || weatherDataSelection == 'CDD') {
-          <td>
-            {{degreeDay.coolingDegreeDays | number}}
-          </td>
-        }
-        @if (weatherDataSelection == 'relativeHumidity') {
-          <td>
-            {{degreeDay.relativeHumidity | number:'1.0-1'}} &percnt;
-          </td>
-        }
-        @if (weatherDataSelection == 'dryBulbTemp') {
-          <td>
-            {{degreeDay.dryBulbTemp | number:'1.0-1'}} &#8457;
-          </td>
-        }
-        @if (weatherDataSelection == 'wetBulbTemp') {
-          <td>
-            {{degreeDay.wetBulbTemp | number:'1.0-1'}} &#8457;
-          </td>
-        }
-        @if (weatherDataSelection == 'dewPointTemp') {
-          <td>
-            {{degreeDay.dewPointTemp | number:'1.0-1'}} &#8457;
-          </td>
-        }
-        @if (weatherDataSelection == 'precipitation') {
-          <td>
-            {{degreeDay.precipitation | number:'1.0-2'}} in
-          </td>
-        }
-      </tr>
+        <a class="click-link" (click)="gotToMonthSummary(degreeDay.date)">
+          {{degreeDay.date | date:'MMM. y'}}
+        </a>
+      </td>
+      @if (weatherDataSelection == 'degreeDays' || weatherDataSelection == 'HDD') {
+      <td>
+        {{degreeDay.heatingDegreeDays | number}}
+      </td>
+      }
+      @if (weatherDataSelection == 'degreeDays' || weatherDataSelection == 'CDD') {
+      <td>
+        {{degreeDay.coolingDegreeDays | number}}
+      </td>
+      }
+      @if (weatherDataSelection == 'relativeHumidity') {
+      <td>
+        {{degreeDay.relativeHumidity | number:'1.0-1'}} &percnt;
+      </td>
+      }
+      @if (weatherDataSelection == 'dryBulbTemp') {
+      <td>
+        {{degreeDay.dryBulbTemp | number:'1.0-1'}} &#8457;
+      </td>
+      }
+      @if (weatherDataSelection == 'wetBulbTemp') {
+      <td>
+        {{degreeDay.wetBulbTemp | number:'1.0-1'}} &#8457;
+      </td>
+      }
+      @if (weatherDataSelection == 'dewPointTemp') {
+      <td>
+        {{degreeDay.dewPointTemp | number:'1.0-1'}} &#8457;
+      </td>
+      }
+      @if (weatherDataSelection == 'precipitation') {
+      <td>
+        {{degreeDay.precipitation | number:'1.0-2'}} in
+      </td>
+      }
+      <td>
+        {{degreeDay.hourlyCoverage | number:'1.0-1'}} &percnt;
+      </td>
+    </tr>
     }
   </tbody>
-  @if (weatherDataSelection != 'relativeHumidity' && weatherDataSelection != 'dryBulbTemp' && weatherDataSelection != 'wetBulbTemp' && weatherDataSelection != 'dewPointTemp' && weatherDataSelection != 'precipitation') {
-    <tfoot>
-      <tr>
-        <th>
-          Total
-        </th>
-        @if (weatherDataSelection == 'degreeDays' || weatherDataSelection == 'HDD') {
-          <th>
-            {{yearSummaryData | total: 'heatingDegreeDays' | number}}
-          </th>
-        }
-        @if (weatherDataSelection == 'degreeDays' || weatherDataSelection == 'CDD') {
-          <th>
-            {{yearSummaryData | total: 'coolingDegreeDays' | number}}
-          </th>
-        }
-      </tr>
-    </tfoot>
+  @if (weatherDataSelection != 'relativeHumidity' && weatherDataSelection != 'dryBulbTemp' && weatherDataSelection !=
+  'wetBulbTemp' && weatherDataSelection != 'dewPointTemp' && weatherDataSelection != 'precipitation') {
+  <tfoot>
+    <tr>
+      <th>
+        Total
+      </th>
+      @if (weatherDataSelection == 'degreeDays' || weatherDataSelection == 'HDD') {
+      <th>
+        {{yearSummaryData | total: 'heatingDegreeDays' | number}}
+      </th>
+      }
+      @if (weatherDataSelection == 'degreeDays' || weatherDataSelection == 'CDD') {
+      <th>
+        {{yearSummaryData | total: 'coolingDegreeDays' | number}}
+      </th>
+      }
+      <th></th>
+    </tr>
+  </tfoot>
   }
 </table>
 


### PR DESCRIPTION
connects #1882 

This pull request adds a new feature to display the percentage of hourly data coverage for each month in the annual station data view. The code calculates the percentage of hours in each month for which data is available, includes this value in the summary data, and updates the table UI to show the new "% Hourly Coverage" column.

**Feature: Hourly Data Coverage Calculation and Display**

* Calculated the percentage of hours in each month with available data (`hourlyCoverage`) in the `AnnualStationDataComponent` by determining the number of unique hour entries and dividing by the total hours in the month.
* Added `hourlyCoverage` to the `AnnualStationDataSummary` interface and included it in the summary data object.

**UI Updates: Annual Station Data Table**

* Added a new column "% Hourly Coverage" to the annual station data table header in `annual-station-table.component.html`.
* Displayed the calculated `hourlyCoverage` value for each row in the new column, formatted as a percentage.
* Updated the table footer to include an empty cell for the new column, maintaining table alignment.