### PR TITLE
Issue 2335 - bulk weather update improvements

### DIFF
--- a/src/app/v0/data-management/data-management-home/update-weather-predictors-modal/update-weather-predictors-modal.component.html
+++ b/src/app/v0/data-management/data-management-home/update-weather-predictors-modal/update-weather-predictors-modal.component.html
@@ -2,55 +2,71 @@
 </div>
 
 @if (showWeatherPredictorModal) {
-  <div class="popup popup-lg" [class.open]="showWeatherPredictorModal">
-    <div class="popup-header">Update Weather Predictors
-      <button class="item-right" (click)="closeWeatherPredictorModal()">x</button>
-    </div>
-    <div class="popup-body">
-      <p>
-        Updating weather predictor data will add predictor data entries for each facility based on the date ranges
-        listed below. Existing predictor data will not be altered. This process may take some time depending on the
-        duration of the time period and the number of facilities.
-      </p>
-      <div class="row">
-        <div class="col-4 bold">
-          Facility
+<div class="popup popup-lg" [class.open]="showWeatherPredictorModal">
+  <div class="popup-header">Update Weather Predictors
+    <button class="item-right" (click)="closeWeatherPredictorModal()">x</button>
+  </div>
+  <div class="popup-body">
+    <p>
+      Updating weather predictor data will add predictor data entries for each facility based on the date ranges
+      listed below. Existing predictor data will not be altered. This process may take some time depending on the
+      duration of the time period and the number of facilities.
+    </p>
+    <div class="row">
+      <div class="col-4 bold">
+        Facility
+      </div>
+      <div class="col-4 bold">
+        Start Date
+        <div class="d-flex justify-content-start mt-2">
+          <a class="click-link" (click)="openCalendar($event, startMonthPicker)">
+            Set Start Date for All
+          </a>
+          <input #startMonthPicker type="month" class="position-absolute invisible"
+            (change)="setBulkDates($event, 'start')">
         </div>
-        <div class="col-4 bold">
-          Start Date
-        </div>
-        <div class="col-4 bold">
-          End Date<br>
+      </div>
+      <div class="col-4 bold">
+        End Date
+        <div class="d-flex justify-content-between mt-2">
+          <div>
+            <a class="click-link" (click)="openCalendar($event, endMonthPicker)">
+              Set End Date for All
+            </a>
+            <input #endMonthPicker type="month" class="position-absolute invisible"
+              (change)="setBulkDates($event, 'end')">
+          </div>
           <a class="click-link" (click)="setEndDateToCurrentDate()">
-            Set Current Month
+            Set Last Month
           </a>
         </div>
       </div>
-      @for (facility of facilityList; track facility; let index = $index) {
-        <div class="row">
-          <div class="col-4 my-auto">
-            {{ facility.facilityId | facilityName}}
-          </div>
-          <div class="col-4">
-            <input id="startDate" class="form-control" type="month" [ngModel]="facility.startDate | date:'yyyy-MM'"
-              (ngModelChange)="setStartDate($event, index)" name="startDate">
-          </div>
-          <div class="col-4">
-            <input id="endDate" class="form-control" type="month" [ngModel]="facility.endDate | date:'yyyy-MM'"
-              (ngModelChange)="setEndDate($event, index)" name="endDate">
-          </div>
-        </div>
-      }
     </div>
-    <div class="d-flex flex-column">
-      <div>
-        <hr class="my-1">
+    @for (facility of facilityList; track facility; let index = $index) {
+    <div class="row">
+      <div class="col-4 my-auto">
+        {{ facility.facilityId | facilityName}}
       </div>
-      <div class="d-flex justify-content-end p-2">
-        <button class="btn btn-secondary me-2" (click)="closeWeatherPredictorModal()">Cancel</button>
-        <button class="btn btn-success" (click)="updateAccountWeatherPredictors()" [disabled]="invalidForm">Confirm
+      <div class="col-4">
+        <input id="startDate" class="form-control" type="month" [ngModel]="facility.startDate | date:'yyyy-MM'"
+          (ngModelChange)="setStartDate($event, index)" name="startDate">
+      </div>
+      <div class="col-4">
+        <input id="endDate" class="form-control" type="month" [ngModel]="facility.endDate | date:'yyyy-MM'"
+          (ngModelChange)="setEndDate($event, index)" name="endDate">
+      </div>
+    </div>
+    }
+  </div>
+  <div class="d-flex flex-column">
+    <div>
+      <hr class="my-1">
+    </div>
+    <div class="d-flex justify-content-end p-2">
+      <button class="btn btn-secondary me-2" (click)="closeWeatherPredictorModal()">Cancel</button>
+      <button class="btn btn-success" (click)="updateAccountWeatherPredictors()" [disabled]="invalidForm">Confirm
         Update</button>
-      </div>
     </div>
   </div>
+</div>
 }

--- a/src/app/v0/data-management/data-management-home/update-weather-predictors-modal/update-weather-predictors-modal.component.ts
+++ b/src/app/v0/data-management/data-management-home/update-weather-predictors-modal/update-weather-predictors-modal.component.ts
@@ -70,7 +70,7 @@ export class UpdateWeatherPredictorsModalComponent {
   setFacilityList() {
     this.facilityList = new Array();
     let facilities: Array<IdbFacility> = [...this.accountWorkspaceStore.facilities()];
-    if(this.fileReference){
+    if (this.fileReference) {
       facilities = this.fileReference.importFacilities;
     }
     facilities.forEach(facility => {
@@ -141,9 +141,48 @@ export class UpdateWeatherPredictorsModalComponent {
     }) !== undefined;
   }
 
-  setEndDateToCurrentDate(){
+  setEndDateToCurrentDate() {
+    const currentDate = new Date();
+    const latestMonth = new Date(currentDate.getFullYear(), currentDate.getMonth() - 1, 1);
     this.facilityList.forEach(facilityItem => {
-      facilityItem.endDate = new Date();
+      facilityItem.endDate = new Date(latestMonth);
     });
+    this.setInvalidForm();
+  }
+
+  openCalendar(event: Event, inputElement: HTMLInputElement): void {
+    event.preventDefault();
+    try {
+      if (typeof inputElement.showPicker === 'function') {
+        inputElement.showPicker();
+      } else {
+        inputElement.click();
+      }
+    } catch {
+      inputElement.focus();
+      inputElement.click();
+    }
+  }
+
+  setBulkDates(event: Event, dateType: 'start' | 'end') {
+    const input = event.target as HTMLInputElement;
+
+    if (!input.value) {
+      return;
+    }
+    const [year, month] = input.value.split('-').map(Number);
+    if (!year || !month) {
+      return;
+    }
+
+    const newDate = new Date(year, month - 1, 1);
+    this.facilityList.forEach(facilityItem => {
+      if (dateType === 'start') {
+        facilityItem.startDate = new Date(newDate);
+      } else {
+        facilityItem.endDate = new Date(newDate);
+      }
+    });
+    this.setInvalidForm();
   }
 }

--- a/src/app/v0/weather-data/weather-predictor-management.service.ts
+++ b/src/app/v0/weather-data/weather-predictor-management.service.ts
@@ -351,7 +351,7 @@ export class WeatherPredictorManagementService {
         let endDate: Date = new Date(facilityList[i].endDate);
         //fetch weather data from predictor station
 
-        while (startDate < endDate) {
+        while (startDate <= endDate) {
           let entryDate: Date = new Date(startDate);
           let monthPredictorEntry: IdbPredictorData = predictorData.find(data => {
             return checkSameMonthPredictorData(data, entryDate);


### PR DESCRIPTION
connects #2335 

This pull request adds new bulk date-setting features and improves the user experience for updating weather predictor dates in the `UpdateWeatherPredictorsModalComponent`. It introduces UI controls to set start and end dates for all facilities at once, updates the logic for setting the end date to the last completed month, and fixes a bug in the weather data fetching loop.

**Bulk Date Setting and UI Enhancements:**

* Added "Set Start Date for All" and "Set End Date for All" links with month pickers to allow users to quickly set start or end dates for all facilities in the modal (`update-weather-predictors-modal.component.html`, `update-weather-predictors-modal.component.ts`).
* Implemented the `openCalendar` and `setBulkDates` methods to handle bulk date selection and update all facility items accordingly (`update-weather-predictors-modal.component.ts`).

**Date Handling Improvements:**

* Changed the "Set Current Month" action to "Set Last Month" and updated the logic so the end date is set to the last completed month instead of the current date (`update-weather-predictors-modal.component.html`, `update-weather-predictors-modal.component.ts`).

**Bug Fixes:**

* Fixed a bug in the weather predictor management service by changing the loop condition from `startDate < endDate` to `startDate <= endDate` to ensure the end month is included in the data fetch (`weather-predictor-management.service.ts`).